### PR TITLE
feat: detect system locale

### DIFF
--- a/lib/storage/setting/setting.dart
+++ b/lib/storage/setting/setting.dart
@@ -1,5 +1,6 @@
 import "dart:convert";
 import "dart:io";
+import "dart:ui" as ui;
 
 import "package:eve_fit_assistant/config/locale.dart";
 import "package:eve_fit_assistant/config/paths.dart";
@@ -16,7 +17,7 @@ part "setting.g.dart";
 @freezed
 abstract class AppSetting with _$AppSetting {
   const factory AppSetting({
-    @JsonKey(unknownEnumValue: Locale.zh, defaultValue: Locale.zh) required Locale locale,
+    @JsonKey(unknownEnumValue: Locale.zh) required Locale locale,
     @JsonKey(defaultValue: false) required bool enableDebugLog,
     @JsonKey(
       unknownEnumValue: TypeListDisplayVariant.marketGroup,
@@ -68,7 +69,15 @@ class AppSettingService extends _$AppSettingService {
     } else {
       json = {};
     }
-    final setting = AppSetting.fromJson(json);
+    final setting = AppSetting.fromJson({"locale": _defaultLocale().name, ...json});
     _appSetting = setting;
+  }
+
+  static Locale _defaultLocale() {
+    final platformLocale = ui.PlatformDispatcher.instance.locale;
+    return switch (platformLocale.languageCode) {
+      "en" => Locale.en,
+      _ => Locale.zh,
+    };
   }
 }

--- a/lib/storage/setting/setting.dart
+++ b/lib/storage/setting/setting.dart
@@ -76,8 +76,8 @@ class AppSettingService extends _$AppSettingService {
   static Locale _defaultLocale() {
     final platformLocale = ui.PlatformDispatcher.instance.locale;
     return switch (platformLocale.languageCode) {
-      "en" => Locale.en,
-      _ => Locale.zh,
+      "zh" => Locale.zh,
+      _ => Locale.en,
     };
   }
 }

--- a/lib/storage/setting/setting.dart
+++ b/lib/storage/setting/setting.dart
@@ -17,7 +17,7 @@ part "setting.g.dart";
 @freezed
 abstract class AppSetting with _$AppSetting {
   const factory AppSetting({
-    @JsonKey(unknownEnumValue: Locale.zh) required Locale locale,
+    @JsonKey(unknownEnumValue: Locale.en) required Locale locale,
     @JsonKey(defaultValue: false) required bool enableDebugLog,
     @JsonKey(
       unknownEnumValue: TypeListDisplayVariant.marketGroup,


### PR DESCRIPTION
Closes #69 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup reliability by ensuring language is initialized from the device locale. Chinese locales are detected and presented in Chinese; other locales default to English. Saved settings are merged with this default so the app consistently displays the correct language on launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->