### PR TITLE
feat: add and expose preset fit skill profiles for simulations

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -57,7 +57,6 @@ linter:
     - avoid_escaping_inner_quotes
     - avoid_final_parameters
     - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     - avoid_private_typedef_functions
     - avoid_redundant_argument_values
@@ -137,7 +136,6 @@ linter:
     - use_colored_box
     - use_decorated_box
     - use_enums
-    - use_if_null_to_convert_nulls_to_bools
     - use_is_even_rather_than_modulo
     - use_named_constants
     - use_null_aware_elements

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -111,6 +111,17 @@
   "fitTabsDrone": "Drone",
   "fitTabsFighter": "Fighter",
   "fitTabsUtils": "Utils",
+  "fitSkillPolicyPresetTitle": "Skill profile: {profileName}",
+  "@fitSkillPolicyPresetTitle": {
+    "placeholders": {
+      "profileName": {
+        "type": "String"
+      }
+    }
+  },
+  "fitSkillPolicyPresetDescription": "This build uses preset skill profiles instead of real character data.",
+  "fitSkillProfileAll5": "All V",
+  "fitSkillProfileAll0": "All 0",
   "fitSkillPolicyUnsupportedTitle": "Skill-aware simulation is not available in this build.",
   "fitSkillPolicyUnsupportedDescription": "Fits are simulated without character skill modifiers. Implants and boosters still apply.",
   "@@@@_FIT_EQUIPMENT_TAB": {},

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -125,6 +125,17 @@
   "fitTabsDrone": "无人机",
   "fitTabsFighter": "舰载机",
   "fitTabsUtils": "杂项",
+  "fitSkillPolicyPresetTitle": "技能档案：{profileName}",
+  "@fitSkillPolicyPresetTitle": {
+    "placeholders": {
+      "profileName": {
+        "type": "String"
+      }
+    }
+  },
+  "fitSkillPolicyPresetDescription": "当前构建使用预设技能档案，而不是真实角色数据。",
+  "fitSkillProfileAll5": "全 5",
+  "fitSkillProfileAll0": "全 0",
   "fitSkillPolicyUnsupportedTitle": "当前构建暂不支持技能感知模拟。",
   "fitSkillPolicyUnsupportedDescription": "当前配置模拟不会应用角色技能修正。植入体和增效剂仍然生效。",
   "@@@@_FIT_EQUIPMENT_TAB": {},

--- a/lib/constant/eve.dart
+++ b/lib/constant/eve.dart
@@ -4,6 +4,7 @@ class EveConstCategoryId {
   const EveConstCategoryId._();
 
   static const int ship = 6;
+  static const int skill = 16;
 }
 
 class EveConstMarketGroupId {

--- a/lib/pages/fit/columns.dart
+++ b/lib/pages/fit/columns.dart
@@ -40,8 +40,10 @@ class FitDisplayColumns extends ConsumerWidget {
                 ),
               ),
             ),
-          if (!currentFitSkillPolicy.supportsSkillAwareSimulation)
-            const Padding(padding: .only(bottom: 8), child: _FitSkillPolicyBanner()),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: _FitSkillPolicyBanner(fitContext: fitContext),
+          ),
           Expanded(
             child: Row(
               children: [
@@ -91,20 +93,71 @@ class _FitStatusBanner extends StatelessWidget {
   }
 }
 
+extension on FitSkillProfile {
+  String localizedName(BuildContext context) => switch (this) {
+    FitSkillProfile.all5 => context.l10n.fitSkillProfileAll5,
+    FitSkillProfile.all0 => context.l10n.fitSkillProfileAll0,
+  };
+}
+
 class _FitSkillPolicyBanner extends StatelessWidget {
-  const _FitSkillPolicyBanner();
+  const _FitSkillPolicyBanner({required this.fitContext});
+
+  final FitContext fitContext;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final skillProfile = fitContext.fit.body.skillProfile;
 
     return Material(
       color: colorScheme.surfaceContainerHighest,
       borderRadius: BorderRadius.circular(12),
-      child: ListTile(
-        leading: Icon(Icons.info_outline, color: colorScheme.primary),
-        title: Text(context.l10n.fitSkillPolicyUnsupportedTitle),
-        subtitle: Text(context.l10n.fitSkillPolicyUnsupportedDescription),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.info_outline, color: colorScheme.primary),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    context.l10n.fitSkillPolicyPresetTitle(
+                      profileName: skillProfile.localizedName(context),
+                    ),
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(context.l10n.fitSkillPolicyPresetDescription),
+            const SizedBox(height: 12),
+            SegmentedButton<FitSkillProfile>(
+              showSelectedIcon: false,
+              segments: [
+                ButtonSegment<FitSkillProfile>(
+                  value: FitSkillProfile.all5,
+                  label: Text(FitSkillProfile.all5.localizedName(context)),
+                ),
+                ButtonSegment<FitSkillProfile>(
+                  value: FitSkillProfile.all0,
+                  label: Text(FitSkillProfile.all0.localizedName(context)),
+                ),
+              ],
+              selected: {skillProfile},
+              onSelectionChanged: (selection) async {
+                final nextProfile = selection.firstOrNull;
+                if (nextProfile == null || nextProfile == skillProfile) {
+                  return;
+                }
+                await fitContext.fitWrapper.setSkillProfile(nextProfile);
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/fit/wrapper.dart
+++ b/lib/pages/fit/wrapper.dart
@@ -53,6 +53,9 @@ class FitWrapper {
 
   Future<void> update(FitStorage Function(FitStorage) updater) => wrapped.update(updater);
 
+  Future<void> setSkillProfile(FitSkillProfile skillProfile) =>
+      wrapped.update((fit) => fit.copyWith(body: fit.body.copyWith(skillProfile: skillProfile)));
+
   int _allocateDynamicItemId(FitStorage fit) => allocateDynamicItemId(fit);
 
   (FitStorage, FitStorageItemId) _cloneStorageItemId(FitStorage fit, FitStorageItemId itemId) =>
@@ -116,11 +119,14 @@ class FitWrapper {
         body: fit.body.copyWith(fighters: _normalizeFighters(tempFighters)),
       );
       final engine = ref.read(nativeFitEngineServiceProvider).engineOrNull;
+      final availableSkillTypeIds = ref.read(bundleCollectionSkillTypeIdsProvider);
       if (engine == null) {
         warning("Fit engine unavailable while resolving fighter squadron max size for $typeId");
         return null;
       }
-      final output = await engine.emulate(fit: convertToNative(tempFit));
+      final output = await engine.emulate(
+        fit: convertToNative(tempFit, availableSkillTypeIds: availableSkillTypeIds),
+      );
 
       for (final item in output.modules) {
         final slotType = item.slot.slotType;

--- a/lib/storage/bundle/service/collection.dart
+++ b/lib/storage/bundle/service/collection.dart
@@ -92,6 +92,24 @@ Iterable<pb_types.Type> bundleCollectionGetAllTypes(Ref ref) =>
     ref.watch(bundleCollectionProvider.select((p) => p?.allTypes ?? const IList.empty()));
 
 @riverpod
+IList<int> bundleCollectionSkillTypeIds(Ref ref) {
+  final collection = ref.watch(bundleCollectionProvider);
+  if (collection == null) {
+    return const IList<int>.empty();
+  }
+
+  final skillGroupIds = collection.allGroups
+      .where((group) => group.categoryId == 16)
+      .map((group) => group.groupId)
+      .toSet();
+
+  return collection.allTypes
+      .where((type) => skillGroupIds.contains(type.groupId))
+      .map((type) => type.typeId)
+      .toIList();
+}
+
+@riverpod
 Iterable<TypeMaterial> bundleCollectionGetAllTypeMaterials(Ref ref) =>
     ref.watch(bundleCollectionProvider.select((p) => p?.allTypeMaterials ?? const IList.empty()));
 

--- a/lib/storage/bundle/service/collection.dart
+++ b/lib/storage/bundle/service/collection.dart
@@ -1,6 +1,7 @@
 import "dart:io";
 
 import "package:eve_fit_assistant/config/logger.dart";
+import "package:eve_fit_assistant/constant/eve.dart";
 import "package:eve_fit_assistant/data/proto/categories.pb.dart";
 import "package:eve_fit_assistant/data/proto/collections.pb.dart";
 import "package:eve_fit_assistant/data/proto/dogma_attributes.pb.dart";
@@ -99,7 +100,7 @@ IList<int> bundleCollectionSkillTypeIds(Ref ref) {
   }
 
   final skillGroupIds = collection.allGroups
-      .where((group) => group.categoryId == 16)
+      .where((group) => group.categoryId == EveConstCategoryId.skill)
       .map((group) => group.groupId)
       .toSet();
 

--- a/lib/storage/fit/schema.dart
+++ b/lib/storage/fit/schema.dart
@@ -24,6 +24,7 @@ abstract class FitStorage with _$FitStorage {
     metadata: metadata,
     body: FitStorageBody(
       shipTypeId: ship.typeId,
+      skillProfile: FitSkillProfile.all5,
       damageProfile: const FitDamageProfile(
         em: 0.25,
         explosive: 0.25,
@@ -53,6 +54,7 @@ abstract class FitStorage with _$FitStorage {
 abstract class FitStorageBody with _$FitStorageBody {
   const factory FitStorageBody({
     required int shipTypeId,
+    @JsonKey(defaultValue: FitSkillProfile.all5) required FitSkillProfile skillProfile,
     required FitDamageProfile damageProfile,
     required FitStorageSlots slots,
     required IList<FitDroneItem> drones,
@@ -274,17 +276,38 @@ FitStorage pruneDynamicRegistry(FitStorage fit) {
   );
 }
 
-enum FitSkillPolicy { noCharacterSkills }
+enum FitSkillPolicy { presetProfiles }
 
-const FitSkillPolicy currentFitSkillPolicy = FitSkillPolicy.noCharacterSkills;
+@JsonEnum()
+enum FitSkillProfile { all5, all0 }
+
+const FitSkillPolicy currentFitSkillPolicy = FitSkillPolicy.presetProfiles;
+
+extension FitSkillProfileX on FitSkillProfile {
+  Map<int, int> resolveSkills(Iterable<int> availableSkillTypeIds) {
+    switch (this) {
+      case FitSkillProfile.all0:
+        return const <int, int>{};
+      case FitSkillProfile.all5:
+        final skillTypeIds = availableSkillTypeIds.toList(growable: false);
+        if (skillTypeIds.isEmpty) {
+          throw StateError("All V skill profile requires bundle skill definitions.");
+        }
+        return Map<int, int>.fromEntries(skillTypeIds.map((typeId) => MapEntry(typeId, 5)));
+    }
+  }
+}
 
 extension FitSkillPolicyX on FitSkillPolicy {
-  Map<int, int> resolveSkills(FitStorage fitStorage) => switch (this) {
-    FitSkillPolicy.noCharacterSkills => const <int, int>{},
-  };
+  Map<int, int> resolveSkills(FitStorage fitStorage, Iterable<int> availableSkillTypeIds) =>
+      switch (this) {
+        FitSkillPolicy.presetProfiles => fitStorage.body.skillProfile.resolveSkills(
+          availableSkillTypeIds,
+        ),
+      };
 
   bool get supportsSkillAwareSimulation => switch (this) {
-    FitSkillPolicy.noCharacterSkills => false,
+    FitSkillPolicy.presetProfiles => true,
   };
 }
 
@@ -319,7 +342,10 @@ int? _resolveNativeTypeId(
   },
 );
 
-native.FitStorage convertToNative(FitStorage fitStorage) {
+native.FitStorage convertToNative(
+  FitStorage fitStorage, {
+  required Iterable<int> availableSkillTypeIds,
+}) {
   final validDynamicIds = collectReferencedDynamicItemIds(
     fitStorage,
   ).intersection(fitStorage.dynamicRegistry.dynamicItems.keys.toSet());
@@ -465,7 +491,7 @@ native.FitStorage convertToNative(FitStorage fitStorage) {
       implants: implants,
       boosters: boosters,
     ),
-    skills: currentFitSkillPolicy.resolveSkills(fitStorage),
+    skills: currentFitSkillPolicy.resolveSkills(fitStorage, availableSkillTypeIds),
     dynamicItems: Map<int, native.DynamicItem>.fromEntries(
       fitStorage.dynamicRegistry.dynamicItems.entries
           .where((entry) => validDynamicIds.contains(entry.key))

--- a/lib/storage/fit/service.dart
+++ b/lib/storage/fit/service.dart
@@ -228,6 +228,12 @@ native.Ship? nativeEmulatedShip(Ref ref, String fitId) =>
 class FitEmulatorService extends _$FitEmulatorService {
   late String _fitId;
 
+  void _scheduleEmulationForCurrentFit() {
+    final fitState = ref.read(fitProvider(_fitId));
+    if (!fitState.isInitialized) return;
+    unawaited(Future(() => emulate(fitState.fit)));
+  }
+
   @override
   FitEmulatorState build(String fitId) {
     _fitId = fitId;
@@ -236,19 +242,28 @@ class FitEmulatorService extends _$FitEmulatorService {
     // during `build` (that can cause `state` to be mutated before the
     // notifier is fully initialized). Instead defer actual emulation to a
     // microtask.
-    ref.listen<FitServiceState>(fitProvider(fitId), (prev, next) {
-      if (prev == next) return;
-      if (!next.isInitialized) {
-        state = next.hasError
-            ? FitEmulatorState.error(
-                message: next.errorMessage ?? "This fit is unavailable.",
-                previous: state.emulated,
-              )
-            : const FitEmulatorState.notInitialized();
-        return;
-      }
-      unawaited(Future(() => emulate(next.fit)));
-    }, fireImmediately: true);
+    ref
+      ..listen<FitServiceState>(fitProvider(fitId), (prev, next) {
+        if (prev == next) return;
+        if (!next.isInitialized) {
+          state = next.hasError
+              ? FitEmulatorState.error(
+                  message: next.errorMessage ?? "This fit is unavailable.",
+                  previous: state.emulated,
+                )
+              : const FitEmulatorState.notInitialized();
+          return;
+        }
+        _scheduleEmulationForCurrentFit();
+      }, fireImmediately: true)
+      ..listen<NativeFitEngineState>(nativeFitEngineServiceProvider, (prev, next) {
+        if (prev == next) return;
+        _scheduleEmulationForCurrentFit();
+      })
+      ..listen(bundleCollectionSkillTypeIdsProvider, (prev, next) {
+        if (prev == next) return;
+        _scheduleEmulationForCurrentFit();
+      });
 
     return const FitEmulatorState.notInitialized();
   }
@@ -265,13 +280,28 @@ class FitEmulatorService extends _$FitEmulatorService {
     try {
       final engineState = ref.read(nativeFitEngineServiceProvider);
       final engine = engineState.engineOrNull;
-      final availableSkillTypeIds = ref.read(bundleCollectionSkillTypeIdsProvider);
       if (engine == null) {
-        final message = engineState.errorMessage ?? "The fit engine is not available yet.";
+        final message = engineState.errorMessage;
+        if (message == null) {
+          debug(
+            "Deferring emulation for ${fitStorage.metadata.fitId}: fit engine is still loading",
+          );
+          return;
+        }
         warning("Failed to emulate ${fitStorage.metadata.fitId}: $message");
         state = FitEmulatorState.error(message: message, previous: state.emulated);
         return;
       }
+
+      if (fitStorage.body.skillProfile == FitSkillProfile.all5 &&
+          ref.read(bundleCollectionProvider) == null) {
+        debug(
+          "Deferring emulation for ${fitStorage.metadata.fitId}: bundle skill definitions are still loading",
+        );
+        return;
+      }
+
+      final availableSkillTypeIds = ref.read(bundleCollectionSkillTypeIdsProvider);
       final nativeCompatible = convertToNative(
         fitStorage,
         availableSkillTypeIds: availableSkillTypeIds,

--- a/lib/storage/fit/service.dart
+++ b/lib/storage/fit/service.dart
@@ -6,6 +6,7 @@ import "package:eve_fit_assistant/config/logger.dart";
 import "package:eve_fit_assistant/native/api/output.dart" as native;
 import "package:eve_fit_assistant/native/api/server.dart" as native_server;
 import "package:eve_fit_assistant/storage/bundle/service.dart";
+import "package:eve_fit_assistant/storage/bundle/service/collection.dart";
 import "package:eve_fit_assistant/storage/fit/manager.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/utils/riverpod.dart";
@@ -264,13 +265,17 @@ class FitEmulatorService extends _$FitEmulatorService {
     try {
       final engineState = ref.read(nativeFitEngineServiceProvider);
       final engine = engineState.engineOrNull;
+      final availableSkillTypeIds = ref.read(bundleCollectionSkillTypeIdsProvider);
       if (engine == null) {
         final message = engineState.errorMessage ?? "The fit engine is not available yet.";
         warning("Failed to emulate ${fitStorage.metadata.fitId}: $message");
         state = FitEmulatorState.error(message: message, previous: state.emulated);
         return;
       }
-      final nativeCompatible = convertToNative(fitStorage);
+      final nativeCompatible = convertToNative(
+        fitStorage,
+        availableSkillTypeIds: availableSkillTypeIds,
+      );
       final emulatedOutput = await engine.emulate(fit: nativeCompatible);
       state = FitEmulatorState.emulated(output: emulatedOutput);
       debug("Finished emulating ${fitStorage.metadata.fitId}");


### PR DESCRIPTION
Closes #21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill profile presets added ("All 5" and "All 0") with an in-page selector to apply presets instead of character skills.
  * Localized UI strings for presets in English and Chinese.
* **Bug Fixes / Reliability**
  * Simulations now honor selected skill presets and defer emulation until relevant data or engine is ready.
* **Style**
  * Removed two linter rules from project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->