### PR TITLE
fix(repo-cache): harden ETag cache persistence and 304 handling

### DIFF
--- a/lib/features/remote_content/etag_cache.dart
+++ b/lib/features/remote_content/etag_cache.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 import "dart:io";
 
@@ -8,24 +9,43 @@ import "package:path/path.dart" as p;
 ///
 /// Enables conditional requests (If-None-Match / If-Modified-Since)
 /// to avoid re-downloading unchanged remote content.
+///
+/// Persistence is debounced and crash-safe: in-memory mutations schedule a
+/// single coalesced write, which lands on disk via an atomic `tmp → rename`
+/// so the cache file is never observed truncated or partially written.
 class EtagCache {
   EtagCache._();
 
   static const String _fileName = "etag_cache.json";
+  static const Duration _debounce = Duration(milliseconds: 200);
+
   static late Map<String, _EtagEntry> _entries;
-  static Future<void> _pendingSync = Future<void>.value();
+  static bool _initialized = false;
+  static Timer? _debounceTimer;
+  static bool _dirty = false;
 
   static File get _file => File(p.join(PathProvider.settingsPath, _fileName));
 
+  /// Loads the cache from disk. Idempotent: repeated calls do not overwrite
+  /// the in-memory state.
   static void init() {
+    if (_initialized) return;
     _entries = _readFromDisk();
+    _initialized = true;
   }
 
-  static String? getEtag(Uri uri) => _entries[uri.toString()]?.etag;
+  static String? getEtag(Uri uri) {
+    _ensureInit();
+    return _entries[uri.toString()]?.etag;
+  }
 
-  static String? getLastModified(Uri uri) => _entries[uri.toString()]?.lastModified;
+  static String? getLastModified(Uri uri) {
+    _ensureInit();
+    return _entries[uri.toString()]?.lastModified;
+  }
 
   static void update(Uri uri, {String? etag, String? lastModified}) {
+    _ensureInit();
     final key = uri.toString();
     final existing = _entries[key];
     if (existing != null &&
@@ -37,18 +57,36 @@ class EtagCache {
       etag: etag ?? existing?.etag,
       lastModified: lastModified ?? existing?.lastModified,
     );
-    _sync();
+    _scheduleSync();
   }
 
   static void remove(Uri uri) {
+    _ensureInit();
     if (_entries.remove(uri.toString()) != null) {
-      _sync();
+      _scheduleSync();
     }
   }
 
   static void clearAll() {
+    _ensureInit();
     _entries.clear();
-    _sync();
+    _scheduleSync();
+  }
+
+  /// Forces any pending write to disk immediately and waits for it to complete.
+  ///
+  /// Callers that need to guarantee persistence (e.g. on app lifecycle pause)
+  /// should await this.
+  static Future<void> flush() async {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    await _flushNow();
+  }
+
+  static void _ensureInit() {
+    if (!_initialized) {
+      throw StateError("EtagCache not initialized. Call EtagCache.init() first.");
+    }
   }
 
   static Map<String, _EtagEntry> _readFromDisk() {
@@ -77,19 +115,46 @@ class EtagCache {
     }
   }
 
-  static void _sync() {
+  /// Marks the cache dirty and (re)arms the debounce timer. Rapid successive
+  /// mutations coalesce into a single write.
+  static void _scheduleSync() {
+    _dirty = true;
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(_debounce, () {
+      _debounceTimer = null;
+      unawaited(_flushNow());
+    });
+  }
+
+  static Future<void> _flushNow() async {
+    if (!_dirty) return;
+    _dirty = false;
+
+    final text = _serializeEntries();
     final filePath = _file.path;
+    final file = File(filePath);
+    final tmp = File("$filePath.tmp");
+
+    try {
+      if (!file.parent.existsSync()) {
+        file.parent.createSync(recursive: true);
+      }
+      // Atomic write: write fully to a sibling temp, then rename over the
+      // target. A crash before the rename leaves the previous (valid) file
+      // intact; the orphaned temp is harmless.
+      await tmp.writeAsString(text, flush: true);
+      await tmp.rename(filePath);
+    } on FileSystemException {
+      // Best-effort persistence: mark dirty again so a later mutation retries.
+      _dirty = true;
+    }
+  }
+
+  static String _serializeEntries() {
     final entries = Map<String, Map<String, dynamic>>.fromEntries(
       _entries.entries.map((e) => MapEntry<String, Map<String, dynamic>>(e.key, e.value.toJson())),
     );
-    final text = jsonEncode(entries);
-    _pendingSync = _pendingSync.catchError((Object _, StackTrace _) {}).then((_) async {
-      final file = File(filePath);
-      if (!file.existsSync()) {
-        file.createSync(recursive: true);
-      }
-      await file.writeAsString(text);
-    });
+    return jsonEncode(entries);
   }
 }
 

--- a/lib/features/remote_content/etag_cache.dart
+++ b/lib/features/remote_content/etag_cache.dart
@@ -126,27 +126,50 @@ class EtagCache {
     });
   }
 
+  static Future<void>? _pendingFlush;
+
+  /// Serializes flush execution so overlapping calls (timer + explicit
+  /// [flush]) never perform concurrent I/O. The write loop re-checks
+  /// [_dirty] after every pass so mutations that arrive during I/O are
+  /// captured before returning.
   static Future<void> _flushNow() async {
-    if (!_dirty) return;
-    _dirty = false;
-
-    final text = _serializeEntries();
-    final filePath = _file.path;
-    final file = File(filePath);
-    final tmp = File("$filePath.tmp");
-
-    try {
-      if (!file.parent.existsSync()) {
-        file.parent.createSync(recursive: true);
+    if (_pendingFlush != null) {
+      await _pendingFlush;
+      if (_dirty) {
+        await _flushNow();
       }
-      // Atomic write: write fully to a sibling temp, then rename over the
-      // target. A crash before the rename leaves the previous (valid) file
-      // intact; the orphaned temp is harmless.
-      await tmp.writeAsString(text, flush: true);
-      await tmp.rename(filePath);
-    } on FileSystemException {
-      // Best-effort persistence: mark dirty again so a later mutation retries.
-      _dirty = true;
+      return;
+    }
+    _pendingFlush = _writeLoop();
+    await _pendingFlush;
+    _pendingFlush = null;
+    if (_dirty) {
+      await _flushNow();
+    }
+  }
+
+  /// Repeatedly persists to disk while dirty.  Because only one instance
+  /// runs at a time (guarded by [_pendingFlush]), the final rename always
+  /// carries the newest available state.
+  static Future<void> _writeLoop() async {
+    while (_dirty) {
+      _dirty = false;
+
+      final text = _serializeEntries();
+      final filePath = _file.path;
+      final file = File(filePath);
+      final tmp = File("$filePath.tmp");
+
+      try {
+        if (!file.parent.existsSync()) {
+          file.parent.createSync(recursive: true);
+        }
+        await tmp.writeAsString(text, flush: true);
+        await tmp.rename(filePath);
+      } on FileSystemException {
+        _dirty = true;
+        return;
+      }
     }
   }
 

--- a/lib/features/remote_content/http.dart
+++ b/lib/features/remote_content/http.dart
@@ -63,13 +63,20 @@ Future<Map<String, dynamic>> fetchRemoteJson(
 /// `If-None-Match` and `If-Modified-Since` respectively.  When the server
 /// responds with HTTP 304, [ConditionalFetchResult.notModified] is true.
 /// Otherwise the response headers are used to update the [EtagCache].
+///
+/// Set [sendConditionalHeaders] to `false` for content-addressed URLs (e.g.
+/// blobs keyed by content hash), where the response can only ever be the exact
+/// requested bytes or a 404. Conditional headers add overhead with no benefit
+/// for such URLs, and caching their ETags only wastes memory; when disabled,
+/// no ETag lookup is performed and the response is not recorded in the cache.
 Future<ConditionalFetchResult<T>> getRemoteUri<T>(
   Dio dio,
   Uri uri, {
   ResponseType responseType = ResponseType.plain,
+  bool sendConditionalHeaders = true,
 }) async {
-  final cachedEtag = EtagCache.getEtag(uri);
-  final cachedLastModified = EtagCache.getLastModified(uri);
+  final cachedEtag = sendConditionalHeaders ? EtagCache.getEtag(uri) : null;
+  final cachedLastModified = sendConditionalHeaders ? EtagCache.getLastModified(uri) : null;
 
   try {
     final response = await dio.getUri<T>(
@@ -79,7 +86,9 @@ Future<ConditionalFetchResult<T>> getRemoteUri<T>(
         headers: _conditionalHeaders(cachedEtag, cachedLastModified),
       ),
     );
-    _updateCacheFromResponse(uri, response);
+    if (sendConditionalHeaders) {
+      _updateCacheFromResponse(uri, response);
+    }
     return ConditionalFetchResult<T>.modified(response);
   } on DioException catch (exception) {
     if (exception.response?.statusCode == 304) {

--- a/lib/storage/repo/assets.dart
+++ b/lib/storage/repo/assets.dart
@@ -10,6 +10,8 @@ import "package:eve_fit_assistant/storage/repo/paths.dart";
 import "package:eve_fit_assistant/storage/repo/utils.dart";
 import "package:eve_fit_assistant/utils/canonical_json.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:file/file.dart" hide Directory, File, FileSystemEntity;
+import "package:file/local.dart";
 import "package:fpdart/fpdart.dart";
 import "package:path/path.dart" as p;
 
@@ -18,7 +20,13 @@ import "package:path/path.dart" as p;
 /// Blobs are stored at `assets/blobs/{2c}/{ident_hash}/{content_hash}`
 /// and resource snapshots at `assets/resources/{snapshot_hash}/`.
 class AssetStore {
-  const AssetStore();
+  const AssetStore() : _fs = null;
+
+  AssetStore.forTest(this._fs);
+
+  final FileSystem? _fs;
+
+  FileSystem get _fileSystem => _fs ?? const LocalFileSystem();
 
   /// Writes a blob identified by [identHash] and [content] to the asset store.
   ///
@@ -256,30 +264,38 @@ class AssetStore {
   ///
   /// Best-effort and idempotent; intended to run once at startup.
   void recoverSync() {
-    final assetsDir = Directory(RepoPaths.assetsPath);
+    final assetsDir = _fileSystem.directory(RepoPaths.assetsPath);
     if (!assetsDir.existsSync()) return;
 
     // Clean orphaned `.tmp` files created by atomic write patterns.
-    for (final entity in assetsDir.listSync(recursive: true)) {
-      if (entity is File && entity.path.endsWith(".tmp")) {
-        try {
-          entity.deleteSync();
-        } on FileSystemException {
-          // best-effort
+    try {
+      for (final entity in assetsDir.listSync(recursive: true, followLinks: false)) {
+        if (entity is File && entity.path.endsWith(".tmp")) {
+          try {
+            entity.deleteSync();
+          } on FileSystemException {
+            // best-effort
+          }
         }
       }
+    } on FileSystemException {
+      // best-effort
     }
 
     // Clean orphaned temporary working directories.
-    for (final dir in assetsDir.listSync().whereType<Directory>()) {
-      final name = p.basename(dir.path);
-      if (name.startsWith("tmp_") || name.endsWith("_temp")) {
-        try {
-          dir.deleteSync(recursive: true);
-        } on FileSystemException {
-          // best-effort
+    try {
+      for (final dir in assetsDir.listSync(followLinks: false).whereType<Directory>()) {
+        final name = p.basename(dir.path);
+        if (name.startsWith("tmp_") || name.endsWith("_temp")) {
+          try {
+            dir.deleteSync(recursive: true);
+          } on FileSystemException {
+            // best-effort
+          }
         }
       }
+    } on FileSystemException {
+      // best-effort
     }
   }
 

--- a/lib/storage/repo/assets.dart
+++ b/lib/storage/repo/assets.dart
@@ -245,6 +245,44 @@ class AssetStore {
     return deleted;
   }
 
+  // ── Recovery ─────────────────────────────────────────────────────────────
+
+  /// Cleans up orphaned temporary artifacts left behind by interrupted atomic
+  /// writes.
+  ///
+  /// Atomic writes use a `tmp → rename` pattern; a crash between the temp write
+  /// and the rename leaves a `.tmp` file (e.g. `blob.tmp`) on disk. This also
+  /// removes orphaned `tmp_*` / `*_temp` working directories.
+  ///
+  /// Best-effort and idempotent; intended to run once at startup.
+  void recoverSync() {
+    final assetsDir = Directory(RepoPaths.assetsPath);
+    if (!assetsDir.existsSync()) return;
+
+    // Clean orphaned `.tmp` files created by atomic write patterns.
+    for (final entity in assetsDir.listSync(recursive: true)) {
+      if (entity is File && entity.path.endsWith(".tmp")) {
+        try {
+          entity.deleteSync();
+        } on FileSystemException {
+          // best-effort
+        }
+      }
+    }
+
+    // Clean orphaned temporary working directories.
+    for (final dir in assetsDir.listSync().whereType<Directory>()) {
+      final name = p.basename(dir.path);
+      if (name.startsWith("tmp_") || name.endsWith("_temp")) {
+        try {
+          dir.deleteSync(recursive: true);
+        } on FileSystemException {
+          // best-effort
+        }
+      }
+    }
+  }
+
   // ── Private helpers ────────────────────────────────────────────────────────
 
   ({String identHash, String contentHash}) _writeBlobAtPath(

--- a/lib/storage/repo/channel_service.dart
+++ b/lib/storage/repo/channel_service.dart
@@ -29,7 +29,10 @@ class ChannelService {
   ///
   /// On first launch, uses defaultChannel from the remote.
   Future<Either<String, ChannelRegistry>> discoverChannels() async {
-    final result = await remoteCatalogService.fetchChannelRegistry();
+    final localReg = readLocalChannelRegistry();
+    final result = await remoteCatalogService.fetchChannelRegistry(
+      cachedPayload: localReg.isSome() ? localReg.toNullable()!.toJson() : null,
+    );
     if (result.isLeft()) {
       final err = result.getLeft().toNullable()!;
       return Left(err is CatalogNetworkError ? err.message : "Failed to fetch channels");
@@ -45,7 +48,11 @@ class ChannelService {
   /// Fetches and persists channel head metadata and server index for [channelName].
   Future<Either<String, Unit>> fetchChannelInfo(String channelName) async {
     // Fetch head metadata
-    final headResult = await remoteCatalogService.fetchHeadMeta(channelName);
+    final localHead = readHeadMeta(channelName);
+    final headResult = await remoteCatalogService.fetchHeadMeta(
+      channelName,
+      cachedPayload: localHead.isSome() ? localHead.toNullable()!.toJson() : null,
+    );
     if (headResult.isLeft()) {
       final err = headResult.getLeft().toNullable()!;
       if (err is CatalogNotFoundError) {
@@ -80,7 +87,11 @@ class ChannelService {
   /// - channels/{channel}/releases.pb2    — GenerationPointer (releases)
   Future<Either<String, Unit>> syncChannelGeneration(String channelName) async {
     // Fetch head metadata to get the generation hash
-    final headResult = await remoteCatalogService.fetchHeadMeta(channelName);
+    final localHead = readHeadMeta(channelName);
+    final headResult = await remoteCatalogService.fetchHeadMeta(
+      channelName,
+      cachedPayload: localHead.isSome() ? localHead.toNullable()!.toJson() : null,
+    );
     if (headResult.isLeft()) {
       final err = headResult.getLeft().toNullable()!;
       if (err is CatalogNotFoundError) {
@@ -224,7 +235,11 @@ class ChannelService {
     final localHash = localGenerationHash(channelName);
     if (localHash == null) return true; // No local state → needs fetch
 
-    final headResult = await remoteCatalogService.fetchHeadMeta(channelName);
+    final localHead = readHeadMeta(channelName);
+    final headResult = await remoteCatalogService.fetchHeadMeta(
+      channelName,
+      cachedPayload: localHead.isSome() ? localHead.toNullable()!.toJson() : null,
+    );
     if (headResult.isLeft()) return false;
 
     return headResult.getRight().toNullable()!.generationHash != localHash;

--- a/lib/storage/repo/checkout_service.dart
+++ b/lib/storage/repo/checkout_service.dart
@@ -289,6 +289,7 @@ class CheckoutService {
           assetStore.writeBlobSync(ihash, retry.getRight().toNullable()!);
         } else {
           warning("Failed to fetch blob $ihash/${dl.contentHash} after retry");
+          return const None();
         }
       } else {
         warning("Failed to fetch blob $ihash/${dl.contentHash}");

--- a/lib/storage/repo/checkout_service.dart
+++ b/lib/storage/repo/checkout_service.dart
@@ -8,6 +8,7 @@ import "package:eve_fit_assistant/data/proto/generation_resources.pb.dart";
 import "package:eve_fit_assistant/data/proto/resource_index.pb.dart";
 import "package:eve_fit_assistant/data/proto/server_index.pb.dart";
 import "package:eve_fit_assistant/features/remote_content/channel.dart";
+import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
 import "package:eve_fit_assistant/storage/repo/assets.dart";
 import "package:eve_fit_assistant/storage/repo/checkout_registry_service.dart";
 import "package:eve_fit_assistant/storage/repo/diff.dart";
@@ -194,8 +195,12 @@ class CheckoutService {
 
     final m = meta.toNullable()!;
 
-    // Step 1: Check remote head for update
-    final headResult = await remoteCatalogService.fetchHeadMeta(channelName);
+    // Step 1: Check remote head for update. Supply the locally cached head
+    // metadata so a 304 short-circuits to it instead of forcing a re-fetch.
+    final headResult = await remoteCatalogService.fetchHeadMeta(
+      channelName,
+      cachedPayload: _readLocalHeadMetaJson(channelName),
+    );
     if (headResult.isLeft()) return const None();
     final remoteHead = headResult.getRight().toNullable()!;
 
@@ -274,6 +279,17 @@ class CheckoutService {
       final blobResult = await remoteCatalogService.fetchBlob(ihash, dl.contentHash);
       if (blobResult.isRight()) {
         assetStore.writeBlobSync(ihash, blobResult.getRight().toNullable()!);
+      } else if (blobResult.getLeft().toNullable()! is CatalogNotModified) {
+        // A 304 for a blob we don't have locally means the cached ETag is
+        // stale. Clear it and retry once unconditionally so the checkout is
+        // not left with missing data.
+        EtagCache.remove(remoteCatalogService.blobUri(ihash, dl.contentHash));
+        final retry = await remoteCatalogService.fetchBlob(ihash, dl.contentHash);
+        if (retry.isRight()) {
+          assetStore.writeBlobSync(ihash, retry.getRight().toNullable()!);
+        } else {
+          warning("Failed to fetch blob $ihash/${dl.contentHash} after retry");
+        }
       } else {
         warning("Failed to fetch blob $ihash/${dl.contentHash}");
       }
@@ -403,6 +419,20 @@ class CheckoutService {
     try {
       final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
       return json["generationHash"] as String?;
+    } on Exception {
+      return null;
+    }
+  }
+
+  /// Reads the raw local channel head metadata JSON for [channelName], or null.
+  ///
+  /// Used as the conditional-request fallback payload for `fetchHeadMeta`.
+  Map<String, dynamic>? _readLocalHeadMetaJson(String channelName) {
+    final file = File(RepoPaths.channelHeadMetaPath(channelName));
+    if (!file.existsSync()) return null;
+    try {
+      final json = jsonDecode(file.readAsStringSync());
+      return json is Map<String, dynamic> ? json : null;
     } on Exception {
       return null;
     }

--- a/lib/storage/repo/generation_nav.dart
+++ b/lib/storage/repo/generation_nav.dart
@@ -1,6 +1,10 @@
+import "dart:convert";
+import "dart:io";
+
 import "package:eve_fit_assistant/data/proto/server_index.pb.dart";
 import "package:eve_fit_assistant/features/remote_content/channel.dart";
 import "package:eve_fit_assistant/storage/repo/models/channel_registry.dart";
+import "package:eve_fit_assistant/storage/repo/paths.dart";
 import "package:eve_fit_assistant/storage/repo/remote_catalog.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:fpdart/fpdart.dart";
@@ -86,8 +90,12 @@ class GenerationNavigationService {
     required Channel channel,
     required String channelName,
   }) async {
-    // Get current generation hash
-    final headResult = await remoteCatalogService.fetchHeadMeta(channelName);
+    // Get current generation hash. Pass the locally cached head metadata so a
+    // 304 short-circuits to it instead of forcing a full re-fetch.
+    final headResult = await remoteCatalogService.fetchHeadMeta(
+      channelName,
+      cachedPayload: _readLocalHeadMetaJson(channelName),
+    );
     if (headResult.isLeft()) {
       return const Left(GenerationNavNetworkError(message: "Failed to fetch head metadata"));
     }
@@ -101,5 +109,19 @@ class GenerationNavigationService {
     final serverIndex = ServerIndex.fromBuffer(serverResult.getRight().toNullable()!);
 
     return Right(serverIndex.servers.map(ServerSummary.fromEntry).toIList());
+  }
+
+  /// Reads the raw local channel head metadata JSON for [channelName], or null.
+  ///
+  /// Used as the conditional-request fallback payload for `fetchHeadMeta`.
+  Map<String, dynamic>? _readLocalHeadMetaJson(String channelName) {
+    final file = File(RepoPaths.channelHeadMetaPath(channelName));
+    if (!file.existsSync()) return null;
+    try {
+      final json = jsonDecode(file.readAsStringSync());
+      return json is Map<String, dynamic> ? json : null;
+    } on Exception {
+      return null;
+    }
   }
 }

--- a/lib/storage/repo/providers.dart
+++ b/lib/storage/repo/providers.dart
@@ -165,7 +165,9 @@ class RepoStateNotifier extends _$RepoStateNotifier {
   Future<void> initialize() async {
     state = const RepoState.initializing();
     try {
-      final repo = ref.read(repoServiceProvider);
+      // Clean up orphaned temp files/dirs from interrupted writes before
+      // trusting the on-disk state.
+      final repo = ref.read(repoServiceProvider)..recoverPartialDownloads();
 
       final registryOpt = repo.checkoutRegistry.readRegistry();
       if (registryOpt.isSome()) {

--- a/lib/storage/repo/remote_catalog.dart
+++ b/lib/storage/repo/remote_catalog.dart
@@ -55,7 +55,9 @@ class RemoteCatalogService {
   ///
   /// Remote spec §7.3 uses `defaultChannel`, while the client model stores
   /// `active`. We map the key before parsing.
-  Future<Either<CatalogError, ChannelRegistry>> fetchChannelRegistry() async {
+  Future<Either<CatalogError, ChannelRegistry>> fetchChannelRegistry({
+    Map<String, dynamic>? cachedPayload,
+  }) async {
     final uri = _buildUri("channels/heads/channels.json");
     return _fetchJson(uri, (json) {
       final mapped = Map<String, dynamic>.from(json);
@@ -63,13 +65,16 @@ class RemoteCatalogService {
         mapped["active"] = mapped["defaultChannel"];
       }
       return ChannelRegistry.fromJson(mapped);
-    });
+    }, cachedPayload: cachedPayload);
   }
 
   /// GET `channels/heads/{channel}/metadata.json`
-  Future<Either<CatalogError, ChannelHeadMeta>> fetchHeadMeta(String channelName) async {
+  Future<Either<CatalogError, ChannelHeadMeta>> fetchHeadMeta(
+    String channelName, {
+    Map<String, dynamic>? cachedPayload,
+  }) async {
     final uri = _buildUri("channels/heads/$channelName/metadata.json");
-    return _fetchJson(uri, ChannelHeadMeta.fromJson);
+    return _fetchJson(uri, ChannelHeadMeta.fromJson, cachedPayload: cachedPayload);
   }
 
   // ── Generation fetch (§13.2) ───────────────────────────────────────────────
@@ -96,10 +101,11 @@ class RemoteCatalogService {
 
   /// GET `assets/resources/{snapshotHash}/metadata.json`
   Future<Either<CatalogError, ResourceSnapshotMeta>> fetchResourceSnapshotMeta(
-    String snapshotHash,
-  ) async {
+    String snapshotHash, {
+    Map<String, dynamic>? cachedPayload,
+  }) async {
     final uri = _buildUri("assets/resources/$snapshotHash/metadata.json");
-    return _fetchJson(uri, ResourceSnapshotMeta.fromJson);
+    return _fetchJson(uri, ResourceSnapshotMeta.fromJson, cachedPayload: cachedPayload);
   }
 
   /// GET `assets/resources/{snapshotHash}/resources.pb2`
@@ -119,20 +125,26 @@ class RemoteCatalogService {
   // ── Blob fetch ─────────────────────────────────────────────────────────────
 
   /// GET `assets/blobs/{2c}/{identHash}/{contentHash}`
-  Future<Either<CatalogError, Uint8List>> fetchBlob(String identHash, String contentHash) async {
+  Future<Either<CatalogError, Uint8List>> fetchBlob(String identHash, String contentHash) async =>
+      _fetchBytes(blobUri(identHash, contentHash));
+
+  /// The content-addressed URI for a blob.
+  ///
+  /// Exposed so callers can target the exact URL (e.g. to clear a stale ETag).
+  Uri blobUri(String identHash, String contentHash) {
     final prefix = identHash.substring(0, 2);
-    final uri = _buildUri("assets/blobs/$prefix/$identHash/$contentHash");
-    return _fetchBytes(uri);
+    return _buildUri("assets/blobs/$prefix/$identHash/$contentHash");
   }
 
   // ── Private helpers ────────────────────────────────────────────────────────
 
   Future<Either<CatalogError, T>> _fetchJson<T>(
     Uri uri,
-    T Function(Map<String, dynamic>) fromJson,
-  ) async {
+    T Function(Map<String, dynamic>) fromJson, {
+    Map<String, dynamic>? cachedPayload,
+  }) async {
     try {
-      final json = await remote_http.fetchRemoteJson(dio, uri);
+      final json = await remote_http.fetchRemoteJson(dio, uri, cachedPayload: cachedPayload);
       return Right(fromJson(json));
     } on DioException catch (e) {
       if (e.response?.statusCode == 404) {
@@ -150,10 +162,15 @@ class RemoteCatalogService {
 
   Future<Either<CatalogError, Uint8List>> _fetchBytes(Uri uri) async {
     try {
+      // All byte resources under `efa/v2/` are content-addressed (keyed by
+      // generation/snapshot/content hash), so conditional requests can never
+      // produce a useful 304 — the server returns the exact bytes or 404.
+      // Skip conditional headers to avoid wasting memory caching their ETags.
       final result = await remote_http.getRemoteUri<Uint8List>(
         dio,
         uri,
         responseType: ResponseType.bytes,
+        sendConditionalHeaders: false,
       );
       if (result.notModified) {
         return const Left(CatalogNotModified());

--- a/lib/storage/repo/service.dart
+++ b/lib/storage/repo/service.dart
@@ -1,6 +1,7 @@
 import "dart:io";
 
 import "package:eve_fit_assistant/features/remote_content/channel.dart";
+import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
 import "package:eve_fit_assistant/storage/repo/assets.dart";
 import "package:eve_fit_assistant/storage/repo/channel_service.dart";
 import "package:eve_fit_assistant/storage/repo/checkout_registry_service.dart";
@@ -168,6 +169,13 @@ class RepoService {
   /// Prunes unreferenced data.
   int prune() => verificationService.prune();
 
+  /// Recovers from interrupted writes by deleting orphaned temp files and
+  /// directories left behind by atomic-write patterns that crashed mid-rename.
+  ///
+  /// Best-effort and idempotent; intended to run once at startup before the
+  /// registry is read.
+  void recoverPartialDownloads() => assetStore.recoverSync();
+
   /// Verifies and repairs by re-downloading missing files.
   Future<IList<VerificationIssue>> verifyAndRepair({required Channel channel}) =>
       verificationService.repairAll(channel: channel);
@@ -192,6 +200,10 @@ class RepoService {
     if (failures.isNotEmpty) {
       return Left("Failed to delete: ${failures.join(", ")}");
     }
+    // Clear cached ETags: the assets they referenced are now gone, so any
+    // surviving ETag would cause conditional re-fetches to receive 304 with no
+    // local data to fall back on, breaking all subsequent downloads.
+    EtagCache.clearAll();
     return const Right(unit);
   }
 

--- a/lib/storage/repo/verification.dart
+++ b/lib/storage/repo/verification.dart
@@ -1,5 +1,6 @@
 import "package:eve_fit_assistant/data/proto/resource_index.pb.dart";
 import "package:eve_fit_assistant/features/remote_content/channel.dart";
+import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
 import "package:eve_fit_assistant/storage/repo/assets.dart";
 import "package:eve_fit_assistant/storage/repo/checkout_registry_service.dart";
 import "package:eve_fit_assistant/storage/repo/checkout_service.dart";
@@ -175,6 +176,16 @@ class VerificationService {
           final blobResult = await remoteCatalogService.fetchBlob(ihash, entry.contentHash);
           if (blobResult.isRight()) {
             assetStore.writeBlobSync(ihash, blobResult.getRight().toNullable()!);
+          } else if (blobResult.getLeft().toNullable()! is CatalogNotModified) {
+            // A 304 for a blob missing locally means the cached ETag is stale.
+            // Clear it and retry once unconditionally.
+            EtagCache.remove(remoteCatalogService.blobUri(ihash, entry.contentHash));
+            final retry = await remoteCatalogService.fetchBlob(ihash, entry.contentHash);
+            if (retry.isRight()) {
+              assetStore.writeBlobSync(ihash, retry.getRight().toNullable()!);
+            } else {
+              unresolved.add(issue);
+            }
           } else {
             unresolved.add(issue);
           }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -346,7 +346,7 @@ packages:
     source: hosted
     version: "2.2.0"
   file:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   date_format: ^2.0.9
   dio: ^5.9.1
   fast_immutable_collections: ^11.1.0
+  file: ^7.0.1
   file_picker: ^11.0.2
   flutter_breadcrumb: ^1.0.1
   flutter_easyloading: ^3.0.5

--- a/test/features/remote_content/etag_cache_guard_test.dart
+++ b/test/features/remote_content/etag_cache_guard_test.dart
@@ -1,0 +1,15 @@
+import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
+import "package:flutter_test/flutter_test.dart";
+
+void main() {
+  // This file's isolate never calls EtagCache.init(), so any access must throw
+  // a clear StateError instead of a LateInitializationError.
+  test("accessing EtagCache before init throws StateError", () {
+    final uri = Uri.parse("https://example.com/a");
+    expect(() => EtagCache.getEtag(uri), throwsStateError);
+    expect(() => EtagCache.getLastModified(uri), throwsStateError);
+    expect(() => EtagCache.update(uri, etag: '"e"'), throwsStateError);
+    expect(() => EtagCache.remove(uri), throwsStateError);
+    expect(EtagCache.clearAll, throwsStateError);
+  });
+}

--- a/test/features/remote_content/etag_cache_test.dart
+++ b/test/features/remote_content/etag_cache_test.dart
@@ -1,0 +1,100 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:eve_fit_assistant/config/logger.dart";
+import "package:eve_fit_assistant/config/paths.dart";
+import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:path/path.dart" as p;
+
+File _cacheFile() => File(p.join(PathProvider.settingsPath, "etag_cache.json"));
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() {
+    GlobalLogger.init(
+      Directory.systemTemp.createTempSync("efa_etag_log_").path,
+      enableDebugLog: false,
+    );
+  });
+
+  setUp(() async {
+    tempDir = Directory.systemTemp.createTempSync("efa_etag_test_");
+    PathProvider.documentsPath = tempDir.path;
+    EtagCache.init();
+    // Reset static in-memory state for isolation between tests.
+    EtagCache.clearAll();
+    await EtagCache.flush();
+    final f = _cacheFile();
+    if (f.existsSync()) f.deleteSync();
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test("update is reflected by getEtag/getLastModified", () {
+    final uri = Uri.parse("https://example.com/a");
+    EtagCache.update(uri, etag: '"e1"', lastModified: "lm1");
+    expect(EtagCache.getEtag(uri), '"e1"');
+    expect(EtagCache.getLastModified(uri), "lm1");
+  });
+
+  test("flush writes valid JSON atomically with no orphaned temp file", () async {
+    final uri = Uri.parse("https://example.com/a");
+    EtagCache.update(uri, etag: '"e1"', lastModified: "lm1");
+    await EtagCache.flush();
+
+    final f = _cacheFile();
+    expect(f.existsSync(), isTrue);
+    expect(File("${f.path}.tmp").existsSync(), isFalse, reason: "temp must be renamed away");
+
+    final decoded = jsonDecode(f.readAsStringSync());
+    expect(decoded, isA<Map<String, dynamic>>());
+    final entry = (decoded as Map<String, dynamic>)[uri.toString()] as Map<String, dynamic>;
+    expect(entry["etag"], '"e1"');
+    expect(entry["lastModified"], "lm1");
+  });
+
+  test("debounce coalesces rapid writes into a single deferred flush", () async {
+    final f = _cacheFile();
+    expect(f.existsSync(), isFalse);
+
+    for (var i = 0; i < 100; i++) {
+      EtagCache.update(Uri.parse("https://example.com/$i"), etag: '"e$i"');
+    }
+
+    // The debounce timer cannot fire while this synchronous loop holds the
+    // event loop, so no intermediate writes have hit disk yet.
+    expect(f.existsSync(), isFalse, reason: "rapid updates must not each write");
+
+    await EtagCache.flush();
+    expect(f.existsSync(), isTrue);
+    final decoded = jsonDecode(f.readAsStringSync()) as Map<String, dynamic>;
+    expect(decoded.length, 100);
+  });
+
+  test("clearAll empties memory and the persisted file", () async {
+    final uri = Uri.parse("https://example.com/a");
+    EtagCache.update(uri, etag: '"e1"');
+    await EtagCache.flush();
+
+    EtagCache.clearAll();
+    expect(EtagCache.getEtag(uri), isNull);
+
+    await EtagCache.flush();
+    final decoded = jsonDecode(_cacheFile().readAsStringSync()) as Map<String, dynamic>;
+    expect(decoded, isEmpty);
+  });
+
+  test("persisted entries are readable back from disk (restart survival)", () async {
+    final uri = Uri.parse("https://example.com/a");
+    EtagCache.update(uri, etag: '"persisted"');
+    await EtagCache.flush();
+
+    // Simulate a restart by reading the file directly, as init() would.
+    final decoded = jsonDecode(_cacheFile().readAsStringSync()) as Map<String, dynamic>;
+    expect((decoded[uri.toString()] as Map<String, dynamic>)["etag"], '"persisted"');
+  });
+}

--- a/test/features/remote_content/http_conditional_test.dart
+++ b/test/features/remote_content/http_conditional_test.dart
@@ -1,0 +1,115 @@
+import "dart:io";
+
+import "package:dio/dio.dart";
+import "package:eve_fit_assistant/config/logger.dart";
+import "package:eve_fit_assistant/config/paths.dart";
+import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
+import "package:eve_fit_assistant/features/remote_content/http.dart";
+import "package:flutter_test/flutter_test.dart";
+
+/// Records every request and returns a canned response.
+class _RecordingAdapter implements HttpClientAdapter {
+  _RecordingAdapter({this.status = 200, this.body = "{}", this.responseHeaders = const {}});
+
+  final int status;
+  final String body;
+  final Map<String, List<String>> responseHeaders;
+  final List<RequestOptions> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    return ResponseBody.fromString(body, status, headers: responseHeaders);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+String? _header(RequestOptions options, String name) {
+  for (final entry in options.headers.entries) {
+    if (entry.key.toLowerCase() == name.toLowerCase()) return entry.value?.toString();
+  }
+  return null;
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() {
+    GlobalLogger.init(
+      Directory.systemTemp.createTempSync("efa_http_log_").path,
+      enableDebugLog: false,
+    );
+  });
+
+  setUp(() async {
+    tempDir = Directory.systemTemp.createTempSync("efa_http_test_");
+    PathProvider.documentsPath = tempDir.path;
+    EtagCache.init();
+    EtagCache.clearAll();
+    await EtagCache.flush();
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  group("getRemoteUri sendConditionalHeaders", () {
+    test("false: no conditional header sent and cache not updated", () async {
+      final uri = Uri.parse("https://example.com/blob");
+      EtagCache.update(uri, etag: '"old"');
+
+      final adapter = _RecordingAdapter(
+        body: "payload",
+        responseHeaders: {
+          "etag": ['"new"'],
+        },
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+
+      final result = await getRemoteUri<String>(dio, uri, sendConditionalHeaders: false);
+
+      expect(result.notModified, isFalse);
+      expect(_header(adapter.requests.single, "If-None-Match"), isNull);
+      // Response ETag must NOT be recorded back into the cache.
+      expect(EtagCache.getEtag(uri), '"old"');
+    });
+
+    test("true (default): sends If-None-Match and records response ETag", () async {
+      final uri = Uri.parse("https://example.com/meta.json");
+      EtagCache.update(uri, etag: '"old"');
+
+      final adapter = _RecordingAdapter(
+        responseHeaders: {
+          "etag": ['"fresh"'],
+        },
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+
+      await getRemoteUri<String>(dio, uri);
+
+      expect(_header(adapter.requests.single, "If-None-Match"), '"old"');
+      expect(EtagCache.getEtag(uri), '"fresh"');
+    });
+  });
+
+  group("fetchRemoteJson on 304", () {
+    test("returns cachedPayload without warning or retry", () async {
+      final uri = Uri.parse("https://example.com/meta.json");
+      final adapter = _RecordingAdapter(status: 304);
+      final dio = Dio()..httpClientAdapter = adapter;
+
+      final cached = {"schemaVersion": 1, "hello": "world"};
+      final result = await fetchRemoteJson(dio, uri, cachedPayload: cached);
+
+      expect(result, cached);
+      // Exactly one request: no destructive ETag clear + unconditional refetch.
+      expect(adapter.requests.length, 1);
+    });
+  });
+}

--- a/test/storage/repo/assets_recover_test.dart
+++ b/test/storage/repo/assets_recover_test.dart
@@ -4,11 +4,12 @@ import "package:eve_fit_assistant/config/logger.dart";
 import "package:eve_fit_assistant/config/paths.dart";
 import "package:eve_fit_assistant/storage/repo/assets.dart";
 import "package:eve_fit_assistant/storage/repo/paths.dart";
+import "package:file/memory.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:path/path.dart" as p;
 
 void main() {
-  late Directory tempDir;
+  late MemoryFileSystem fs;
 
   setUpAll(() {
     GlobalLogger.init(
@@ -18,42 +19,37 @@ void main() {
   });
 
   setUp(() {
-    tempDir = Directory.systemTemp.createTempSync("efa_recover_test_");
-    PathProvider.documentsPath = tempDir.path;
-  });
-
-  tearDown(() {
-    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    fs = MemoryFileSystem();
+    PathProvider.documentsPath = "/";
   });
 
   test("recoverSync deletes orphaned .tmp files but keeps real blobs", () {
-    final assets = Directory(RepoPaths.assetsPath)..createSync(recursive: true);
-    final blobDir = Directory(p.join(assets.path, "blobs", "ab", "abc"))
+    final assets = fs.directory(RepoPaths.assetsPath)..createSync(recursive: true);
+    final blobDir = fs.directory(p.join(assets.path, "blobs", "ab", "abc"))
       ..createSync(recursive: true);
-    final realBlob = File(p.join(blobDir.path, "content"))..writeAsStringSync("data");
-    final orphanedTmp = File(p.join(blobDir.path, "content.tmp"))..writeAsStringSync("partial");
+    final realBlob = fs.file(p.join(blobDir.path, "content"))..writeAsStringSync("data");
+    final orphanedTmp = fs.file(p.join(blobDir.path, "content.tmp"))..writeAsStringSync("partial");
 
-    const AssetStore().recoverSync();
+    AssetStore.forTest(fs).recoverSync();
 
     expect(realBlob.existsSync(), isTrue);
     expect(orphanedTmp.existsSync(), isFalse);
   });
 
   test("recoverSync removes tmp_* and *_temp working directories", () {
-    final assets = Directory(RepoPaths.assetsPath)..createSync(recursive: true);
-    final tmpDir = Directory(p.join(assets.path, "tmp_resource_snapshot"))
+    final assets = fs.directory(RepoPaths.assetsPath)..createSync(recursive: true);
+    final tmpDir = fs.directory(p.join(assets.path, "tmp_resource_snapshot"))
       ..createSync(recursive: true);
-    File(p.join(tmpDir.path, "x")).writeAsStringSync("y");
-    final tempSuffixDir = Directory(p.join(assets.path, "foo_temp"))..createSync(recursive: true);
+    fs.file(p.join(tmpDir.path, "x")).writeAsStringSync("y");
+    final tempSuffixDir = fs.directory(p.join(assets.path, "foo_temp"))..createSync(recursive: true);
 
-    const AssetStore().recoverSync();
+    AssetStore.forTest(fs).recoverSync();
 
     expect(tmpDir.existsSync(), isFalse);
     expect(tempSuffixDir.existsSync(), isFalse);
   });
 
   test("recoverSync is a no-op when the assets directory is absent", () {
-    expect(Directory(RepoPaths.assetsPath).existsSync(), isFalse);
-    expect(const AssetStore().recoverSync, returnsNormally);
+    expect(AssetStore.forTest(fs).recoverSync, returnsNormally);
   });
 }

--- a/test/storage/repo/assets_recover_test.dart
+++ b/test/storage/repo/assets_recover_test.dart
@@ -1,0 +1,59 @@
+import "dart:io";
+
+import "package:eve_fit_assistant/config/logger.dart";
+import "package:eve_fit_assistant/config/paths.dart";
+import "package:eve_fit_assistant/storage/repo/assets.dart";
+import "package:eve_fit_assistant/storage/repo/paths.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:path/path.dart" as p;
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() {
+    GlobalLogger.init(
+      Directory.systemTemp.createTempSync("efa_recover_log_").path,
+      enableDebugLog: false,
+    );
+  });
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync("efa_recover_test_");
+    PathProvider.documentsPath = tempDir.path;
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test("recoverSync deletes orphaned .tmp files but keeps real blobs", () {
+    final assets = Directory(RepoPaths.assetsPath)..createSync(recursive: true);
+    final blobDir = Directory(p.join(assets.path, "blobs", "ab", "abc"))
+      ..createSync(recursive: true);
+    final realBlob = File(p.join(blobDir.path, "content"))..writeAsStringSync("data");
+    final orphanedTmp = File(p.join(blobDir.path, "content.tmp"))..writeAsStringSync("partial");
+
+    const AssetStore().recoverSync();
+
+    expect(realBlob.existsSync(), isTrue);
+    expect(orphanedTmp.existsSync(), isFalse);
+  });
+
+  test("recoverSync removes tmp_* and *_temp working directories", () {
+    final assets = Directory(RepoPaths.assetsPath)..createSync(recursive: true);
+    final tmpDir = Directory(p.join(assets.path, "tmp_resource_snapshot"))
+      ..createSync(recursive: true);
+    File(p.join(tmpDir.path, "x")).writeAsStringSync("y");
+    final tempSuffixDir = Directory(p.join(assets.path, "foo_temp"))..createSync(recursive: true);
+
+    const AssetStore().recoverSync();
+
+    expect(tmpDir.existsSync(), isFalse);
+    expect(tempSuffixDir.existsSync(), isFalse);
+  });
+
+  test("recoverSync is a no-op when the assets directory is absent", () {
+    expect(Directory(RepoPaths.assetsPath).existsSync(), isFalse);
+    expect(const AssetStore().recoverSync, returnsNormally);
+  });
+}

--- a/test/storage/repo/channel_service_test.dart
+++ b/test/storage/repo/channel_service_test.dart
@@ -34,16 +34,28 @@ class _FakeRemoteCatalogService extends RemoteCatalogService {
   Either<CatalogError, Uint8List>? generationResourcesResult;
   Either<CatalogError, Uint8List>? generationPointerResult;
 
+  // Captured invocations for test assertions
+  String? lastHeadMetaChannel;
+  Map<String, dynamic>? lastChannelRegistryPayload;
+  Map<String, dynamic>? lastHeadMetaPayload;
+
   @override
   Future<Either<CatalogError, ChannelRegistry>> fetchChannelRegistry({
     Map<String, dynamic>? cachedPayload,
-  }) async => channelRegistryResult ?? Left(const CatalogNetworkError(message: "not configured"));
+  }) async {
+    lastChannelRegistryPayload = cachedPayload;
+    return channelRegistryResult ?? Left(const CatalogNetworkError(message: "not configured"));
+  }
 
   @override
   Future<Either<CatalogError, ChannelHeadMeta>> fetchHeadMeta(
     String channelName, {
     Map<String, dynamic>? cachedPayload,
-  }) async => headMetaResult ?? Left(const CatalogNetworkError(message: "not configured"));
+  }) async {
+    lastHeadMetaChannel = channelName;
+    lastHeadMetaPayload = cachedPayload;
+    return headMetaResult ?? Left(const CatalogNetworkError(message: "not configured"));
+  }
 
   @override
   Future<Either<CatalogError, Uint8List>> fetchServerIndex(String generationHash) async =>
@@ -244,5 +256,490 @@ void main() {
               as Map<String, dynamic>;
       expect(saved["active"], "testing");
     });
+
+    test("forwards cachedPayload as null when no local registry exists", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        channelRegistryResult: Right(
+          ChannelRegistry(schemaVersion: 1, active: "testing", channels: const IMap.empty()),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      await service.discoverChannels();
+
+      expect(fakeRemote.lastChannelRegistryPayload, isNull);
+    });
+
+    test("forwards cachedPayload as local registry when one exists", () async {
+      final channels = IMap<String, ChannelEntry>({
+        "testing": ChannelEntry(label: IMap<String, String>({"en": "Testing"})),
+      });
+      final fakeRemote = _FakeRemoteCatalogService(
+        channelRegistryResult: Right(
+          ChannelRegistry(schemaVersion: 1, active: "testing", channels: channels),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      // First call writes a local registry
+      await service.discoverChannels();
+
+      // Second call should forward the local registry as cachedPayload
+      await service.discoverChannels();
+
+      expect(fakeRemote.lastChannelRegistryPayload, isNotNull);
+      expect(fakeRemote.lastChannelRegistryPayload!["active"], "testing");
+    });
+
+    test("returns Left on CatalogNetworkError", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        channelRegistryResult: Left(const CatalogNetworkError(message: "timeout")),
+      );
+      final service = _makeService(fakeRemote);
+
+      final result = await service.discoverChannels();
+
+      expect(result.isLeft(), isTrue);
+      expect(result.getLeft().toNullable(), "timeout");
+    });
+
+    test("returns Left on other catalog error", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        channelRegistryResult: Left(const CatalogParseError(message: "bad json")),
+      );
+      final service = _makeService(fakeRemote);
+
+      final result = await service.discoverChannels();
+
+      expect(result.isLeft(), isTrue);
+      expect(result.getLeft().toNullable(), "Failed to fetch channels");
+    });
+  });
+
+  group("fetchChannelInfo", () {
+    test("fetches head meta and server index on success", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-15T12:00:00Z",
+            label: IMap(const {"en": "Test Release"}),
+          ),
+        ),
+        serverIndexResult: Right(Uint8List.fromList([1, 2, 3])),
+      );
+      final service = _makeService(fakeRemote);
+
+      final result = await service.fetchChannelInfo("testing");
+
+      expect(result.isRight(), isTrue);
+      expect(File(RepoPaths.channelHeadMetaPath("testing")).existsSync(), isTrue);
+      expect(File(RepoPaths.channelServerIndexPath("testing")).existsSync(), isTrue);
+    });
+
+    test("returns Right(unit) on 404 (channel not initialized)", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Left(const CatalogNotFoundError(message: "not found")),
+      );
+      final service = _makeService(fakeRemote);
+
+      final result = await service.fetchChannelInfo("testing");
+
+      expect(result.isRight(), isTrue);
+      expect(File(RepoPaths.channelHeadMetaPath("testing")).existsSync(), isFalse);
+    });
+
+    test("returns Left on network error", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Left(const CatalogNetworkError(message: "connection refused")),
+      );
+      final service = _makeService(fakeRemote);
+
+      final result = await service.fetchChannelInfo("testing");
+
+      expect(result.isLeft(), isTrue);
+      expect(result.getLeft().toNullable(), "connection refused");
+    });
+
+    test("succeeds when server index fetch fails but head meta succeeds", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-15T12:00:00Z",
+            label: IMap(const {"en": "Test Release"}),
+          ),
+        ),
+        serverIndexResult: Left(const CatalogNetworkError(message: "timeout")),
+      );
+      final service = _makeService(fakeRemote);
+
+      final result = await service.fetchChannelInfo("testing");
+
+      expect(result.isRight(), isTrue);
+      // Head meta should be written despite server index failure
+      expect(File(RepoPaths.channelHeadMetaPath("testing")).existsSync(), isTrue);
+    });
+
+    test("forwards cachedPayload as null when no local head exists", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-15T12:00:00Z",
+            label: IMap(const {"en": "Test Release"}),
+          ),
+        ),
+        serverIndexResult: Right(Uint8List.fromList([1, 2, 3])),
+      );
+      final service = _makeService(fakeRemote);
+
+      await service.fetchChannelInfo("testing");
+
+      expect(fakeRemote.lastHeadMetaPayload, isNull);
+    });
+
+    test("forwards cachedPayload as local head when one exists", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-15T12:00:00Z",
+            label: IMap(const {"en": "Test Release"}),
+          ),
+        ),
+        serverIndexResult: Right(Uint8List.fromList([1, 2, 3])),
+      );
+      final service = _makeService(fakeRemote);
+
+      // First call writes a local head
+      await service.fetchChannelInfo("testing");
+      // Second call should forward the local head as cachedPayload
+      await service.fetchChannelInfo("testing");
+
+      expect(fakeRemote.lastHeadMetaPayload, isNotNull);
+      expect(fakeRemote.lastHeadMetaPayload!["generationHash"], _testGenerationHash);
+    });
+  });
+
+  group("hasUpdates", () {
+    test("returns true when no local state", () async {
+      final fakeRemote = _FakeRemoteCatalogService();
+      final service = _makeService(fakeRemote);
+
+      final hasUpdates = await service.hasUpdates("testing");
+
+      expect(hasUpdates, isTrue);
+    });
+
+    test("returns true when remote generation differs from local", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash:
+                "sha256:ffff0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+            updatedAt: "2026-06-16T12:00:00Z",
+            label: IMap(const {"en": "Newer Release"}),
+          ),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      // Write a local head with a different generation hash
+      final headPath = RepoPaths.channelHeadMetaPath("testing");
+      File(headPath).parent.createSync(recursive: true);
+      File(headPath).writeAsStringSync(
+        jsonEncode({
+          "schemaVersion": 1,
+          "generationHash": _testGenerationHash,
+          "updatedAt": "2026-06-15T12:00:00Z",
+          "label": {"en": "Current Release"},
+        }),
+      );
+
+      final hasUpdates = await service.hasUpdates("testing");
+
+      expect(hasUpdates, isTrue);
+    });
+
+    test("returns false when local and remote generation match", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-16T12:00:00Z",
+            label: IMap(const {"en": "Same Release"}),
+          ),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      // Write a local head with the same generation hash
+      final headPath = RepoPaths.channelHeadMetaPath("testing");
+      File(headPath).parent.createSync(recursive: true);
+      File(headPath).writeAsStringSync(
+        jsonEncode({
+          "schemaVersion": 1,
+          "generationHash": _testGenerationHash,
+          "updatedAt": "2026-06-15T12:00:00Z",
+          "label": {"en": "Same Release"},
+        }),
+      );
+
+      final hasUpdates = await service.hasUpdates("testing");
+
+      expect(hasUpdates, isFalse);
+    });
+
+    test("returns false on network error", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Left(const CatalogNetworkError(message: "timeout")),
+      );
+      final service = _makeService(fakeRemote);
+
+      // Ensure there is local state (otherwise it would return true)
+      final headPath = RepoPaths.channelHeadMetaPath("testing");
+      File(headPath).parent.createSync(recursive: true);
+      File(headPath).writeAsStringSync(
+        jsonEncode({
+          "schemaVersion": 1,
+          "generationHash": _testGenerationHash,
+          "updatedAt": "2026-06-15T12:00:00Z",
+          "label": {"en": "Current Release"},
+        }),
+      );
+
+      final hasUpdates = await service.hasUpdates("testing");
+
+      expect(hasUpdates, isFalse);
+    });
+
+    test("forwards cachedPayload as local head when local state exists", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-16T12:00:00Z",
+            label: IMap(const {"en": "Same Release"}),
+          ),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      // Write a local head
+      final headPath = RepoPaths.channelHeadMetaPath("testing");
+      File(headPath).parent.createSync(recursive: true);
+      File(headPath).writeAsStringSync(
+        jsonEncode({
+          "schemaVersion": 1,
+          "generationHash": _testGenerationHash,
+          "updatedAt": "2026-06-15T12:00:00Z",
+          "label": {"en": "Current Release"},
+        }),
+      );
+
+      await service.hasUpdates("testing");
+
+      expect(fakeRemote.lastHeadMetaPayload, isNotNull);
+      expect(fakeRemote.lastHeadMetaPayload!["generationHash"], _testGenerationHash);
+    });
+
+    test("does not call fetchHeadMeta when no local state (early return)", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-16T12:00:00Z",
+            label: IMap(const {"en": "New Release"}),
+          ),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      final result = await service.hasUpdates("testing");
+
+      expect(result, isTrue);
+      // When localGenerationHash is null, hasUpdates returns true immediately
+      // without calling fetchHeadMeta at all.
+      expect(fakeRemote.lastHeadMetaChannel, isNull);
+    });
+  });
+
+  group("cachedPayload propagation", () {
+    test("discoverChannels passes cachedPayload when local registry exists", () async {
+      final channels = IMap<String, ChannelEntry>({
+        "testing": ChannelEntry(label: IMap<String, String>({"en": "Testing"})),
+      });
+      final fakeRemote = _FakeRemoteCatalogService(
+        channelRegistryResult: Right(
+          ChannelRegistry(schemaVersion: 1, active: "testing", channels: channels),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      // First call writes local registry
+      await service.discoverChannels();
+      // Second call should forward it
+      await service.discoverChannels();
+
+      expect(fakeRemote.lastChannelRegistryPayload, isNotNull);
+    });
+
+    test("discoverChannels passes null when no local registry", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        channelRegistryResult: Right(
+          ChannelRegistry(schemaVersion: 1, active: "testing", channels: const IMap.empty()),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      await service.discoverChannels();
+
+      expect(fakeRemote.lastChannelRegistryPayload, isNull);
+    });
+
+    test("syncChannelGeneration passes cachedPayload when local head exists", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-15T12:00:00Z",
+            label: IMap(const {"en": "Test Release"}),
+          ),
+        ),
+        serverIndexResult: Right(Uint8List.fromList([1, 2, 3])),
+        generationResourcesResult: Right(Uint8List.fromList([4, 5, 6])),
+        generationPointerResult: Right(Uint8List.fromList([7, 8, 9])),
+      );
+      final service = _makeService(fakeRemote);
+
+      // First call writes local head
+      await service.syncChannelGeneration("testing");
+      // Second call should forward local head as cachedPayload
+      await service.syncChannelGeneration("testing");
+
+      expect(fakeRemote.lastHeadMetaPayload, isNotNull);
+    });
+
+    test("syncChannelGeneration passes null when no local head", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-15T12:00:00Z",
+            label: IMap(const {"en": "Test Release"}),
+          ),
+        ),
+        serverIndexResult: Right(Uint8List.fromList([1, 2, 3])),
+      );
+      final service = _makeService(fakeRemote);
+
+      await service.syncChannelGeneration("testing");
+
+      expect(fakeRemote.lastHeadMetaPayload, isNull);
+    });
+
+    test("fetchChannelInfo passes cachedPayload when local head exists", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-15T12:00:00Z",
+            label: IMap(const {"en": "Test Release"}),
+          ),
+        ),
+        serverIndexResult: Right(Uint8List.fromList([1, 2, 3])),
+      );
+      final service = _makeService(fakeRemote);
+
+      await service.fetchChannelInfo("testing");
+      await service.fetchChannelInfo("testing");
+
+      expect(fakeRemote.lastHeadMetaPayload, isNotNull);
+    });
+
+    test("fetchChannelInfo passes null when no local head", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-15T12:00:00Z",
+            label: IMap(const {"en": "Test Release"}),
+          ),
+        ),
+        serverIndexResult: Right(Uint8List.fromList([1, 2, 3])),
+      );
+      final service = _makeService(fakeRemote);
+
+      await service.fetchChannelInfo("testing");
+
+      expect(fakeRemote.lastHeadMetaPayload, isNull);
+    });
+
+    test("hasUpdates passes cachedPayload when local head exists", () async {
+      final fakeRemote = _FakeRemoteCatalogService(
+        headMetaResult: Right(
+          ChannelHeadMeta(
+            schemaVersion: 1,
+            generationHash: _testGenerationHash,
+            updatedAt: "2026-06-16T12:00:00Z",
+            label: IMap(const {"en": "Same Release"}),
+          ),
+        ),
+      );
+      final service = _makeService(fakeRemote);
+
+      final headPath = RepoPaths.channelHeadMetaPath("testing");
+      File(headPath).parent.createSync(recursive: true);
+      File(headPath).writeAsStringSync(
+        jsonEncode({
+          "schemaVersion": 1,
+          "generationHash": _testGenerationHash,
+          "updatedAt": "2026-06-15T12:00:00Z",
+          "label": {"en": "Current Release"},
+        }),
+      );
+
+      await service.hasUpdates("testing");
+
+      expect(fakeRemote.lastHeadMetaPayload, isNotNull);
+      expect(fakeRemote.lastHeadMetaPayload!["generationHash"], _testGenerationHash);
+    });
+
+    test(
+      "hasUpdates does not forward cachedPayload when local state absent (early return)",
+      () async {
+        // When localGenerationHash is null, hasUpdates returns true immediately
+        // without calling fetchHeadMeta at all.
+        final fakeRemote = _FakeRemoteCatalogService(
+          headMetaResult: Right(
+            ChannelHeadMeta(
+              schemaVersion: 1,
+              generationHash: _testGenerationHash,
+              updatedAt: "2026-06-16T12:00:00Z",
+              label: IMap(const {"en": "New Release"}),
+            ),
+          ),
+        );
+        final service = _makeService(fakeRemote);
+
+        final result = await service.hasUpdates("testing");
+
+        expect(result, isTrue);
+        expect(fakeRemote.lastHeadMetaChannel, isNull);
+      },
+    );
   });
 }

--- a/test/storage/repo/channel_service_test.dart
+++ b/test/storage/repo/channel_service_test.dart
@@ -35,12 +35,15 @@ class _FakeRemoteCatalogService extends RemoteCatalogService {
   Either<CatalogError, Uint8List>? generationPointerResult;
 
   @override
-  Future<Either<CatalogError, ChannelRegistry>> fetchChannelRegistry() async =>
-      channelRegistryResult ?? Left(const CatalogNetworkError(message: "not configured"));
+  Future<Either<CatalogError, ChannelRegistry>> fetchChannelRegistry({
+    Map<String, dynamic>? cachedPayload,
+  }) async => channelRegistryResult ?? Left(const CatalogNetworkError(message: "not configured"));
 
   @override
-  Future<Either<CatalogError, ChannelHeadMeta>> fetchHeadMeta(String channelName) async =>
-      headMetaResult ?? Left(const CatalogNetworkError(message: "not configured"));
+  Future<Either<CatalogError, ChannelHeadMeta>> fetchHeadMeta(
+    String channelName, {
+    Map<String, dynamic>? cachedPayload,
+  }) async => headMetaResult ?? Left(const CatalogNetworkError(message: "not configured"));
 
   @override
   Future<Either<CatalogError, Uint8List>> fetchServerIndex(String generationHash) async =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed stale ETag cache causing download failures when local data is missing
  * Improved recovery from interrupted downloads by cleaning up orphaned temporary files on startup
  * Enhanced robustness when server indicates content unchanged but local data is absent

* **Chores**
  * Optimized HTTP conditional request caching to reduce redundant downloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->