### PR TITLE
fix(skills): treat missing alpha max as unavailable

### DIFF
--- a/data/lib/workspace/generate/static/types.py
+++ b/data/lib/workspace/generate/static/types.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 _REQUIRED_SKILL_ATTRIBUTE_IDS = [182, 183, 184, 1285, 1289, 1290]
 _REQUIRED_SKILL_LEVEL_ATTRIBUTE_IDS = [277, 278, 279, 1286, 1287, 1288]
+_SKILL_CATEGORY_ID = 16
 
 
 class TypeDogmaDef(BaseModel):
@@ -78,6 +79,11 @@ class TypeDef(BaseModel):
             pb.description.CopyFrom(loc(self.descriptionID))
 
         return pb
+
+
+class GroupCategoryDef(BaseModel):
+    groupID: int
+    categoryID: int
 
 
 class CloneGradeSkill(BaseModel):
@@ -160,6 +166,20 @@ async def _load_info_bubble_traits(data: GeneratorDatasource) -> dict[int, TypeT
     return {int(type_id): TypeTraitRaw.model_validate(value) for type_id, value in traits.items()}
 
 
+async def _load_skill_group_ids(data: GeneratorDatasource) -> set[int]:
+    groups = await data.resources.fsd.get("groups")
+    skill_group_ids: set[int] = set()
+    for group_id, group_def in groups.items():
+        try:
+            validated = GroupCategoryDef.model_validate(group_def)
+        except Exception as e:
+            error(f"Failed to validate group {group_id} for skill alpha levels: {e}")
+            continue
+        if validated.categoryID == _SKILL_CATEGORY_ID:
+            skill_group_ids.add(validated.groupID)
+    return skill_group_ids
+
+
 def _normalize_clone_grade_skills(skills: list[CloneGradeSkill]) -> tuple[tuple[int, int], ...]:
     return tuple(sorted((skill.typeID, skill.level) for skill in skills))
 
@@ -197,6 +217,7 @@ async def generate(data: GeneratorDatasource, collection):
     types = await data.resources.fsd.get("types")
     type_dogma = await data.resources.fsd.get("typedogma")
     traits = await _load_info_bubble_traits(data)
+    skill_group_ids = await _load_skill_group_ids(data)
     alpha_skill_levels = await _load_alpha_skill_levels(data)
 
     cnt = 0
@@ -209,9 +230,8 @@ async def generate(data: GeneratorDatasource, collection):
 
         cnt += 1
         pb = validated.to_pb()
-        alpha_max_level = alpha_skill_levels.get(validated.typeID)
-        if alpha_max_level is not None:
-            pb.alpha_max_level = alpha_max_level
+        if validated.groupID in skill_group_ids:
+            pb.alpha_max_level = alpha_skill_levels.get(validated.typeID, 0)
 
         dogma_def = type_dogma.get(type_id)
         if dogma_def is not None:

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -6,6 +6,7 @@ import "package:eve_fit_assistant/data/proto/types.pb.dart" as pb_types;
 import "package:eve_fit_assistant/pages/item-detail/page.dart";
 import "package:eve_fit_assistant/storage/bundle/service/collection.dart";
 import "package:eve_fit_assistant/utils/context.dart";
+import "package:eve_fit_assistant/utils/skill.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
@@ -56,7 +57,7 @@ class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
               return _SkillListTile(
                 skill: skill,
                 level: widget.skills[skill.typeId] ?? 0,
-                alphaMaxLevel: skill.hasAlphaMaxLevel() ? skill.alphaMaxLevel : null,
+                alphaMaxLevel: skill.alphaCloneMaxLevel,
                 onTapLevel: widget.onTapLevel == null
                     ? null
                     : (level) => widget.onTapLevel!(skill.typeId, level),

--- a/lib/pages/item-detail/page.dart
+++ b/lib/pages/item-detail/page.dart
@@ -22,6 +22,7 @@ import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/storage/fit/service.dart";
 import "package:eve_fit_assistant/utils/context.dart";
 import "package:eve_fit_assistant/utils/screen.dart";
+import "package:eve_fit_assistant/utils/skill.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -1282,9 +1283,7 @@ class _SkillTreeNodeState extends ConsumerState<_SkillTreeNode> {
                   const SizedBox(width: 12),
                   _LevelPips(
                     level: widget.requirement.level,
-                    alphaMaxLevel: skillType?.hasAlphaMaxLevel() ?? false
-                        ? skillType!.alphaMaxLevel
-                        : null,
+                    alphaMaxLevel: skillType?.alphaCloneMaxLevel,
                   ),
                 ],
               ),

--- a/lib/storage/character/manager.dart
+++ b/lib/storage/character/manager.dart
@@ -8,6 +8,7 @@ import "package:eve_fit_assistant/storage/bundle/service.dart";
 import "package:eve_fit_assistant/storage/bundle/service/collection.dart";
 import "package:eve_fit_assistant/storage/character/schema.dart";
 import "package:eve_fit_assistant/utils/riverpod.dart";
+import "package:eve_fit_assistant/utils/skill.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 import "package:path/path.dart" as p;
@@ -174,7 +175,7 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
     final skillTypeIdSet = skillTypeIds.toSet();
     return <int, int>{
       for (final type in collection.allTypes)
-        if (skillTypeIdSet.contains(type.typeId)) type.typeId: type.alphaMaxLevel,
+        if (skillTypeIdSet.contains(type.typeId)) type.typeId: type.alphaCloneMaxLevel,
     }.lock;
   }
 

--- a/lib/utils/skill.dart
+++ b/lib/utils/skill.dart
@@ -1,0 +1,5 @@
+import "package:eve_fit_assistant/data/proto/types.pb.dart" as pb_types;
+
+extension SkillTypeAlphaCloneLevel on pb_types.Type {
+  int get alphaCloneMaxLevel => hasAlphaMaxLevel() ? alphaMaxLevel : 0;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected alpha clone skill level limitations by filtering skills based on category, ensuring maximum level indicators display accurately across skill lists and item detail views.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Embers-of-the-Fire/eve-fit-assistant/pull/76)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->