### PR TITLE
feat: hide unavailable attribute current value in item detail

### DIFF
--- a/lib/pages/item-detail/page.dart
+++ b/lib/pages/item-detail/page.dart
@@ -991,21 +991,18 @@ class _AttributeOverviewContent extends ConsumerWidget {
                   ? context.l10n.itemDetailUnavailable
                   : _formatItemDetailDogmaValue(context, ref, unit, staticValue!),
             ),
-            _ValueChip(
-              label: context.l10n.itemDetailAttributeCurrentValue,
-              value: current?.value == null
-                  ? context.l10n.itemDetailUnavailable
-                  : _formatItemDetailDogmaValue(context, ref, unit, current!.value!),
-              tone: current?.value == null
-                  ? null
-                  : staticValue == null
-                  ? null
-                  : _attributeDeltaTone(
-                      attribute: attribute,
-                      baseValue: staticValue!,
-                      currentValue: current!.value!,
-                    ),
-            ),
+            if (current?.value != null)
+              _ValueChip(
+                label: context.l10n.itemDetailAttributeCurrentValue,
+                value: _formatItemDetailDogmaValue(context, ref, unit, current!.value!),
+                tone: staticValue == null
+                    ? null
+                    : _attributeDeltaTone(
+                        attribute: attribute,
+                        baseValue: staticValue!,
+                        currentValue: current!.value!,
+                      ),
+              ),
             if (staticValue != null && current?.value != null && canFormatDogmaUnitDelta(unit))
               _ValueChip(
                 label: context.l10n.itemDetailAttributeDelta,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the current value display behavior to show the value chip only when a value is present. This removes unnecessary "unavailable" indicators from the interface, improving clarity in the attribute overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->