### PR TITLE
feat: implement alpha clone skill limits and UI enhancements

### DIFF
--- a/data/lib/workspace/generate/static/types.py
+++ b/data/lib/workspace/generate/static/types.py
@@ -80,6 +80,16 @@ class TypeDef(BaseModel):
         return pb
 
 
+class CloneGradeSkill(BaseModel):
+    typeID: int
+    level: int = Field(ge=0, le=5)
+
+
+class CloneGradeDef(BaseModel):
+    skills: list[CloneGradeSkill]
+    internalDescription: str
+
+
 def _extract_required_skills(dogma_attributes: list[DogmaAttributeItem]) -> list[tuple[int, int]]:
     attr_map = {attr.attributeID: attr.value for attr in dogma_attributes}
     requirements: list[tuple[int, int]] = []
@@ -150,11 +160,44 @@ async def _load_info_bubble_traits(data: GeneratorDatasource) -> dict[int, TypeT
     return {int(type_id): TypeTraitRaw.model_validate(value) for type_id, value in traits.items()}
 
 
+def _normalize_clone_grade_skills(skills: list[CloneGradeSkill]) -> tuple[tuple[int, int], ...]:
+    return tuple(sorted((skill.typeID, skill.level) for skill in skills))
+
+
+async def _load_alpha_skill_levels(data: GeneratorDatasource) -> dict[int, int]:
+    node = data.resources.res.get_resource("res:/staticdata/clonegrades.static")
+    await node.download()
+    path = node.local_path
+    if path is None:
+        raise RuntimeError("Failed to resolve clonegrades.static local path")
+
+    with sqlite3.connect(path) as connection:
+        rows = connection.execute('SELECT "key", "value" FROM "cache"').fetchall()
+
+    if not rows:
+        raise RuntimeError("Failed to load clonegrades.static cache rows")
+
+    first_key, first_value = rows[0]
+    first_grade = CloneGradeDef.model_validate_json(first_value)
+    first_skills = _normalize_clone_grade_skills(first_grade.skills)
+
+    for key, value in rows[1:]:
+        grade = CloneGradeDef.model_validate_json(value)
+        if _normalize_clone_grade_skills(grade.skills) != first_skills:
+            error(
+                "Clone grade skills differ from the first cache row; "
+                f"alpha max levels are generated from {first_key!r}, but {key!r} differs."
+            )
+
+    return {skill.typeID: skill.level for skill in first_grade.skills}
+
+
 async def generate(data: GeneratorDatasource, collection):
     info("Generating types...")
     types = await data.resources.fsd.get("types")
     type_dogma = await data.resources.fsd.get("typedogma")
     traits = await _load_info_bubble_traits(data)
+    alpha_skill_levels = await _load_alpha_skill_levels(data)
 
     cnt = 0
     for type_id, type_def in types.items():
@@ -166,6 +209,9 @@ async def generate(data: GeneratorDatasource, collection):
 
         cnt += 1
         pb = validated.to_pb()
+        alpha_max_level = alpha_skill_levels.get(validated.typeID)
+        if alpha_max_level is not None:
+            pb.alpha_max_level = alpha_max_level
 
         dogma_def = type_dogma.get(type_id)
         if dogma_def is not None:

--- a/data/schema/types.proto
+++ b/data/schema/types.proto
@@ -48,4 +48,5 @@ message Type {
   repeated SkillRequirement required_skills = 10;
   repeated DogmaAttributeValue dogma_attributes = 11;
   repeated TraitSection trait_sections = 12;
+  optional uint32 alpha_max_level = 13;
 }

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -183,6 +183,7 @@
   "fitSkillPolicyPresetTitle": "Skill profile: {profileName}",
   "fitSkillPolicyPresetDescription": "This build uses preset skill profiles instead of real character data.",
   "fitSkillProfileAll5": "All V",
+  "fitSkillProfileAlphaMax": "Alpha Max",
   "fitSkillProfileAll0": "All 0",
   "fitSkillPolicyUnsupportedTitle": "Skill-aware simulation is not available in this build.",
   "fitSkillPolicyUnsupportedDescription": "Fits are simulated without character skill modifiers. Implants and boosters still apply.",

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -341,6 +341,7 @@
   },
   "fitSkillPolicyPresetDescription": "当前构建使用预设技能档案，而不是真实角色数据。",
   "fitSkillProfileAll5": "全 5",
+  "fitSkillProfileAlphaMax": "Alpha 最高",
   "fitSkillProfileAll0": "全 0",
   "fitSkillPolicyUnsupportedTitle": "当前构建暂不支持技能感知模拟。",
   "fitSkillPolicyUnsupportedDescription": "当前配置模拟不会应用角色技能修正。植入体和增效剂仍然生效。",

--- a/lib/constant/colors.dart
+++ b/lib/constant/colors.dart
@@ -17,6 +17,8 @@ const Color colorStatusOverload = Color(0xFFEF5350);
 const Color colorStatusOnline = Color(0xFFBDBDBD);
 const Color colorStatusPassive = Color(0xFF2D2D2D);
 
+const Color colorSkillAlphaLimited = Color(0xFFFBC02D);
+
 const Color colorActionDelete = Color(0xFFFE4A49);
 
 final MarkdownConfig markdownDarkConfig = MarkdownConfig(

--- a/lib/pages/character/page.dart
+++ b/lib/pages/character/page.dart
@@ -265,6 +265,7 @@ String characterDisplayName(
   CharacterMetadata? metadata,
 ) => switch (characterId) {
   predefinedMaxCharacterId => context.l10n.fitSkillProfileAll5,
+  predefinedAlphaMaxCharacterId => context.l10n.fitSkillProfileAlphaMax,
   predefinedZeroCharacterId => context.l10n.fitSkillProfileAll0,
   _ => metadata?.name ?? characterId,
 };

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -155,7 +155,9 @@ class _SkillLevelIndicator extends StatelessWidget {
       final color = unavailableToAlpha
           ? colorSkillAlphaLimited
           : Theme.of(context).colorScheme.primary;
-      final borderColor = trained || unavailableToAlpha ? color : Theme.of(context).dividerColor;
+      final borderColor = trained || unavailableToAlpha
+          ? color
+          : Theme.of(context).colorScheme.outline;
       final pip = AnimatedContainer(
         duration: const Duration(milliseconds: 120),
         width: _pipSize,

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -1,4 +1,5 @@
 import "package:eve_fit_assistant/components/list/eve_list_tile.dart";
+import "package:eve_fit_assistant/constant/colors.dart";
 import "package:eve_fit_assistant/constant/eve.dart";
 import "package:eve_fit_assistant/data/proto/groups.pb.dart" as pb_groups;
 import "package:eve_fit_assistant/data/proto/types.pb.dart" as pb_types;
@@ -152,7 +153,7 @@ class _SkillLevelIndicator extends StatelessWidget {
       final trained = skillLevel <= level;
       final unavailableToAlpha = skillLevel > alphaMaxLevel;
       final color = unavailableToAlpha
-          ? Colors.orange.shade700
+          ? colorSkillAlphaLimited
           : Theme.of(context).colorScheme.primary;
       final borderColor = trained || unavailableToAlpha ? color : Theme.of(context).dividerColor;
       final pip = AnimatedContainer(

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -55,6 +55,7 @@ class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
               return _SkillListTile(
                 skill: skill,
                 level: widget.skills[skill.typeId] ?? 0,
+                alphaMaxLevel: skill.alphaMaxLevel,
                 onTapLevel: widget.onTapLevel == null
                     ? null
                     : (level) => widget.onTapLevel!(skill.typeId, level),
@@ -108,27 +109,38 @@ class _SkillGroupFilter extends StatelessWidget {
 }
 
 class _SkillListTile extends StatelessWidget {
-  const _SkillListTile({required this.skill, required this.level, this.onTapLevel});
+  const _SkillListTile({
+    required this.skill,
+    required this.level,
+    required this.alphaMaxLevel,
+    this.onTapLevel,
+  });
 
   final pb_types.Type skill;
   final int level;
+  final int alphaMaxLevel;
   final ValueChanged<int>? onTapLevel;
 
   @override
   Widget build(BuildContext context) => ListTile(
     title: TypeNameText(typeId: skill.typeId),
-    trailing: _SkillLevelIndicator(level: level, onTapLevel: onTapLevel),
+    trailing: _SkillLevelIndicator(
+      level: level,
+      alphaMaxLevel: alphaMaxLevel,
+      onTapLevel: onTapLevel,
+    ),
     onLongPress: () => showItemDetailPage(context, typeId: skill.typeId),
   );
 }
 
 class _SkillLevelIndicator extends StatelessWidget {
-  const _SkillLevelIndicator({required this.level, this.onTapLevel});
+  const _SkillLevelIndicator({required this.level, required this.alphaMaxLevel, this.onTapLevel});
 
   static const double _hitTargetSize = 44;
   static const double _pipSize = 18;
 
   final int level;
+  final int alphaMaxLevel;
   final ValueChanged<int>? onTapLevel;
 
   @override
@@ -138,8 +150,11 @@ class _SkillLevelIndicator extends StatelessWidget {
     children: List.generate(5, (index) {
       final skillLevel = index + 1;
       final trained = skillLevel <= level;
-      final color = Theme.of(context).colorScheme.primary;
-      final borderColor = trained ? color : Theme.of(context).dividerColor;
+      final unavailableToAlpha = skillLevel > alphaMaxLevel;
+      final color = unavailableToAlpha
+          ? Colors.orange.shade700
+          : Theme.of(context).colorScheme.primary;
+      final borderColor = trained || unavailableToAlpha ? color : Theme.of(context).dividerColor;
       final pip = AnimatedContainer(
         duration: const Duration(milliseconds: 120),
         width: _pipSize,

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -56,7 +56,7 @@ class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
               return _SkillListTile(
                 skill: skill,
                 level: widget.skills[skill.typeId] ?? 0,
-                alphaMaxLevel: skill.alphaMaxLevel,
+                alphaMaxLevel: skill.hasAlphaMaxLevel() ? skill.alphaMaxLevel : null,
                 onTapLevel: widget.onTapLevel == null
                     ? null
                     : (level) => widget.onTapLevel!(skill.typeId, level),
@@ -113,13 +113,13 @@ class _SkillListTile extends StatelessWidget {
   const _SkillListTile({
     required this.skill,
     required this.level,
-    required this.alphaMaxLevel,
+    this.alphaMaxLevel,
     this.onTapLevel,
   });
 
   final pb_types.Type skill;
   final int level;
-  final int alphaMaxLevel;
+  final int? alphaMaxLevel;
   final ValueChanged<int>? onTapLevel;
 
   @override
@@ -135,13 +135,13 @@ class _SkillListTile extends StatelessWidget {
 }
 
 class _SkillLevelIndicator extends StatelessWidget {
-  const _SkillLevelIndicator({required this.level, required this.alphaMaxLevel, this.onTapLevel});
+  const _SkillLevelIndicator({required this.level, this.alphaMaxLevel, this.onTapLevel});
 
   static const double _hitTargetSize = 44;
   static const double _pipSize = 18;
 
   final int level;
-  final int alphaMaxLevel;
+  final int? alphaMaxLevel;
   final ValueChanged<int>? onTapLevel;
 
   @override
@@ -151,7 +151,7 @@ class _SkillLevelIndicator extends StatelessWidget {
     children: List.generate(5, (index) {
       final skillLevel = index + 1;
       final trained = skillLevel <= level;
-      final unavailableToAlpha = skillLevel > alphaMaxLevel;
+      final unavailableToAlpha = alphaMaxLevel != null && skillLevel > alphaMaxLevel!;
       final color = unavailableToAlpha
           ? colorSkillAlphaLimited
           : Theme.of(context).colorScheme.primary;

--- a/lib/pages/fit/tabs/character.dart
+++ b/lib/pages/fit/tabs/character.dart
@@ -174,6 +174,7 @@ String _characterDisplayName(
   CharacterMetadata? metadata,
 ) => switch (characterId) {
   predefinedMaxCharacterId => context.l10n.fitSkillProfileAll5,
+  predefinedAlphaMaxCharacterId => context.l10n.fitSkillProfileAlphaMax,
   predefinedZeroCharacterId => context.l10n.fitSkillProfileAll0,
   _ => metadata?.name ?? characterId,
 };

--- a/lib/pages/item-detail/page.dart
+++ b/lib/pages/item-detail/page.dart
@@ -1263,17 +1263,17 @@ class _SkillTreeNodeState extends ConsumerState<_SkillTreeNode> {
                 children: [
                   SizedBox(
                     width: 24,
+                    height: 24,
                     child: hasChildren
-                        ? IconButton(
-                            visualDensity: VisualDensity.compact,
-                            padding: EdgeInsets.zero,
-                            onPressed: () => setState(() => _expanded = !_expanded),
-                            icon: Icon(
+                        ? InkResponse(
+                            onTap: () => setState(() => _expanded = !_expanded),
+                            radius: 16,
+                            child: Icon(
                               _expanded ? Icons.expand_more : Icons.chevron_right,
                               size: 18,
                             ),
                           )
-                        : const SizedBox.shrink(),
+                        : null,
                   ),
                   Expanded(
                     child: skillType == null

--- a/lib/pages/item-detail/page.dart
+++ b/lib/pages/item-detail/page.dart
@@ -6,6 +6,7 @@ import "package:eve_fit_assistant/components/icon/eve_icon.dart";
 import "package:eve_fit_assistant/components/layout.dart";
 import "package:eve_fit_assistant/components/list/eve_list_tile.dart";
 import "package:eve_fit_assistant/components/localized_text.dart";
+import "package:eve_fit_assistant/constant/colors.dart";
 import "package:eve_fit_assistant/data/proto/dogma_attributes.pb.dart";
 import "package:eve_fit_assistant/data/proto/dogma_units.pb.dart";
 import "package:eve_fit_assistant/data/proto/dynamic.pb.dart" as pb_dynamic;
@@ -1802,7 +1803,7 @@ class _LevelPips extends StatelessWidget {
       final skillLevel = index + 1;
       final active = skillLevel <= level;
       final unavailableToAlpha = alphaMaxLevel != null && skillLevel > alphaMaxLevel!;
-      final color = unavailableToAlpha ? Colors.orange.shade700 : context.theme.colorScheme.primary;
+      final color = unavailableToAlpha ? colorSkillAlphaLimited : context.theme.colorScheme.primary;
       final borderColor = active || unavailableToAlpha ? color : context.theme.colorScheme.outline;
       return Container(
         width: 16,

--- a/lib/pages/item-detail/page.dart
+++ b/lib/pages/item-detail/page.dart
@@ -1265,10 +1265,12 @@ class _SkillTreeNodeState extends ConsumerState<_SkillTreeNode> {
                     width: 24,
                     height: 24,
                     child: hasChildren
-                        ? InkResponse(
-                            onTap: () => setState(() => _expanded = !_expanded),
-                            radius: 16,
-                            child: Icon(
+                        ? IconButton(
+                            visualDensity: VisualDensity.compact,
+                            padding: EdgeInsets.zero,
+                            constraints: const BoxConstraints.tightFor(width: 24, height: 24),
+                            onPressed: () => setState(() => _expanded = !_expanded),
+                            icon: Icon(
                               _expanded ? Icons.expand_more : Icons.chevron_right,
                               size: 18,
                             ),

--- a/lib/pages/item-detail/page.dart
+++ b/lib/pages/item-detail/page.dart
@@ -1285,7 +1285,9 @@ class _SkillTreeNodeState extends ConsumerState<_SkillTreeNode> {
                   const SizedBox(width: 12),
                   _LevelPips(
                     level: widget.requirement.level,
-                    alphaMaxLevel: skillType?.alphaMaxLevel,
+                    alphaMaxLevel: skillType?.hasAlphaMaxLevel() ?? false
+                        ? skillType!.alphaMaxLevel
+                        : null,
                   ),
                 ],
               ),

--- a/lib/pages/item-detail/page.dart
+++ b/lib/pages/item-detail/page.dart
@@ -1280,7 +1280,10 @@ class _SkillTreeNodeState extends ConsumerState<_SkillTreeNode> {
                         : TypeNameText(typeId: widget.requirement.skillTypeId),
                   ),
                   const SizedBox(width: 12),
-                  _LevelPips(level: widget.requirement.level),
+                  _LevelPips(
+                    level: widget.requirement.level,
+                    alphaMaxLevel: skillType?.alphaMaxLevel,
+                  ),
                 ],
               ),
             ),
@@ -1787,24 +1790,27 @@ class _EffectValueText extends StatelessWidget {
 }
 
 class _LevelPips extends StatelessWidget {
-  const _LevelPips({required this.level});
+  const _LevelPips({required this.level, this.alphaMaxLevel});
 
   final int level;
+  final int? alphaMaxLevel;
 
   @override
   Widget build(BuildContext context) => Row(
     mainAxisSize: MainAxisSize.min,
     children: List.generate(5, (index) {
-      final active = index < level;
+      final skillLevel = index + 1;
+      final active = skillLevel <= level;
+      final unavailableToAlpha = alphaMaxLevel != null && skillLevel > alphaMaxLevel!;
+      final color = unavailableToAlpha ? Colors.orange.shade700 : context.theme.colorScheme.primary;
+      final borderColor = active || unavailableToAlpha ? color : context.theme.colorScheme.outline;
       return Container(
         width: 16,
         height: 16,
         margin: const EdgeInsets.symmetric(horizontal: 3),
         decoration: BoxDecoration(
-          color: active ? context.theme.colorScheme.primary : Colors.transparent,
-          border: Border.all(
-            color: active ? context.theme.colorScheme.primary : context.theme.colorScheme.outline,
-          ),
+          color: active ? color : Colors.transparent,
+          border: Border.all(color: borderColor),
           borderRadius: BorderRadius.circular(2),
         ),
       );

--- a/lib/storage/character/manager.dart
+++ b/lib/storage/character/manager.dart
@@ -58,7 +58,11 @@ abstract class CharacterRegistry with _$CharacterRegistry {
 class CharacterRegistryManager extends _$CharacterRegistryManager {
   static String get _characterRegistryPath => p.join(PathProvider.charactersPath, "registry.json");
 
-  static const builtInCharacterIds = <String>[predefinedMaxCharacterId, predefinedZeroCharacterId];
+  static const builtInCharacterIds = <String>[
+    predefinedMaxCharacterId,
+    predefinedAlphaMaxCharacterId,
+    predefinedZeroCharacterId,
+  ];
   static const _registrySyncDebounce = Duration(milliseconds: 300);
   static const _idGenerator = Uuid();
 
@@ -82,7 +86,9 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
       unawaited(_queueRegistrySync());
     });
     final bundleId = ref.watch(currentBundleProvider)?.bundleId ?? "";
+    final collection = ref.watch(bundleCollectionProvider);
     final skillTypeIds = ref.watch(bundleCollectionSkillTypeIdsProvider);
+    final alphaSkillLevels = _alphaSkillLevels(collection, skillTypeIds);
     final registryFile = File(_characterRegistryPath);
     if (!registryFile.existsSync()) {
       registryFile
@@ -93,7 +99,12 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
     final registryContent = registryFile.readAsStringSync();
     final registryJson = jsonDecode(registryContent) as Map<String, dynamic>;
     final registry = CharacterRegistry.fromJson(registryJson);
-    return _ensureBuiltInCharacters(registry, bundleId: bundleId, skillTypeIds: skillTypeIds);
+    return _ensureBuiltInCharacters(
+      registry,
+      bundleId: bundleId,
+      skillTypeIds: skillTypeIds,
+      alphaSkillLevels: alphaSkillLevels,
+    );
   }
 
   void updateCharacter(CharacterMetadata metadata) {
@@ -130,9 +141,13 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
     Iterable<int> availableSkillTypeIds,
   ) async {
     final skillTypeIds = availableSkillTypeIds.toList(growable: false);
+    final alphaSkillLevels = _alphaSkillLevels(ref.read(bundleCollectionProvider), skillTypeIds);
     final skills = switch (characterId) {
       predefinedMaxCharacterId => Map<int, int>.fromEntries(
         skillTypeIds.map((typeId) => MapEntry(typeId, 5)),
+      ),
+      predefinedAlphaMaxCharacterId => Map<int, int>.fromEntries(
+        skillTypeIds.map((typeId) => MapEntry(typeId, alphaSkillLevels[typeId] ?? 0)),
       ),
       predefinedZeroCharacterId => Map<int, int>.fromEntries(
         skillTypeIds.map((typeId) => MapEntry(typeId, 0)),
@@ -147,6 +162,20 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
     return Map<int, int>.fromEntries(
       skillTypeIds.map((typeId) => MapEntry(typeId, _normalizeSkillLevel(skills[typeId] ?? 0))),
     );
+  }
+
+  static IMap<int, int> _alphaSkillLevels(
+    BundleCollectionProxy? collection,
+    Iterable<int> skillTypeIds,
+  ) {
+    if (collection == null) {
+      return const <int, int>{}.lock;
+    }
+    final skillTypeIdSet = skillTypeIds.toSet();
+    return <int, int>{
+      for (final type in collection.allTypes)
+        if (skillTypeIdSet.contains(type.typeId)) type.typeId: type.alphaMaxLevel,
+    }.lock;
   }
 
   Future<CharacterStorage> createCharacter({
@@ -282,6 +311,7 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
     CharacterRegistry registry, {
     required String bundleId,
     required Iterable<int> skillTypeIds,
+    required IMap<int, int> alphaSkillLevels,
   }) {
     var nextRegistry = registry;
 
@@ -290,6 +320,13 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
         characterId: predefinedMaxCharacterId,
         name: "All V",
         description: "Built-in max skill profile",
+        lastModified: 0,
+        bundleId: bundleId,
+      ),
+      CharacterMetadata(
+        characterId: predefinedAlphaMaxCharacterId,
+        name: "Alpha Max",
+        description: "Built-in Alpha clone max skill profile",
         lastModified: 0,
         bundleId: bundleId,
       ),
@@ -304,6 +341,9 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
       final skills = switch (metadata.characterId) {
         predefinedMaxCharacterId => Map<int, int>.fromEntries(
           skillTypeIds.map((typeId) => MapEntry(typeId, 5)),
+        ),
+        predefinedAlphaMaxCharacterId => Map<int, int>.fromEntries(
+          skillTypeIds.map((typeId) => MapEntry(typeId, alphaSkillLevels[typeId] ?? 0)),
         ),
         predefinedZeroCharacterId => Map<int, int>.fromEntries(
           skillTypeIds.map((typeId) => MapEntry(typeId, 0)),

--- a/lib/storage/character/schema.dart
+++ b/lib/storage/character/schema.dart
@@ -7,6 +7,7 @@ part "schema.freezed.dart";
 part "schema.g.dart";
 
 const predefinedMaxCharacterId = "predefined_all_5";
+const predefinedAlphaMaxCharacterId = "predefined_alpha_max";
 const predefinedZeroCharacterId = "predefined_all_0";
 
 @freezed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Alpha Max" built-in character profile that reflects per-skill alpha maximums.
  * Skill lists, trees, and level indicators now mark and cap levels above alpha limits as alpha-limited.

* **Localization**
  * Added English and Chinese labels for the Alpha Max UI.

* **Style**
  * Introduced a distinct color for alpha-limited skill display.

* **UX**
  * Display names and character selection now surface the Alpha Max profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->