### PR TITLE
feat: add rich-text rendered description text

### DIFF
--- a/lib/components/description_text.dart
+++ b/lib/components/description_text.dart
@@ -139,12 +139,21 @@ class _DescriptionTextState extends State<DescriptionText>
     }
 
     final normalized = value.replaceFirst("#", "");
-    final parsed = int.tryParse(normalized, radix: 16);
+    final expanded = switch (normalized.length) {
+      3 || 4 => normalized.split("").map((part) => "$part$part").join(),
+      6 || 8 => normalized,
+      _ => null,
+    };
+    if (expanded == null) {
+      return null;
+    }
+
+    final parsed = int.tryParse(expanded, radix: 16);
     if (parsed == null) {
       return null;
     }
 
-    return Color(normalized.length <= 6 ? parsed | 0xFF000000 : parsed);
+    return Color(expanded.length == 6 ? parsed | 0xFF000000 : parsed);
   }
 
   double? _parseHtmlFontSize(String? value) {

--- a/lib/components/description_text.dart
+++ b/lib/components/description_text.dart
@@ -63,7 +63,6 @@ class _DescriptionTextState extends State<DescriptionText>
   TextSpan _buildFromElement(BuildContext context, html.Element element) {
     List<TextSpan> buildChildren() =>
         element.nodes.map((child) => _buildFromNode(context, child)).toList();
-    String buildInlineText() => buildChildren().map((child) => child.toPlainText()).join();
 
     final builder = switch (element.localName) {
       "i" => () => TextSpan(
@@ -83,7 +82,7 @@ class _DescriptionTextState extends State<DescriptionText>
         ),
       ),
       "url" => () => TextSpan(
-        text: buildInlineText(),
+        children: buildChildren(),
         style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
         recognizer: _registerRecognizer(
           element.attributes["href"] == null
@@ -92,7 +91,7 @@ class _DescriptionTextState extends State<DescriptionText>
         ),
       ),
       "a" => () => TextSpan(
-        text: buildInlineText(),
+        children: buildChildren(),
         style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
         recognizer: _registerRecognizer(
           element.attributes["href"] == null ? null : () => _openShowInfo(context, element),

--- a/lib/components/description_text.dart
+++ b/lib/components/description_text.dart
@@ -19,6 +19,8 @@ class DescriptionText extends StatefulWidget {
 
 class _DescriptionTextState extends State<DescriptionText>
     with AutomaticKeepAliveClientMixin<DescriptionText> {
+  static const Set<String> _externalUrlSchemes = <String>{"http", "https"};
+
   final List<TapGestureRecognizer> _recognizers = <TapGestureRecognizer>[];
 
   @override
@@ -115,11 +117,14 @@ class _DescriptionTextState extends State<DescriptionText>
 
   Future<void> _openExternalUrl(String rawUrl) async {
     final uri = Uri.tryParse(rawUrl);
-    if (uri == null) {
+    if (uri == null || !_externalUrlSchemes.contains(uri.scheme)) {
       return;
     }
 
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
+    final didLaunch = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!didLaunch) {
+      throw StateError("Could not launch external URL: $rawUrl");
+    }
   }
 
   Future<void> _openShowInfo(BuildContext context, html.Element element) async {

--- a/lib/components/description_text.dart
+++ b/lib/components/description_text.dart
@@ -1,0 +1,154 @@
+import "dart:async";
+
+import "package:eve_fit_assistant/pages/item-detail/page.dart";
+import "package:flutter/gestures.dart";
+import "package:flutter/material.dart";
+import "package:html/dom.dart" as html;
+import "package:html/parser.dart" as html_parser;
+import "package:url_launcher/url_launcher.dart";
+
+class DescriptionText extends StatefulWidget {
+  const DescriptionText({required this.text, super.key, this.style});
+
+  final String text;
+  final TextStyle? style;
+
+  @override
+  State<DescriptionText> createState() => _DescriptionTextState();
+}
+
+class _DescriptionTextState extends State<DescriptionText>
+    with AutomaticKeepAliveClientMixin<DescriptionText> {
+  final List<TapGestureRecognizer> _recognizers = <TapGestureRecognizer>[];
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void dispose() {
+    _disposeRecognizers();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    _disposeRecognizers();
+
+    final normalizedText = widget.text.replaceAllMapped(
+      RegExp("<url=([^>]+)>([^<]+)</url>"),
+      (match) => '<url href="${match.group(1)}">${match.group(2)}</url>',
+    );
+    final fragment = html_parser.parseFragment("<div>$normalizedText</div>");
+
+    return SelectableText.rich(_buildFromNode(context, fragment), style: widget.style);
+  }
+
+  void _disposeRecognizers() {
+    for (final recognizer in _recognizers) {
+      recognizer.dispose();
+    }
+    _recognizers.clear();
+  }
+
+  TextSpan _buildFromNode(BuildContext context, html.Node node) => switch (node) {
+    html.Text(:final data) => TextSpan(text: data),
+    html.Element() => _buildFromElement(context, node),
+    html.Node() => TextSpan(
+      children: node.nodes.map((child) => _buildFromNode(context, child)).toList(),
+    ),
+  };
+
+  TextSpan _buildFromElement(BuildContext context, html.Element element) {
+    List<TextSpan> buildChildren() =>
+        element.nodes.map((child) => _buildFromNode(context, child)).toList();
+    String buildInlineText() => buildChildren().map((child) => child.toPlainText()).join();
+
+    final builder = switch (element.localName) {
+      "i" => () => TextSpan(
+        children: buildChildren(),
+        style: const TextStyle(fontStyle: FontStyle.italic),
+      ),
+      "b" => () => TextSpan(
+        children: buildChildren(),
+        style: const TextStyle(fontWeight: FontWeight.bold),
+      ),
+      "br" => () => const TextSpan(text: "\n"),
+      "font" => () => TextSpan(
+        children: buildChildren(),
+        style: TextStyle(
+          color: _parseHtmlColor(element.attributes["color"]),
+          fontSize: _parseHtmlFontSize(element.attributes["size"]),
+        ),
+      ),
+      "url" => () => TextSpan(
+        text: buildInlineText(),
+        style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
+        recognizer: _registerRecognizer(
+          element.attributes["href"] == null
+              ? null
+              : () => _openExternalUrl(element.attributes["href"]!),
+        ),
+      ),
+      "a" => () => TextSpan(
+        text: buildInlineText(),
+        style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
+        recognizer: _registerRecognizer(
+          element.attributes["href"] == null ? null : () => _openShowInfo(context, element),
+        ),
+      ),
+      _ => () => TextSpan(children: buildChildren()),
+    };
+
+    return builder();
+  }
+
+  TapGestureRecognizer? _registerRecognizer(VoidCallback? onTap) {
+    if (onTap == null) {
+      return null;
+    }
+
+    final recognizer = TapGestureRecognizer()..onTap = onTap;
+    _recognizers.add(recognizer);
+    return recognizer;
+  }
+
+  Future<void> _openExternalUrl(String rawUrl) async {
+    final uri = Uri.tryParse(rawUrl);
+    if (uri == null) {
+      return;
+    }
+
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<void> _openShowInfo(BuildContext context, html.Element element) async {
+    final href = element.attributes["href"];
+    final typeId = href == null ? null : int.tryParse(href.replaceFirst("showinfo:", ""));
+    if (typeId == null || !context.mounted) {
+      return;
+    }
+
+    await showItemDetailPage(context, typeId: typeId);
+  }
+
+  Color? _parseHtmlColor(String? value) {
+    if (value == null) {
+      return null;
+    }
+
+    final normalized = value.replaceFirst("#", "");
+    final parsed = int.tryParse(normalized, radix: 16);
+    if (parsed == null) {
+      return null;
+    }
+
+    return Color(normalized.length <= 6 ? parsed | 0xFF000000 : parsed);
+  }
+
+  double? _parseHtmlFontSize(String? value) {
+    final size = value == null ? null : double.tryParse(value);
+    return size == null ? null : size * 1.5;
+  }
+}

--- a/lib/components/description_text.dart
+++ b/lib/components/description_text.dart
@@ -37,8 +37,8 @@ class _DescriptionTextState extends State<DescriptionText>
     _disposeRecognizers();
 
     final normalizedText = widget.text.replaceAllMapped(
-      RegExp("<url=([^>]+)>([^<]+)</url>"),
-      (match) => '<url href="${match.group(1)}">${match.group(2)}</url>',
+      RegExp("<url=([^>]+)>"),
+      (match) => '<url href="${match.group(1)}">',
     );
     final fragment = html_parser.parseFragment("<div>$normalizedText</div>");
 

--- a/lib/pages/item-detail/page.dart
+++ b/lib/pages/item-detail/page.dart
@@ -1,3 +1,4 @@
+import "package:eve_fit_assistant/components/description_text.dart";
 import "package:eve_fit_assistant/components/icon/eve_icon.dart";
 import "package:eve_fit_assistant/components/layout.dart";
 import "package:eve_fit_assistant/components/list/eve_list_tile.dart";
@@ -17,7 +18,6 @@ import "package:eve_fit_assistant/utils/context.dart";
 import "package:eve_fit_assistant/utils/screen.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
-import "package:html/parser.dart" as html_parser;
 
 const List<int> _requiredSkillAttributeIds = [182, 183, 184, 1285, 1289, 1290];
 const List<int> _requiredSkillLevelAttributeIds = [277, 278, 279, 1286, 1287, 1288];
@@ -279,7 +279,7 @@ class _ItemTabContent extends ConsumerWidget {
         const SizedBox(height: 12),
         _SectionCard(
           title: context.l10n.itemDetailDescription,
-          child: SelectableText(description!),
+          child: DescriptionText(text: description!, style: context.theme.textTheme.bodyMedium),
         ),
       ],
       if (type.traitSections.isNotEmpty) ...[
@@ -382,8 +382,8 @@ class AttributeDetailPage extends ConsumerWidget {
                   const SizedBox(height: 12),
                 ],
                 if (attribute != null && attribute.description.isNotEmpty) ...[
-                  Text(
-                    _normalizeRichText(attribute.description),
+                  DescriptionText(
+                    text: attribute.description,
                     style: context.theme.textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 12),
@@ -555,8 +555,8 @@ class _TraitCard extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         for (final section in type.traitSections) ...[
-          Text(
-            _traitSectionTitle(context, ref, section),
+          DescriptionText(
+            text: _traitSectionLabel(ref, context, section),
             style: context.theme.textTheme.titleSmall,
           ),
           const SizedBox(height: 8),
@@ -568,25 +568,14 @@ class _TraitCard extends ConsumerWidget {
                 children: [
                   const Text("- "),
                   Expanded(
-                    child: Text(
-                      _traitEntryLabel(ref, entry),
+                    child: DescriptionText(
+                      text: _traitEntryMarkup(ref, entry),
                       style: context.theme.textTheme.bodyMedium,
                     ),
                   ),
                 ],
               ),
             ),
-          if (section.hasSkillTypeId()) ...[
-            const SizedBox(height: 4),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: TextButton.icon(
-                onPressed: () => showItemDetailPage(context, typeId: section.skillTypeId),
-                icon: const Icon(Icons.open_in_new),
-                label: TypeNameText(typeId: section.skillTypeId),
-              ),
-            ),
-          ],
           const SizedBox(height: 12),
         ],
       ],
@@ -1056,8 +1045,6 @@ String? _resolveLocalization(WidgetRef ref, LocalizationID? localization) => swi
   _ => ref.watch(localizationProvider(localization.id)),
 };
 
-String _normalizeRichText(String input) => (html_parser.parseFragment(input).text ?? "").trim();
-
 String? _attributeDisplayName(WidgetRef ref, DogmaAttribute? attribute) {
   if (attribute == null) return null;
   if (attribute.hasDisplayName()) {
@@ -1299,21 +1286,28 @@ String _effectOperatorLabel(BuildContext context, native.EffectOperator operator
       native.EffectOperator.postAssign => context.l10n.itemDetailEffectOperatorPostAssign,
     };
 
-String _traitSectionTitle(
-  BuildContext context,
+String _traitSectionLabel(
   WidgetRef ref,
+  BuildContext context,
   pb_types.Type_TraitSection section,
 ) => switch (section.kind) {
-  pb_types.Type_TraitSectionKind.SKILL when section.hasSkillTypeId() =>
-    context.l10n.itemDetailTraitPerLevel(
-      skillName: _resolveTypeName(ref, section.skillTypeId) ?? "Type ${section.skillTypeId}",
-    ),
+  pb_types.Type_TraitSectionKind.SKILL when section.hasSkillTypeId() => _traitSectionSkillLabel(
+    ref,
+    context,
+    section.skillTypeId,
+  ),
   pb_types.Type_TraitSectionKind.ROLE => context.l10n.itemDetailTraitRoleBonuses,
   pb_types.Type_TraitSectionKind.MISC => context.l10n.itemDetailTraitMiscBonuses,
   _ => context.l10n.itemDetailTraits,
 };
 
-String _traitEntryLabel(WidgetRef ref, pb_types.Type_TraitEntry entry) {
+String _traitSectionSkillLabel(WidgetRef ref, BuildContext context, int skillTypeId) {
+  final skillName = _resolveTypeName(ref, skillTypeId) ?? "Type $skillTypeId";
+  final localized = context.l10n.itemDetailTraitPerLevel(skillName: skillName);
+  return localized.replaceFirst(skillName, '<a href="showinfo:$skillTypeId">$skillName</a>');
+}
+
+String _traitEntryMarkup(WidgetRef ref, pb_types.Type_TraitEntry entry) {
   final text = _resolveLocalization(ref, entry.text) ?? "LOC[${entry.text.id}]";
   if (!entry.hasBonus()) return text;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item descriptions now render as selectable rich text with bold, italic, color, and size formatting.
  * Descriptions include interactive links that navigate to related item details or open external URLs.
  * Trait and attribute text now use consistent, enhanced styling for clearer presentation.

* **Other Changes**
  * Removed the separate "open in new" button; link navigation is integrated into the description text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->