### PR TITLE
feat: restyle skill group selector and editor layout

### DIFF
--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -243,7 +243,7 @@ class _SkillListTile extends StatelessWidget {
 class _SkillLevelIndicator extends StatelessWidget {
   const _SkillLevelIndicator({required this.level, this.alphaMaxLevel, this.onTapLevel});
 
-  static const double _hitTargetSize = 32;
+  static const double _hitTargetSize = 48;
   static const double _pipSize = 16;
 
   final int level;

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -187,6 +187,7 @@ class _SkillGroupCard extends StatelessWidget {
       onTap: onTap,
       borderRadius: BorderRadius.circular(8),
       child: Container(
+        constraints: const BoxConstraints(minHeight: kMinInteractiveDimension),
         padding: const EdgeInsets.symmetric(vertical: 4),
         decoration: BoxDecoration(
           border: Border.all(
@@ -221,14 +222,21 @@ class _SkillListTile extends StatelessWidget {
   Widget build(BuildContext context) => InkWell(
     onTap: () => showItemDetailPage(context, typeId: skill.typeId),
     onLongPress: () => showItemDetailPage(context, typeId: skill.typeId),
-    child: Padding(
-      padding: const EdgeInsets.only(top: 5, bottom: 5, left: 25, right: 10),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Expanded(child: TypeNameText(typeId: skill.typeId)),
-          _SkillLevelIndicator(level: level, alphaMaxLevel: alphaMaxLevel, onTapLevel: onTapLevel),
-        ],
+    child: ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: kMinInteractiveDimension),
+      child: Padding(
+        padding: const EdgeInsets.only(top: 5, bottom: 5, left: 25, right: 10),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Expanded(child: TypeNameText(typeId: skill.typeId)),
+            _SkillLevelIndicator(
+              level: level,
+              alphaMaxLevel: alphaMaxLevel,
+              onTapLevel: onTapLevel,
+            ),
+          ],
+        ),
       ),
     ),
   );
@@ -237,7 +245,7 @@ class _SkillListTile extends StatelessWidget {
 class _SkillLevelIndicator extends StatelessWidget {
   const _SkillLevelIndicator({required this.level, this.alphaMaxLevel, this.onTapLevel});
 
-  static const double _hitTargetSize = 48;
+  static const double _hitTargetSize = kMinInteractiveDimension;
   static const double _pipSize = 16;
 
   final int level;

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -212,22 +212,26 @@ class _SkillListTile extends StatelessWidget {
   final ValueChanged<int>? onTapLevel;
 
   @override
-  Widget build(BuildContext context) => ListTile(
-    title: TypeNameText(typeId: skill.typeId),
-    trailing: _SkillLevelIndicator(
-      level: level,
-      alphaMaxLevel: alphaMaxLevel,
-      onTapLevel: onTapLevel,
-    ),
+  Widget build(BuildContext context) => InkWell(
     onLongPress: () => showItemDetailPage(context, typeId: skill.typeId),
+    child: Padding(
+      padding: const EdgeInsets.only(top: 5, bottom: 5, left: 25, right: 10),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(child: TypeNameText(typeId: skill.typeId)),
+          _SkillLevelIndicator(level: level, alphaMaxLevel: alphaMaxLevel, onTapLevel: onTapLevel),
+        ],
+      ),
+    ),
   );
 }
 
 class _SkillLevelIndicator extends StatelessWidget {
   const _SkillLevelIndicator({required this.level, this.alphaMaxLevel, this.onTapLevel});
 
-  static const double _hitTargetSize = 44;
-  static const double _pipSize = 18;
+  static const double _hitTargetSize = 32;
+  static const double _pipSize = 16;
 
   final int level;
   final int? alphaMaxLevel;
@@ -239,22 +243,18 @@ class _SkillLevelIndicator extends StatelessWidget {
     spacing: 6,
     children: List.generate(5, (index) {
       final skillLevel = index + 1;
-      final trained = skillLevel <= level;
       final unavailableToAlpha = alphaMaxLevel != null && skillLevel > alphaMaxLevel!;
       final color = unavailableToAlpha
           ? colorSkillAlphaLimited
           : Theme.of(context).colorScheme.primary;
-      final borderColor = trained || unavailableToAlpha
-          ? color
-          : Theme.of(context).colorScheme.outline;
+      final trained = skillLevel <= level;
       final pip = AnimatedContainer(
         duration: const Duration(milliseconds: 120),
         width: _pipSize,
         height: _pipSize,
         decoration: BoxDecoration(
           color: trained ? color : Colors.transparent,
-          border: Border.all(color: borderColor),
-          borderRadius: BorderRadius.circular(4),
+          border: trained ? null : Border.all(color: color),
         ),
       );
 

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -1,3 +1,5 @@
+import "dart:math" as math;
+
 import "package:eve_fit_assistant/components/list/eve_list_tile.dart";
 import "package:eve_fit_assistant/constant/colors.dart";
 import "package:eve_fit_assistant/constant/eve.dart";
@@ -151,8 +153,13 @@ class _SkillGroupGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) => LayoutBuilder(
     builder: (context, constraints) {
-      const columnCount = 4;
+      const minTileWidth = 88.0;
+      const maxColumnCount = 6;
       const spacing = 8.0;
+      final columnCount = math.max(
+        1,
+        math.min(maxColumnCount, constraints.maxWidth ~/ minTileWidth),
+      );
       final tileWidth = (constraints.maxWidth - spacing * (columnCount - 1)) / columnCount;
       return Wrap(
         spacing: spacing,

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -22,6 +22,10 @@ class CharacterSkillList extends ConsumerStatefulWidget {
 
 class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
     with AutomaticKeepAliveClientMixin {
+  static const double _filterHeaderHeight = 60;
+
+  final ExpansibleController _controller = ExpansibleController();
+
   int? _selectedGroupId;
 
   @override
@@ -40,30 +44,41 @@ class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
       return _selectedGroupId == null || type.groupId == _selectedGroupId;
     }).toList()..sort((left, right) => left.typeId.compareTo(right.typeId));
 
-    return Column(
+    return Stack(
       children: [
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: _controller.collapse,
+          child: Column(
+            children: [
+              const SizedBox(height: _filterHeaderHeight),
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.only(right: 10),
+                  itemCount: skills.length,
+                  itemBuilder: (context, index) {
+                    final skill = skills[index];
+                    return _SkillListTile(
+                      skill: skill,
+                      level: widget.skills[skill.typeId] ?? 0,
+                      alphaMaxLevel: skill.alphaCloneMaxLevel,
+                      onTapLevel: widget.onTapLevel == null
+                          ? null
+                          : (level) => widget.onTapLevel!(skill.typeId, level),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
         _SkillGroupFilter(
+          controller: _controller,
           groups: groups,
           selectedGroupId: _selectedGroupId,
           onSelect: (groupId) => setState(() {
             _selectedGroupId = groupId == _selectedGroupId ? null : groupId;
           }),
-        ),
-        Expanded(
-          child: ListView.builder(
-            itemCount: skills.length,
-            itemBuilder: (context, index) {
-              final skill = skills[index];
-              return _SkillListTile(
-                skill: skill,
-                level: widget.skills[skill.typeId] ?? 0,
-                alphaMaxLevel: skill.alphaCloneMaxLevel,
-                onTapLevel: widget.onTapLevel == null
-                    ? null
-                    : (level) => widget.onTapLevel!(skill.typeId, level),
-              );
-            },
-          ),
         ),
       ],
     );
@@ -75,6 +90,49 @@ class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
 
 class _SkillGroupFilter extends StatelessWidget {
   const _SkillGroupFilter({
+    required this.controller,
+    required this.groups,
+    required this.selectedGroupId,
+    required this.onSelect,
+  });
+
+  final ExpansibleController controller;
+  final List<pb_groups.Group> groups;
+  final int? selectedGroupId;
+  final ValueChanged<int> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).scaffoldBackgroundColor;
+    final shape = Border(bottom: BorderSide(color: Theme.of(context).dividerColor));
+    return ExpansionTile(
+      controller: controller,
+      backgroundColor: color,
+      collapsedBackgroundColor: color,
+      title: selectedGroupId == null
+          ? Text(context.l10n.characterSkillAllGroups)
+          : GroupNameText(groupId: selectedGroupId!),
+      shape: shape,
+      collapsedShape: shape,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+          child: _SkillGroupGrid(
+            groups: groups,
+            selectedGroupId: selectedGroupId,
+            onSelect: (groupId) {
+              controller.collapse();
+              onSelect(groupId);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SkillGroupGrid extends StatelessWidget {
+  const _SkillGroupGrid({
     required this.groups,
     required this.selectedGroupId,
     required this.onSelect,
@@ -85,28 +143,58 @@ class _SkillGroupFilter extends StatelessWidget {
   final ValueChanged<int> onSelect;
 
   @override
-  Widget build(BuildContext context) => ExpansionTile(
-    title: selectedGroupId == null
-        ? Text(context.l10n.characterSkillAllGroups)
-        : GroupNameText(groupId: selectedGroupId!),
-    childrenPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-    children: [
-      Align(
-        alignment: Alignment.centerLeft,
-        child: Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            for (final group in groups)
-              ChoiceChip(
+  Widget build(BuildContext context) => LayoutBuilder(
+    builder: (context, constraints) {
+      const columnCount = 4;
+      const spacing = 8.0;
+      final tileWidth = (constraints.maxWidth - spacing * (columnCount - 1)) / columnCount;
+      return Wrap(
+        spacing: spacing,
+        runSpacing: spacing,
+        children: [
+          for (final group in groups)
+            SizedBox(
+              width: tileWidth,
+              child: _SkillGroupCard(
+                groupId: group.groupId,
                 selected: group.groupId == selectedGroupId,
-                label: GroupNameText(groupId: group.groupId),
-                onSelected: (_) => onSelect(group.groupId),
+                onTap: () => onSelect(group.groupId),
               ),
-          ],
+            ),
+        ],
+      );
+    },
+  );
+}
+
+class _SkillGroupCard extends StatelessWidget {
+  const _SkillGroupCard({required this.groupId, required this.selected, this.onTap});
+
+  final int groupId;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    margin: EdgeInsets.symmetric(horizontal: selected ? 3 : 4, vertical: selected ? 3 : 4),
+    child: InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: selected
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).dividerColor,
+            width: selected ? 2 : 1,
+          ),
+          borderRadius: BorderRadius.circular(8),
         ),
+        alignment: Alignment.center,
+        child: Center(child: GroupNameText(groupId: groupId)),
       ),
-    ],
+    ),
   );
 }
 

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -24,8 +24,6 @@ class CharacterSkillList extends ConsumerStatefulWidget {
 
 class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
     with AutomaticKeepAliveClientMixin {
-  static const double _filterHeaderHeight = 60;
-
   final ExpansibleController _controller = ExpansibleController();
 
   int? _selectedGroupId;
@@ -52,34 +50,8 @@ class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
       return _selectedGroupId == null || type.groupId == _selectedGroupId;
     }).toList()..sort((left, right) => left.typeId.compareTo(right.typeId));
 
-    return Stack(
+    return Column(
       children: [
-        GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: _controller.collapse,
-          child: Column(
-            children: [
-              const SizedBox(height: _filterHeaderHeight),
-              Expanded(
-                child: ListView.builder(
-                  padding: const EdgeInsets.only(right: 10),
-                  itemCount: skills.length,
-                  itemBuilder: (context, index) {
-                    final skill = skills[index];
-                    return _SkillListTile(
-                      skill: skill,
-                      level: widget.skills[skill.typeId] ?? 0,
-                      alphaMaxLevel: skill.alphaCloneMaxLevel,
-                      onTapLevel: widget.onTapLevel == null
-                          ? null
-                          : (level) => widget.onTapLevel!(skill.typeId, level),
-                    );
-                  },
-                ),
-              ),
-            ],
-          ),
-        ),
         _SkillGroupFilter(
           controller: _controller,
           groups: groups,
@@ -87,6 +59,27 @@ class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
           onSelect: (groupId) => setState(() {
             _selectedGroupId = groupId == _selectedGroupId ? null : groupId;
           }),
+        ),
+        Expanded(
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: _controller.collapse,
+            child: ListView.builder(
+              padding: const EdgeInsets.only(right: 10),
+              itemCount: skills.length,
+              itemBuilder: (context, index) {
+                final skill = skills[index];
+                return _SkillListTile(
+                  skill: skill,
+                  level: widget.skills[skill.typeId] ?? 0,
+                  alphaMaxLevel: skill.alphaCloneMaxLevel,
+                  onTapLevel: widget.onTapLevel == null
+                      ? null
+                      : (level) => widget.onTapLevel!(skill.typeId, level),
+                );
+              },
+            ),
+          ),
         ),
       ],
     );

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -226,6 +226,7 @@ class _SkillListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => InkWell(
+    onTap: () => showItemDetailPage(context, typeId: skill.typeId),
     onLongPress: () => showItemDetailPage(context, typeId: skill.typeId),
     child: Padding(
       padding: const EdgeInsets.only(top: 5, bottom: 5, left: 25, right: 10),

--- a/lib/pages/character/skill_list.dart
+++ b/lib/pages/character/skill_list.dart
@@ -32,6 +32,12 @@ class _CharacterSkillListState extends ConsumerState<CharacterSkillList>
   bool get wantKeepAlive => true;
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     super.build(context);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned skill list header with expandable/collapsible filter and tap-to-collapse behavior for faster navigation
  * Reworked group filter into a responsive, card-style grid with clearer selection affordances and smoother expansion behavior
  * Updated skill rows to touch-friendly, padded cards with refined spacing, borders, and rounded styling
  * Improved skill-level indicators with adjusted sizing and filled/outlined pip visuals reflecting training level

* **Bug Fixes**
  * Skill entries now open detail view on both tap and long-press for more consistent navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Embers-of-the-Fire/eve-fit-assistant/pull/77)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->