### PR TITLE
feat: enhance EFA1 text import compatibility and update documentation

### DIFF
--- a/docs/dev/fit-storage.md
+++ b/docs/dev/fit-storage.md
@@ -73,8 +73,8 @@ then rewritten immediately in the versioned format.
 
 - Native text import/export lives in [`lib/features/fit_io`](../../lib/features/fit_io).
 - Export currently emits the `EFA:` prefix only.
-- Import recognizes `EFA:` and also recognizes `EFA<int>:` structurally.
-  However, any explicit numeric suffix is rejected as unsupported by the current parser version.
+- Import accepts both the legacy `EFA:` prefix and the explicit `EFA1:` prefix.
+- Explicit numeric prefixes newer than `EFA1:` are rejected as unsupported.
 - The compressed payload inside `EFA:` still contains its own `version` field,
   validated through `decodeNativeFitPayload(...)`.
 
@@ -86,6 +86,7 @@ without tying future native text versions directly to on-disk file versions.
 - There is no multi-step historical migration chain yet.
   The current alpha implementation only normalizes legacy unversioned payloads into version `1` envelopes.
 - Unknown future versions are rejected instead of partially decoded.
+  This applies both to persisted fit payloads and to native text imports with explicit prefixes.
 - Additive compatibility is only relaxed where the current JSON decoding already tolerates extra fields.
 
 ## Suggested Future Extension

--- a/lib/features/fit_io/text_import.dart
+++ b/lib/features/fit_io/text_import.dart
@@ -41,6 +41,7 @@ class FitTextImporter {
   const FitTextImporter(this.ref);
 
   static final _nativePrefixPattern = RegExp(r"^EFA(?:(\d+))?:");
+  static const _legacyNativePrefixVersion = 1;
 
   final WidgetRef ref;
 
@@ -77,7 +78,7 @@ class FitTextImporter {
         throw const FitTextImportException(FitTextImportErrorCode.unsupportedNativeVersion);
       }
       final explicitVersion = prefixMatch.group(1);
-      if (explicitVersion != null) {
+      if (explicitVersion != null && int.tryParse(explicitVersion) != _legacyNativePrefixVersion) {
         throw const FitTextImportException(FitTextImportErrorCode.unsupportedNativeVersion);
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native text import validation now properly accepts both legacy `EFA:` prefix format and explicit `EFA1:` version prefix
  * Enhanced rejection of unsupported future version prefixes during imports

* **Documentation**
  * Updated documentation to clarify native text import prefix formats and version compatibility limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->