### PR TITLE
feat: persist fit bundle snapshots and warn on incompatible saved fits

### DIFF
--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -126,6 +126,22 @@
   "fitPageMissingMessage": "This fit could not be found.",
   "fitPageBrokenMessage": "This fit could not be loaded.",
   "fitPageShipUnavailableMessage": "This fit references ship data that is not available in the current bundle.",
+  "fitBundleChangedTitle": "Bundle changed",
+  "fitBundleChangedDescription": "This fit was saved against an older revision of the active bundle. You can inspect and export it, but editing stays disabled until you switch back to a compatible bundle.",
+  "fitBundleMismatchTitle": "Bundle mismatch",
+  "fitBundleMismatchDescription": "This fit was saved against bundle {savedBundleId}, but the active bundle is {activeBundleId}. You can inspect and export it, but editing stays disabled.",
+  "@fitBundleMismatchDescription": {
+    "placeholders": {
+      "savedBundleId": {
+        "type": "String"
+      },
+      "activeBundleId": {
+        "type": "String"
+      }
+    }
+  },
+  "fitBundleUnavailableTitle": "Bundle unavailable",
+  "fitBundleUnavailableDescription": "No active bundle is loaded, so compatibility cannot be confirmed. Fit editing stays disabled until a bundle is available.",
   "fitPageStatsUnavailableTitle": "Stats unavailable",
   "fitPageStatsUnavailableMessage": "You can still inspect and edit the fit while calculations recover.",
   "fitPageSaveErrorTitle": "Changes not saved",

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -128,6 +128,8 @@
   "fitPageShipUnavailableMessage": "This fit references ship data that is not available in the current bundle.",
   "fitBundleChangedTitle": "Bundle changed",
   "fitBundleChangedDescription": "This fit was saved against an older revision of the active bundle. You can inspect and export it, but editing stays disabled until you switch back to a compatible bundle.",
+  "fitBundleLegacyTitle": "Bundle check required",
+  "fitBundleLegacyDescription": "This fit was saved before bundle revision tracking was available. You can inspect and export it, but editing stays disabled until it is reopened from a bundle with current compatibility metadata.",
   "fitBundleMismatchTitle": "Bundle mismatch",
   "fitBundleMismatchDescription": "This fit was saved against bundle {savedBundleId}, but the active bundle is {activeBundleId}. You can inspect and export it, but editing stays disabled.",
   "@fitBundleMismatchDescription": {

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -142,6 +142,8 @@
   "fitPageShipUnavailableMessage": "该配置引用了当前数据包中不可用的舰船数据。",
   "fitBundleChangedTitle": "数据包已变更",
   "fitBundleChangedDescription": "该配置保存于当前活动数据包的旧版本。您仍可查看和导出该配置，但在切回兼容数据包前将保持只读。",
+  "fitBundleLegacyTitle": "需要重新确认数据包",
+  "fitBundleLegacyDescription": "该配置保存时尚未记录数据包版本信息。您仍可查看和导出该配置，但在使用当前兼容元数据重新打开前将保持只读。",
   "fitBundleMismatchTitle": "数据包不匹配",
   "fitBundleMismatchDescription": "该配置保存于数据包 {savedBundleId}，而当前活动数据包为 {activeBundleId}。您仍可查看和导出该配置，但编辑将保持禁用。",
   "@fitBundleMismatchDescription": {

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -140,6 +140,22 @@
   "fitPageMissingMessage": "找不到该配置。",
   "fitPageBrokenMessage": "无法加载该配置。",
   "fitPageShipUnavailableMessage": "该配置引用了当前数据包中不可用的舰船数据。",
+  "fitBundleChangedTitle": "数据包已变更",
+  "fitBundleChangedDescription": "该配置保存于当前活动数据包的旧版本。您仍可查看和导出该配置，但在切回兼容数据包前将保持只读。",
+  "fitBundleMismatchTitle": "数据包不匹配",
+  "fitBundleMismatchDescription": "该配置保存于数据包 {savedBundleId}，而当前活动数据包为 {activeBundleId}。您仍可查看和导出该配置，但编辑将保持禁用。",
+  "@fitBundleMismatchDescription": {
+    "placeholders": {
+      "savedBundleId": {
+        "type": "String"
+      },
+      "activeBundleId": {
+        "type": "String"
+      }
+    }
+  },
+  "fitBundleUnavailableTitle": "数据包不可用",
+  "fitBundleUnavailableDescription": "当前没有活动数据包，无法确认兼容性。在数据包可用前，该配置将保持只读。",
   "fitPageStatsUnavailableTitle": "属性不可用",
   "fitPageStatsUnavailableMessage": "在计算恢复期间，您仍然可以查看和编辑该配置。",
   "fitPageSaveErrorTitle": "更改未保存",

--- a/lib/features/fit_io/text_import.dart
+++ b/lib/features/fit_io/text_import.dart
@@ -132,6 +132,7 @@ class FitTextImporter {
         lastModified: 0,
         description: "",
         bundleId: "",
+        bundleSnapshot: const FitBundleSnapshot(bundleId: ""),
       ),
       ship,
     );

--- a/lib/pages/fit-list/page.dart
+++ b/lib/pages/fit-list/page.dart
@@ -5,6 +5,8 @@ import "package:eve_fit_assistant/components/list/eve_list_tile.dart";
 import "package:eve_fit_assistant/features/fit_io/export_dialog.dart";
 import "package:eve_fit_assistant/pages/router.dart";
 import "package:eve_fit_assistant/storage/bundle/service/collection.dart";
+import "package:eve_fit_assistant/storage/fit/compatibility.dart";
+import "package:eve_fit_assistant/storage/fit/compatibility_notice.dart";
 import "package:eve_fit_assistant/storage/fit/manager.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/utils/context.dart";
@@ -79,6 +81,8 @@ class _FitListTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final typeInfo = ref.watch(bundleCollectionGetTypeProvider(metadata.shipTypeId));
+    final compatibility = ref.watch(fitBundleCompatibilityProvider(metadata.fitId));
+    final compatibilityNotice = localizeFitBundleCompatibility(context.l10n, compatibility);
     final metaGroupIcon = typeInfo == null
         ? null
         : ref.watch(
@@ -133,9 +137,27 @@ class _FitListTile extends ConsumerWidget {
             ? const Icon(Icons.help_outline)
             : EveIcon(icon: typeInfo.icon, overlayIcon: metaGroupIcon),
         title: Text(metadata.name),
+        trailing: compatibilityNotice == null
+            ? null
+            : Tooltip(
+                message: compatibilityNotice.message,
+                child: Icon(Icons.warning_amber_rounded, color: context.theme.colorScheme.tertiary),
+              ),
         subtitle: Row(
           children: [
             Expanded(child: TypeNameText(typeId: metadata.shipTypeId)),
+            if (compatibilityNotice != null) ...[
+              const SizedBox(width: 12),
+              Flexible(
+                child: Text(
+                  compatibilityNotice.label,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.theme.textTheme.bodySmall?.copyWith(
+                    color: context.theme.colorScheme.tertiary,
+                  ),
+                ),
+              ),
+            ],
             const SizedBox(width: 12),
             Text(lastModified),
           ],

--- a/lib/pages/fit/columns.dart
+++ b/lib/pages/fit/columns.dart
@@ -1,9 +1,10 @@
 part of "page.dart";
 
 class FitDisplayColumns extends ConsumerWidget {
-  const FitDisplayColumns({required this.fitContext, super.key});
+  const FitDisplayColumns({required this.fitContext, this.compatibilityNotice, super.key});
 
   final FitContext fitContext;
+  final FitBundleCompatibilityNotice? compatibilityNotice;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -17,6 +18,15 @@ class FitDisplayColumns extends ConsumerWidget {
       padding: const .symmetric(horizontal: 6),
       child: Column(
         children: [
+          if (compatibilityNotice != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _FitStatusBanner(
+                icon: Icons.inventory_2_outlined,
+                title: compatibilityNotice!.title,
+                message: compatibilityNotice!.message,
+              ),
+            ),
           if (saveErrorMessage != null)
             Padding(
               padding: const EdgeInsets.only(bottom: 8),

--- a/lib/pages/fit/page.dart
+++ b/lib/pages/fit/page.dart
@@ -29,6 +29,8 @@ import "package:eve_fit_assistant/storage/bundle/service/collection.dart";
 import "package:eve_fit_assistant/storage/bundle/service/localization.dart";
 import "package:eve_fit_assistant/storage/character/manager.dart";
 import "package:eve_fit_assistant/storage/character/schema.dart";
+import "package:eve_fit_assistant/storage/fit/compatibility.dart";
+import "package:eve_fit_assistant/storage/fit/compatibility_notice.dart";
 import "package:eve_fit_assistant/storage/fit/manager.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/storage/fit/service.dart";
@@ -98,6 +100,8 @@ class _FitPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final fitMetadata = ref.watch(fitRegistryManagerProvider.select((t) => t.fits[fitId]));
+    final compatibility = ref.watch(fitBundleCompatibilityProvider(fitId));
+    final compatibilityNotice = localizeFitBundleCompatibility(context.l10n, compatibility);
     if (fitMetadata == null) {
       return Layout(
         title: context.l10n.fitPageUnavailableTitle,
@@ -123,8 +127,8 @@ class _FitPage extends ConsumerWidget {
         title: fitMetadata.name,
         child: _FitPageErrorState(
           icon: Icons.directions_boat_filled_outlined,
-          title: context.l10n.fitPageUnavailableTitle,
-          message: context.l10n.fitPageShipUnavailableMessage,
+          title: compatibilityNotice?.title ?? context.l10n.fitPageUnavailableTitle,
+          message: compatibilityNotice?.message ?? context.l10n.fitPageShipUnavailableMessage,
           details: "typeId=${fitMetadata.shipTypeId}",
           actions: [
             TextButton.icon(
@@ -177,8 +181,8 @@ class _FitPage extends ConsumerWidget {
         title: context.l10n.fitPageTitle(fitName: fitMetadata.name, shipName: shipName),
         child: _FitPageErrorState(
           icon: Icons.warning_amber_rounded,
-          title: context.l10n.fitPageUnavailableTitle,
-          message: context.l10n.fitPageShipUnavailableMessage,
+          title: compatibilityNotice?.title ?? context.l10n.fitPageUnavailableTitle,
+          message: compatibilityNotice?.message ?? context.l10n.fitPageShipUnavailableMessage,
           details: "typeId=${fit.fit.body.shipTypeId}",
           actions: [
             FilledButton.icon(
@@ -213,7 +217,7 @@ class _FitPage extends ConsumerWidget {
 
     return Layout(
       title: context.l10n.fitPageTitle(fitName: fitMetadata.name, shipName: shipName),
-      child: FitDisplayColumns(fitContext: fitContext),
+      child: FitDisplayColumns(fitContext: fitContext, compatibilityNotice: compatibilityNotice),
     );
   }
 }

--- a/lib/storage/fit/compatibility.dart
+++ b/lib/storage/fit/compatibility.dart
@@ -9,6 +9,7 @@ enum FitBundleCompatibilityReason {
   none,
   activeBundleUnavailable,
   bundleIdMismatch,
+  missingComparableRevision,
   manifestMismatch,
   generationMismatch,
   buildMismatch,
@@ -61,6 +62,15 @@ FitBundleCompatibility evaluateFitBundleCompatibility(
     return FitBundleCompatibility(
       kind: FitBundleCompatibilityKind.incompatible,
       reason: FitBundleCompatibilityReason.bundleIdMismatch,
+      savedSnapshot: savedSnapshot,
+      activeSnapshot: activeSnapshot,
+    );
+  }
+
+  if (!savedSnapshot.hasComparableRevision) {
+    return FitBundleCompatibility(
+      kind: FitBundleCompatibilityKind.outdated,
+      reason: FitBundleCompatibilityReason.missingComparableRevision,
       savedSnapshot: savedSnapshot,
       activeSnapshot: activeSnapshot,
     );

--- a/lib/storage/fit/compatibility.dart
+++ b/lib/storage/fit/compatibility.dart
@@ -1,0 +1,134 @@
+import "package:eve_fit_assistant/storage/bundle/service.dart";
+import "package:eve_fit_assistant/storage/fit/manager.dart";
+import "package:eve_fit_assistant/storage/fit/schema.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+enum FitBundleCompatibilityKind { compatible, outdated, incompatible, unavailable }
+
+enum FitBundleCompatibilityReason {
+  none,
+  activeBundleUnavailable,
+  bundleIdMismatch,
+  manifestMismatch,
+  generationMismatch,
+  buildMismatch,
+  appVersionMismatch,
+}
+
+class FitBundleCompatibility {
+  const FitBundleCompatibility({
+    required this.kind,
+    required this.reason,
+    required this.savedSnapshot,
+    required this.activeSnapshot,
+  });
+
+  const FitBundleCompatibility.compatible({
+    required FitBundleSnapshot savedSnapshot,
+    required FitBundleSnapshot activeSnapshot,
+  }) : this(
+         kind: FitBundleCompatibilityKind.compatible,
+         reason: FitBundleCompatibilityReason.none,
+         savedSnapshot: savedSnapshot,
+         activeSnapshot: activeSnapshot,
+       );
+
+  final FitBundleCompatibilityKind kind;
+  final FitBundleCompatibilityReason reason;
+  final FitBundleSnapshot savedSnapshot;
+  final FitBundleSnapshot? activeSnapshot;
+
+  bool get allowsEditing => kind == FitBundleCompatibilityKind.compatible;
+  bool get requiresAttention => kind != FitBundleCompatibilityKind.compatible;
+}
+
+FitBundleCompatibility evaluateFitBundleCompatibility(
+  FitMetadata metadata,
+  BundleMetadata? activeBundle,
+) {
+  final savedSnapshot = metadata.bundleSnapshot;
+  if (activeBundle == null) {
+    return FitBundleCompatibility(
+      kind: FitBundleCompatibilityKind.unavailable,
+      reason: FitBundleCompatibilityReason.activeBundleUnavailable,
+      savedSnapshot: savedSnapshot,
+      activeSnapshot: null,
+    );
+  }
+
+  final activeSnapshot = FitBundleSnapshot.fromBundleMetadata(activeBundle);
+  if (savedSnapshot.bundleId != activeSnapshot.bundleId) {
+    return FitBundleCompatibility(
+      kind: FitBundleCompatibilityKind.incompatible,
+      reason: FitBundleCompatibilityReason.bundleIdMismatch,
+      savedSnapshot: savedSnapshot,
+      activeSnapshot: activeSnapshot,
+    );
+  }
+
+  if (savedSnapshot.manifestHash case final savedManifestHash?) {
+    final activeManifestHash = activeSnapshot.manifestHash;
+    if (activeManifestHash != null && savedManifestHash != activeManifestHash) {
+      return FitBundleCompatibility(
+        kind: FitBundleCompatibilityKind.outdated,
+        reason: FitBundleCompatibilityReason.manifestMismatch,
+        savedSnapshot: savedSnapshot,
+        activeSnapshot: activeSnapshot,
+      );
+    }
+  }
+
+  if (savedSnapshot.generateTimestamp case final savedGenerateTimestamp?) {
+    final activeGenerateTimestamp = activeSnapshot.generateTimestamp;
+    if (activeGenerateTimestamp != null && savedGenerateTimestamp != activeGenerateTimestamp) {
+      return FitBundleCompatibility(
+        kind: FitBundleCompatibilityKind.outdated,
+        reason: FitBundleCompatibilityReason.generationMismatch,
+        savedSnapshot: savedSnapshot,
+        activeSnapshot: activeSnapshot,
+      );
+    }
+  }
+
+  if (savedSnapshot.gameBuild case final savedGameBuild?) {
+    final activeGameBuild = activeSnapshot.gameBuild;
+    if (activeGameBuild != null && savedGameBuild != activeGameBuild) {
+      return FitBundleCompatibility(
+        kind: FitBundleCompatibilityKind.outdated,
+        reason: FitBundleCompatibilityReason.buildMismatch,
+        savedSnapshot: savedSnapshot,
+        activeSnapshot: activeSnapshot,
+      );
+    }
+  }
+
+  if (savedSnapshot.appVersion case final savedAppVersion?) {
+    final activeAppVersion = activeSnapshot.appVersion;
+    if (activeAppVersion != null && savedAppVersion != activeAppVersion) {
+      return FitBundleCompatibility(
+        kind: FitBundleCompatibilityKind.outdated,
+        reason: FitBundleCompatibilityReason.appVersionMismatch,
+        savedSnapshot: savedSnapshot,
+        activeSnapshot: activeSnapshot,
+      );
+    }
+  }
+
+  return FitBundleCompatibility.compatible(
+    savedSnapshot: savedSnapshot,
+    activeSnapshot: activeSnapshot,
+  );
+}
+
+final fitBundleCompatibilityProvider = Provider.family<FitBundleCompatibility?, String>((
+  ref,
+  fitId,
+) {
+  final metadata = ref.watch(fitRegistryManagerProvider.select((registry) => registry.fits[fitId]));
+  if (metadata == null) {
+    return null;
+  }
+
+  final activeBundle = ref.watch(currentBundleProvider);
+  return evaluateFitBundleCompatibility(metadata, activeBundle);
+});

--- a/lib/storage/fit/compatibility.dart
+++ b/lib/storage/fit/compatibility.dart
@@ -76,6 +76,15 @@ FitBundleCompatibility evaluateFitBundleCompatibility(
     );
   }
 
+  if (!activeSnapshot.hasComparableRevision) {
+    return FitBundleCompatibility(
+      kind: FitBundleCompatibilityKind.outdated,
+      reason: FitBundleCompatibilityReason.missingComparableRevision,
+      savedSnapshot: savedSnapshot,
+      activeSnapshot: activeSnapshot,
+    );
+  }
+
   if (savedSnapshot.manifestHash case final savedManifestHash?) {
     final activeManifestHash = activeSnapshot.manifestHash;
     if (activeManifestHash != null && savedManifestHash != activeManifestHash) {

--- a/lib/storage/fit/compatibility_notice.dart
+++ b/lib/storage/fit/compatibility_notice.dart
@@ -23,11 +23,18 @@ FitBundleCompatibilityNotice? localizeFitBundleCompatibility(
 
   return switch (compatibility.kind) {
     FitBundleCompatibilityKind.compatible => null,
-    FitBundleCompatibilityKind.outdated => FitBundleCompatibilityNotice(
-      title: l10n.fitBundleChangedTitle,
-      message: l10n.fitBundleChangedDescription,
-      label: l10n.fitBundleChangedTitle,
-    ),
+    FitBundleCompatibilityKind.outdated => switch (compatibility.reason) {
+      FitBundleCompatibilityReason.missingComparableRevision => FitBundleCompatibilityNotice(
+        title: l10n.fitBundleLegacyTitle,
+        message: l10n.fitBundleLegacyDescription,
+        label: l10n.fitBundleLegacyTitle,
+      ),
+      _ => FitBundleCompatibilityNotice(
+        title: l10n.fitBundleChangedTitle,
+        message: l10n.fitBundleChangedDescription,
+        label: l10n.fitBundleChangedTitle,
+      ),
+    },
     FitBundleCompatibilityKind.incompatible => FitBundleCompatibilityNotice(
       title: l10n.fitBundleMismatchTitle,
       message: l10n.fitBundleMismatchDescription(

--- a/lib/storage/fit/compatibility_notice.dart
+++ b/lib/storage/fit/compatibility_notice.dart
@@ -1,0 +1,45 @@
+import "package:eve_fit_assistant/data/l10n/app_localizations.dart";
+import "package:eve_fit_assistant/storage/fit/compatibility.dart";
+
+class FitBundleCompatibilityNotice {
+  const FitBundleCompatibilityNotice({
+    required this.title,
+    required this.message,
+    required this.label,
+  });
+
+  final String title;
+  final String message;
+  final String label;
+}
+
+FitBundleCompatibilityNotice? localizeFitBundleCompatibility(
+  AppLocalizations l10n,
+  FitBundleCompatibility? compatibility,
+) {
+  if (compatibility == null || !compatibility.requiresAttention) {
+    return null;
+  }
+
+  return switch (compatibility.kind) {
+    FitBundleCompatibilityKind.compatible => null,
+    FitBundleCompatibilityKind.outdated => FitBundleCompatibilityNotice(
+      title: l10n.fitBundleChangedTitle,
+      message: l10n.fitBundleChangedDescription,
+      label: l10n.fitBundleChangedTitle,
+    ),
+    FitBundleCompatibilityKind.incompatible => FitBundleCompatibilityNotice(
+      title: l10n.fitBundleMismatchTitle,
+      message: l10n.fitBundleMismatchDescription(
+        savedBundleId: compatibility.savedSnapshot.bundleId,
+        activeBundleId: compatibility.activeSnapshot?.bundleId ?? "-",
+      ),
+      label: l10n.fitBundleMismatchTitle,
+    ),
+    FitBundleCompatibilityKind.unavailable => FitBundleCompatibilityNotice(
+      title: l10n.fitBundleUnavailableTitle,
+      message: l10n.fitBundleUnavailableDescription,
+      label: l10n.fitBundleUnavailableTitle,
+    ),
+  };
+}

--- a/lib/storage/fit/manager.dart
+++ b/lib/storage/fit/manager.dart
@@ -117,7 +117,7 @@ class FitManager extends _$FitManager {
     }
     info("Creating new fit of type $shipId named $name");
     final fitId = generateFitId();
-    final bundleInfo = ref.watch(currentBundleProvider.select((t) => t?.metadata));
+    final bundleInfo = ref.watch(currentBundleProvider);
     if (bundleInfo == null) {
       throw StateError("A valid bundle must be active before creating a fit.");
     }
@@ -128,6 +128,7 @@ class FitManager extends _$FitManager {
       lastModified: DateTime.now().millisecondsSinceEpoch,
       description: "",
       bundleId: bundleInfo.bundleId,
+      bundleSnapshot: FitBundleSnapshot.fromBundleMetadata(bundleInfo),
     );
     final fit = FitStorage.empty(metadata, ship);
     final fitPath = fit.fitStoragePath;
@@ -175,7 +176,7 @@ class FitManager extends _$FitManager {
       throw Exception(text);
     }
 
-    final bundleInfo = ref.watch(currentBundleProvider.select((t) => t?.metadata));
+    final bundleInfo = ref.watch(currentBundleProvider);
     if (bundleInfo == null) {
       throw StateError("A valid bundle must be active before importing a fit.");
     }
@@ -189,6 +190,7 @@ class FitManager extends _$FitManager {
           : importedFit.metadata.name.trim(),
       lastModified: DateTime.now().millisecondsSinceEpoch,
       bundleId: bundleInfo.bundleId,
+      bundleSnapshot: FitBundleSnapshot.fromBundleMetadata(bundleInfo),
     );
     final fit = pruneDynamicRegistry(importedFit.copyWith(metadata: metadata));
 

--- a/lib/storage/fit/persistence.dart
+++ b/lib/storage/fit/persistence.dart
@@ -1,7 +1,7 @@
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 
-const currentFitStorageVersion = 1;
-const currentFitRegistryVersion = 1;
+const currentFitStorageVersion = 2;
+const currentFitRegistryVersion = 2;
 const currentNativeFitPayloadVersion = 1;
 
 enum FitPersistencePayloadKind { fitStorage, fitRegistry, nativeText }
@@ -52,6 +52,13 @@ DecodedFitStorage decodeFitStorage(Map<String, dynamic> json) {
   }
 
   switch (version) {
+    case 1:
+      return DecodedFitStorage(
+        fit: FitStorage.fromJson(
+          _readPayloadMap(json, "fit", kind: FitPersistencePayloadKind.fitStorage),
+        ),
+        didMigrate: true,
+      );
     case currentFitStorageVersion:
       return DecodedFitStorage(
         fit: FitStorage.fromJson(
@@ -81,6 +88,13 @@ DecodedFitRegistry decodeFitRegistry(Map<String, dynamic> json) {
   }
 
   switch (version) {
+    case 1:
+      return DecodedFitRegistry(
+        registry: FitRegistry.fromJson(
+          _readPayloadMap(json, "registry", kind: FitPersistencePayloadKind.fitRegistry),
+        ),
+        didMigrate: true,
+      );
     case currentFitRegistryVersion:
       return DecodedFitRegistry(
         registry: FitRegistry.fromJson(

--- a/lib/storage/fit/schema.dart
+++ b/lib/storage/fit/schema.dart
@@ -3,6 +3,7 @@ import "package:eve_fit_assistant/config/paths.dart";
 import "package:eve_fit_assistant/constant/eve.dart";
 import "package:eve_fit_assistant/data/proto/fit.pb.dart";
 import "package:eve_fit_assistant/native/api/storage.dart" as native;
+import "package:eve_fit_assistant/storage/bundle/service.dart";
 import "package:eve_fit_assistant/storage/character/schema.dart";
 import "package:eve_fit_assistant/utils/fp.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
@@ -12,6 +13,33 @@ import "package:path/path.dart" as p;
 
 part "schema.freezed.dart";
 part "schema.g.dart";
+
+@freezed
+abstract class FitBundleSnapshot with _$FitBundleSnapshot {
+  const factory FitBundleSnapshot({
+    required String bundleId,
+    String? manifestHash,
+    String? gameBuild,
+    String? appVersion,
+    int? generateTimestamp,
+  }) = _FitBundleSnapshot;
+
+  const FitBundleSnapshot._();
+
+  factory FitBundleSnapshot.fromJson(Map<String, dynamic> json) =>
+      _$FitBundleSnapshotFromJson(json);
+
+  factory FitBundleSnapshot.fromBundleMetadata(BundleMetadata bundle) => FitBundleSnapshot(
+    bundleId: bundle.bundleId,
+    manifestHash: bundle.metadata.latest.manifestHash,
+    gameBuild: bundle.metadata.latest.gameBuild,
+    appVersion: bundle.metadata.latest.appVersion,
+    generateTimestamp: bundle.metadata.latest.generateTimestamp,
+  );
+
+  bool get hasComparableRevision =>
+      manifestHash != null || generateTimestamp != null || gameBuild != null || appVersion != null;
+}
 
 @freezed
 abstract class FitMetadata with _$FitMetadata {
@@ -25,6 +53,7 @@ abstract class FitMetadata with _$FitMetadata {
 
     required String description,
     required String bundleId,
+    @JsonKey(readValue: _readBundleSnapshot) required FitBundleSnapshot bundleSnapshot,
   }) = _FitMetadata;
 
   factory FitMetadata.fromJson(Map<String, dynamic> json) => _$FitMetadataFromJson(json);
@@ -98,6 +127,20 @@ Object? _readCharacterId(Map<dynamic, dynamic> json, String key) =>
       "all0" => predefinedZeroCharacterId,
       _ => predefinedMaxCharacterId,
     };
+
+Object? _readBundleSnapshot(Map<dynamic, dynamic> json, String key) {
+  final snapshot = json[key];
+  if (snapshot != null) {
+    return snapshot;
+  }
+
+  final bundleId = json["bundleId"];
+  if (bundleId is! String) {
+    return null;
+  }
+
+  return <String, dynamic>{"bundleId": bundleId};
+}
 
 /// The length of any slot is fixed (or partially fixed, since we have subsystems) for a given ship.
 /// So we can use a list to represent the slots, and use `None` to represent empty slots.

--- a/lib/storage/fit/service.dart
+++ b/lib/storage/fit/service.dart
@@ -8,6 +8,7 @@ import "package:eve_fit_assistant/native/api/server.dart" as native_server;
 import "package:eve_fit_assistant/storage/bundle/service.dart";
 import "package:eve_fit_assistant/storage/bundle/service/collection.dart";
 import "package:eve_fit_assistant/storage/character/schema.dart";
+import "package:eve_fit_assistant/storage/fit/compatibility.dart";
 import "package:eve_fit_assistant/storage/fit/manager.dart";
 import "package:eve_fit_assistant/storage/fit/persistence.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
@@ -155,6 +156,9 @@ class Fit extends _$Fit {
 
   Future<void> _mount(String fitId) => _loadFromDisk(fitId);
 
+  FitBundleCompatibility _compatibilityFor(FitStorage fit) =>
+      evaluateFitBundleCompatibility(fit.metadata, ref.read(currentBundleProvider));
+
   void _unmount() {
     debug("Unmounting fit service");
     final fit = _mountedFit;
@@ -180,9 +184,27 @@ class Fit extends _$Fit {
       error("Cannot update fit service: not initialized");
       return;
     }
-    final fit = pruneDynamicRegistry(updater(state.fit)).copyWith(
-      metadata: state.fit.metadata.copyWith(lastModified: DateTime.now().millisecondsSinceEpoch),
+    final currentFit = state.fit;
+    final compatibility = _compatibilityFor(currentFit);
+    if (!compatibility.allowsEditing) {
+      state = FitServiceState.loaded(
+        status: const FitServiceStatus.error(
+          message: "This fit is read-only until its saved bundle matches the active bundle.",
+        ),
+        fit: currentFit,
+      );
+      return;
+    }
+
+    final activeBundle = ref.read(currentBundleProvider);
+    final updatedMetadata = currentFit.metadata.copyWith(
+      lastModified: DateTime.now().millisecondsSinceEpoch,
+      bundleId: activeBundle?.bundleId ?? currentFit.metadata.bundleId,
+      bundleSnapshot: activeBundle == null
+          ? currentFit.metadata.bundleSnapshot
+          : FitBundleSnapshot.fromBundleMetadata(activeBundle),
     );
+    final fit = pruneDynamicRegistry(updater(currentFit)).copyWith(metadata: updatedMetadata);
     _mountedFit = fit;
     state = FitServiceState.loaded(status: const FitServiceStatus.syncing(), fit: fit);
     ref.read(fitRegistryManagerProvider.notifier).updateFit(fit.metadata);


### PR DESCRIPTION
Closes #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bundle compatibility checks and localized notices (EN/ZH) for fits: changed, legacy/outdated, mismatch (shows saved vs active IDs), and unavailable.
  * Fit list and fit detail pages now display compatibility warnings and labels.

* **Improvements**
  * Editing is disabled for affected fits while inspection/export remains available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->