### PR TITLE
refactor(subsystem): force subsystem apply and state

### DIFF
--- a/lib/pages/fit/components/equipment/slot_row/subsystem_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/subsystem_slot.dart
@@ -52,7 +52,6 @@ class _SubsystemSlotRow extends ConsumerWidget {
       child: ListTile(
         leading: StateIcon.rect(
           state: slotInfo.state,
-          onTap: () => fitContext.fitWrapper.toggleSlot(slotIdent, ref),
           child: type != null
               ? EveIcon(icon: type.icon, overlayIcon: metaGroupIcon, size: 35)
               : Image(

--- a/lib/pages/fit/tabs/equipment.dart
+++ b/lib/pages/fit/tabs/equipment.dart
@@ -8,6 +8,10 @@ class _EquipmentTab extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final fit = fitContext.fit;
+    final subsystemSlotCount = fitContext.ship.subsystemSlots.clamp(
+      0,
+      fit.body.slots.subsystem.length,
+    );
     final fitWrapper = fitContext.fitWrapper;
 
     return ListView(
@@ -137,7 +141,7 @@ class _EquipmentTab extends ConsumerWidget {
             ),
           ),
         ),
-        if (fit.body.slots.subsystem.isNotEmpty)
+        if (subsystemSlotCount > 0)
           _EquipmentHeader(
             title: context.l10n.subsystemSlot,
             actions: [
@@ -147,21 +151,23 @@ class _EquipmentTab extends ConsumerWidget {
               ),
             ],
           ),
-        ...SubsystemType.allTypes.map(
-          (type) => _AnySlotRow(
-            fitContext: fitContext,
-            slotIdent: SlotIdentifier.subsystem(type: type),
-            slotInfo: fit.body.slots.subsystem[type.index].match(
-              () => SlotInfo.empty(index: type.index),
-              (slot) => SlotInfo.item(
-                state: slot.state,
-                type: const native.OutSlotType.subSystem(),
-                index: type.index,
-                slot: slot,
+        ...SubsystemType.allTypes
+            .take(subsystemSlotCount)
+            .map(
+              (type) => _AnySlotRow(
+                fitContext: fitContext,
+                slotIdent: SlotIdentifier.subsystem(type: type),
+                slotInfo: fit.body.slots.subsystem[type.index].match(
+                  () => SlotInfo.empty(index: type.index),
+                  (slot) => SlotInfo.item(
+                    state: FitItemState.online,
+                    type: const native.OutSlotType.subSystem(),
+                    index: type.index,
+                    slot: slot,
+                  ),
+                ),
               ),
             ),
-          ),
-        ),
       ],
     );
   }

--- a/lib/pages/fit/wrapper.dart
+++ b/lib/pages/fit/wrapper.dart
@@ -206,7 +206,7 @@ class FitWrapper {
                 FitModuleItem(
                   itemId: FitStorageItemId.item(id: proto.typeId),
                   charge: const Option.none(),
-                  state: proto.maxState.dartImpl.limitToActive,
+                  state: FitItemState.online,
                 ),
               ),
             );
@@ -667,12 +667,11 @@ class FitWrapper {
     FitStorage fit,
     SubsystemType type,
     FitModuleItem slot,
-    Slots_GeneralSlot slotInfo,
+    Slots_GeneralSlot _,
   ) {
-    final newState = slot.state.toggle(slotInfo.maxState.dartImpl);
     final updatedSubsystem = fit.body.slots.subsystem.replaceBy(
       type.index,
-      (_) => Option.of(slot.copyWith(state: newState)),
+      (_) => Option.of(slot.copyWith(state: FitItemState.online)),
     );
     return fit.copyWith(
       body: fit.body.copyWith(slots: fit.body.slots.copyWith(subsystem: updatedSubsystem)),
@@ -931,7 +930,7 @@ class FitWrapper {
     return fit.copyWith(body: fit.body.copyWith(drones: drones.toIList()));
   });
 
-  FitStorage toggleDroneSlot(FitStorage fit, FitModuleItem _slot, int index) {
+  FitStorage toggleDroneSlot(FitStorage fit, FitModuleItem _, int index) {
     if (index < 0 || index >= fit.body.drones.length) return fit;
 
     final drone = fit.body.drones[index];

--- a/lib/pages/fit/wrapper.dart
+++ b/lib/pages/fit/wrapper.dart
@@ -669,6 +669,10 @@ class FitWrapper {
     FitModuleItem slot,
     Slots_GeneralSlot _,
   ) {
+    if (slot.state == FitItemState.online) {
+      return fit;
+    }
+
     final updatedSubsystem = fit.body.slots.subsystem.replaceBy(
       type.index,
       (_) => Option.of(slot.copyWith(state: FitItemState.online)),

--- a/lib/storage/fit/schema.dart
+++ b/lib/storage/fit/schema.dart
@@ -221,7 +221,12 @@ native.FitStorage convertToNative(FitStorage fitStorage) => native.FitStorage(
         (fitStorage.body.slots.medium, native.SlotType.medium),
         (fitStorage.body.slots.low, native.SlotType.low),
         (fitStorage.body.slots.rig, native.SlotType.rig),
-        (fitStorage.body.slots.subsystem, native.SlotType.subSystem),
+        (
+          fitStorage.body.slots.subsystem.map(
+            (slotOpt) => slotOpt.map((slot) => slot.copyWith(state: FitItemState.online)),
+          ),
+          native.SlotType.subSystem,
+        ),
         (fitStorage.body.slots.service, native.SlotType.service),
       ].flatMap<native.Module>(
         (arg) => arg.$1.filterNone().mapWithIndex(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subsystem slots now render according to ship capacity and available slots.
  * Subsystem items consistently initialize and remain in the online state.

* **Changes**
  * Tapping the subsystem state icon no longer toggles slot state; slot toggles follow the main slot controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->