### PR TITLE
feat: defer dynamic item conversion and update fitting release scope

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 - [Bundle Registry](./bundle-registry.md)
+- [Advanced Fitting Release Scope](./advanced-fitting-release-scope.md)
 - [Fit Management](./fit-management.md)
 - [Patches](./patches.md)
 - [Settings](./settings.md)

--- a/docs/reference/advanced-fitting-release-scope.md
+++ b/docs/reference/advanced-fitting-release-scope.md
@@ -1,0 +1,24 @@
+# Advanced Fitting Release Scope
+
+This document records which advanced fitting workflows are included in the initial tester release and which ones stay deferred until parity work is finished.
+
+## Included in scope
+
+- Charges on high, medium, and low slot modules remain enabled.
+- Fighter fitting remains enabled, including squadron sizing resolved from the native engine and ability toggles exposed by the fighter row UI.
+- Subsystem fitting remains enabled for ships that expose subsystem slots, including slot validation and slot-layout resizing after install or removal.
+
+## Deferred from scope
+
+- Dynamic item conversion is intentionally deferred for the initial release.
+- Existing dynamic items can still be opened and reverted back to their origin type, but the UI no longer offers conversion into a dynamic item.
+
+## Release-safety rationale
+
+- Charges, fighters, and subsystem flows already have end-to-end UI wiring and native fit-engine support in the current workspace.
+- Dynamic item support is not complete yet; the native engine still contains TODO-backed attribute handling for dynamic items, so enabling fresh conversions would risk shipping partially applied stats.
+
+## Expected tester impact
+
+- Testers can keep exercising advanced charge, fighter, and subsystem workflows without being pushed into unfinished mutator paths.
+- Imported or previously saved fits that already contain dynamic items should remain recoverable because reverting those items is still available.

--- a/lib/pages/fit/components/equipment/slot_row/slot_row.dart
+++ b/lib/pages/fit/components/equipment/slot_row/slot_row.dart
@@ -1,5 +1,6 @@
 part of "../../../page.dart";
 
+// TODO(dynamic-item-conversion): Re-enable after conversion parity work lands.
 const bool _dynamicItemConversionEnabled = false;
 
 class _AnySlotRow extends StatelessWidget {

--- a/lib/pages/fit/components/equipment/slot_row/slot_row.dart
+++ b/lib/pages/fit/components/equipment/slot_row/slot_row.dart
@@ -1,5 +1,7 @@
 part of "../../../page.dart";
 
+const bool _dynamicItemConversionEnabled = false;
+
 class _AnySlotRow extends StatelessWidget {
   const _AnySlotRow({
     required this.fitContext,
@@ -253,30 +255,29 @@ class _SlotRowDisplay extends ConsumerWidget {
       );
     }
 
-    if (_supportsDynamicItems()) {
-      if (isDynamic) {
-        actions.add(
-          SlidableAction(
-            onPressed: (_) => fitContext.fitWrapper.revertSlotFromDynamic(slotIdent),
-            backgroundColor: Colors.grey,
-            foregroundColor: Colors.white,
-            icon: Icons.cyclone_outlined,
-            label: context.l10n.dynamicRevert,
-            padding: .zero,
-          ),
-        );
-      } else if (_availableDynamicModifierTypeIds(ref).isNotEmpty) {
-        actions.add(
-          SlidableAction(
-            onPressed: (_) => _handleConvertToDynamic(context, ref),
-            backgroundColor: Colors.red,
-            foregroundColor: Colors.white,
-            icon: Icons.cyclone_outlined,
-            label: context.l10n.dynamicConvert,
-            padding: .zero,
-          ),
-        );
-      }
+    if (isDynamic) {
+      actions.add(
+        SlidableAction(
+          onPressed: (_) => fitContext.fitWrapper.revertSlotFromDynamic(slotIdent),
+          backgroundColor: Colors.grey,
+          foregroundColor: Colors.white,
+          icon: Icons.cyclone_outlined,
+          label: context.l10n.dynamicRevert,
+          padding: .zero,
+        ),
+      );
+    } else if (_supportsDynamicItemConversion() &&
+        _availableDynamicModifierTypeIds(ref).isNotEmpty) {
+      actions.add(
+        SlidableAction(
+          onPressed: (_) => _handleConvertToDynamic(context, ref),
+          backgroundColor: Colors.red,
+          foregroundColor: Colors.white,
+          icon: Icons.cyclone_outlined,
+          label: context.l10n.dynamicConvert,
+          padding: .zero,
+        ),
+      );
     }
 
     if (_canHaveCharge(ref)) {
@@ -345,7 +346,7 @@ class _SlotRowDisplay extends ConsumerWidget {
       slotIdent is SlotIdentifierLow ||
       slotIdent is SlotIdentifierRig;
 
-  bool _supportsDynamicItems() => _canCopy();
+  bool _supportsDynamicItemConversion() => _dynamicItemConversionEnabled && _canCopy();
 
   List<int> _availableDynamicModifierTypeIds(WidgetRef ref) {
     final originTypeId = fitContext.resolveOriginTypeId(slotInfo.slot.itemId);


### PR DESCRIPTION
Closes #29 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Advanced Fitting Release Scope documentation detailing the initial tester release specifications.

* **Features**
  * Dynamic item conversion deferred from initial release; reverting dynamic items remains available.
  * Charges, fighter, and subsystem fitting included in initial scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->