### PR TITLE
fix(remote-session): accumulate generation resources from parent

### DIFF
--- a/bootstrap/cli/remote/session.py
+++ b/bootstrap/cli/remote/session.py
@@ -13,6 +13,7 @@ from colorama import Style
 from bootstrap.cli import runtime
 from bootstrap.cli.remote.helpers import validate_remote_channel
 from bootstrap.color import styled
+from bootstrap.log import warning
 from bootstrap.remote import SessionManager
 from bootstrap.remote import SessionManagerCommittedError
 from bootstrap.remote import SessionManagerInvalidError
@@ -298,7 +299,7 @@ def _compute_diff(root: Path, session: Session) -> dict:
             meta, _ = snap_store.load_resource_snapshot(h)
             staged_resources[meta.server_id] = h
         except Exception:
-            pass
+            warning("Failed to load staged resource snapshot %s; omitted from diff", h)
 
     added: list[str] = []
     updated: list[str] = []
@@ -781,7 +782,7 @@ def register_remote_session(remote: click.Group) -> None:
         }
         for snap_type in ("resources", "releases"):
             data = diff[snap_type]
-            display_type = snap_type.rstrip("s")
+            display_type = snap_type.removesuffix("s")
 
             if not any(data.values()):
                 continue

--- a/bootstrap/cli/remote/session.py
+++ b/bootstrap/cli/remote/session.py
@@ -541,6 +541,102 @@ def _print_issues(issues: list) -> None:
         )
 
 
+def _build_generation_data(snap_store, staged_resources, staged_releases, parent_gen=None):
+    """Build generation data structures from staged resources & releases.
+
+    Seeds from *parent_gen* if provided (accumulation model), then overlays
+    staged resource snapshots (updating existing server entries or adding new
+    ones) and sets the release pointer from staged releases (falling back to
+    the parent's pointer if none staged).
+
+    Returns (server_index, gen_resources, release_ptr).
+    """
+    from bootstrap.remote.models import GenerationPointer
+    from bootstrap.remote.models import GenerationResources
+    from bootstrap.remote.models import ServerIndex
+
+    server_index = ServerIndex()
+    server_index.schema_version = 1
+    gen_resources = GenerationResources()
+    gen_resources.schema_version = 1
+
+    if parent_gen is not None:
+        for srv in parent_gen.server_index.servers:
+            srv_entry = server_index.servers.add()
+            srv_entry.CopyFrom(srv)
+        for res in parent_gen.resources.entries:
+            res_entry = gen_resources.entries.add()
+            res_entry.CopyFrom(res)
+
+    for hash_val in staged_resources:
+        meta, _ = snap_store.load_resource_snapshot(hash_val)
+
+        srv_existing = None
+        for srv in server_index.servers:
+            if srv.server_id == meta.server_id:
+                srv_existing = srv
+                break
+
+        if srv_existing is not None:
+            srv_existing.game_build = meta.game_build
+            srv_existing.game_version = meta.game_version
+            srv_existing.ClearField("region")
+            srv_existing.ClearField("sync")
+            srv_existing.ClearField("branch")
+            if meta.game_region:
+                srv_existing.region = meta.game_region
+            if meta.game_sync:
+                srv_existing.sync = meta.game_sync
+            if meta.game_branch:
+                srv_existing.branch = meta.game_branch
+            srv_existing.name.clear()
+            if meta.name:
+                for locale, display_name in meta.name.items():
+                    srv_existing.name[locale] = display_name
+            else:
+                srv_existing.name["en"] = meta.server_id
+        else:
+            srv_entry = server_index.servers.add()
+            srv_entry.server_id = meta.server_id
+            if meta.name:
+                for locale, display_name in meta.name.items():
+                    srv_entry.name[locale] = display_name
+            else:
+                srv_entry.name["en"] = meta.server_id
+            srv_entry.game_build = meta.game_build
+            srv_entry.game_version = meta.game_version
+            if meta.game_region:
+                srv_entry.region = meta.game_region
+            if meta.game_sync:
+                srv_entry.sync = meta.game_sync
+            if meta.game_branch:
+                srv_entry.branch = meta.game_branch
+
+        res_existing = None
+        for res in gen_resources.entries:
+            if res.server_id == meta.server_id:
+                res_existing = res
+                break
+
+        if res_existing is not None:
+            res_existing.snapshot_hash = hash_val
+        else:
+            gentry = gen_resources.entries.add()
+            gentry.server_id = meta.server_id
+            gentry.snapshot_hash = hash_val
+
+    release_ptr = GenerationPointer()
+    release_ptr.schema_version = 1
+    if parent_gen is not None:
+        release_ptr.snapshot_hash = parent_gen.release_pointer.snapshot_hash
+    else:
+        release_ptr.snapshot_hash = ""
+    if staged_releases:
+        release_ptr.snapshot_hash = staged_releases[-1]
+
+    return server_index, gen_resources, release_ptr
+
+
 _SCHEMA_ROOT_OPTION = click.option(
     "--schema-root",
     type=click.Path(path_type=Path),
@@ -871,9 +967,6 @@ def register_remote_session(remote: click.Group) -> None:
         """Assemble a generation from staged snapshots and advance the channel head."""
         from bootstrap.remote.generation import utc_timestamp
         from bootstrap.remote.models import GenerationMetadata
-        from bootstrap.remote.models import GenerationPointer
-        from bootstrap.remote.models import GenerationResources
-        from bootstrap.remote.models import ServerIndex
 
         root = runtime.resolve_schema_root(schema_root)
         store = SessionStore(root)
@@ -915,92 +1008,21 @@ def register_remote_session(remote: click.Group) -> None:
 
         parent_gen = mgr.gen_store.load(parent) if parent else None
 
-        server_index = ServerIndex()
-        server_index.schema_version = 1
+        server_index, gen_resources, release_ptr = _build_generation_data(
+            snap_store=snap_store,
+            staged_resources=session.staged.resources,
+            staged_releases=session.staged.releases,
+            parent_gen=parent_gen,
+        )
 
-        gen_resources = GenerationResources()
-        gen_resources.schema_version = 1
-
-        # ── Seed from parent generation ──────────────────────────────────────
-        if parent_gen is not None:
-            for srv in parent_gen.server_index.servers:
-                srv_entry = server_index.servers.add()
-                srv_entry.CopyFrom(srv)
-            for res in parent_gen.resources.entries:
-                res_entry = gen_resources.entries.add()
-                res_entry.CopyFrom(res)
-
-        # ── Overlay staged snapshots ─────────────────────────────────────────
         server_ids: list[str] = []
         for hash_val in session.staged.resources:
-            meta, _index = snap_store.load_resource_snapshot(hash_val)
-
-            srv_existing = None
-            for srv in server_index.servers:
-                if srv.server_id == meta.server_id:
-                    srv_existing = srv
-                    break
-
-            if srv_existing is not None:
-                srv_existing.game_build = meta.game_build
-                srv_existing.game_version = meta.game_version
-                srv_existing.ClearField("region")
-                srv_existing.ClearField("sync")
-                srv_existing.ClearField("branch")
-                if meta.game_region:
-                    srv_existing.region = meta.game_region
-                if meta.game_sync:
-                    srv_existing.sync = meta.game_sync
-                if meta.game_branch:
-                    srv_existing.branch = meta.game_branch
-                srv_existing.name.clear()
-                if meta.name:
-                    for locale, display_name in meta.name.items():
-                        srv_existing.name[locale] = display_name
-                else:
-                    srv_existing.name["en"] = meta.server_id
-            else:
-                srv_entry = server_index.servers.add()
-                srv_entry.server_id = meta.server_id
-                if meta.name:
-                    for locale, display_name in meta.name.items():
-                        srv_entry.name[locale] = display_name
-                else:
-                    srv_entry.name["en"] = meta.server_id
-                srv_entry.game_build = meta.game_build
-                srv_entry.game_version = meta.game_version
-                if meta.game_region:
-                    srv_entry.region = meta.game_region
-                if meta.game_sync:
-                    srv_entry.sync = meta.game_sync
-                if meta.game_branch:
-                    srv_entry.branch = meta.game_branch
-
-            res_existing = None
-            for res in gen_resources.entries:
-                if res.server_id == meta.server_id:
-                    res_existing = res
-                    break
-
-            if res_existing is not None:
-                res_existing.snapshot_hash = hash_val
-            else:
-                gentry = gen_resources.entries.add()
-                gentry.server_id = meta.server_id
-                gentry.snapshot_hash = hash_val
-
+            meta, _ = snap_store.load_resource_snapshot(hash_val)
             server_ids.append(meta.server_id)
 
-        release_ptr = GenerationPointer()
-        release_ptr.schema_version = 1
-        if parent_gen is not None:
-            release_ptr.snapshot_hash = parent_gen.release_pointer.snapshot_hash
-        else:
-            release_ptr.snapshot_hash = ""
         release_hash: str | None = None
         if session.staged.releases:
             release_hash = session.staged.releases[-1]
-            release_ptr.snapshot_hash = release_hash
 
         ts = utc_timestamp()
         meta = GenerationMetadata(

--- a/bootstrap/cli/remote/session.py
+++ b/bootstrap/cli/remote/session.py
@@ -260,18 +260,25 @@ def _get_snapshot_summary(root: Path, snap_type: str, hash_value: str) -> str:
 
 
 def _compute_diff(root: Path, session: Session) -> dict:
-    """Compare session staged hashes against the current channel head."""
+    """Compare session staged hashes against the current channel head.
+
+    Categories (with accumulation in mind):
+      - added:     staged snapshot, server not in head
+      - updated:   staged snapshot, server in head with DIFFERENT snapshot hash
+      - unchanged: staged snapshot, server in head with SAME snapshot hash
+      - inherited: server in head, NOT staged (carried forward by accumulation)
+    """
     from bootstrap.remote.generation import GenerationStore
     from bootstrap.remote.head import ChannelHeadStore
+    from bootstrap.remote.snapshot import SnapshotStore
 
     head_store = ChannelHeadStore(root)
     gen_store = GenerationStore(root)
+    snap_store = SnapshotStore(root)
 
     head_hash: str | None = None
-    head_sets: dict[str, set[str]] = {
-        "resources": set(),
-        "releases": set(),
-    }
+    head_resources: dict[str, str] = {}
+    head_release: str | None = None
 
     try:
         head = head_store._safe_get_head(session.channel)
@@ -279,27 +286,57 @@ def _compute_diff(root: Path, session: Session) -> dict:
             head_hash = head.generation_hash
             generation = gen_store.load(head.generation_hash)
             for entry in generation.resources.entries:
-                head_sets["resources"].add(entry.snapshot_hash)
+                head_resources[entry.server_id] = entry.snapshot_hash
             if generation.release_pointer.snapshot_hash:
-                head_sets["releases"].add(generation.release_pointer.snapshot_hash)
+                head_release = generation.release_pointer.snapshot_hash
     except Exception:
         pass
 
-    session_sets = {
-        "resources": set(session.staged.resources),
-        "releases": set(session.staged.releases),
-    }
+    staged_resources: dict[str, str] = {}
+    for h in session.staged.resources:
+        try:
+            meta, _ = snap_store.load_resource_snapshot(h)
+            staged_resources[meta.server_id] = h
+        except Exception:
+            pass
 
-    diff: dict = {"channel": session.channel, "head": head_hash}
-    for snap_type in ("resources", "releases"):
-        s_set = session_sets[snap_type]
-        h_set = head_sets[snap_type]
-        diff[snap_type] = {
-            "added": sorted(s_set - h_set),
-            "removed": sorted(h_set - s_set),
-            "unchanged": sorted(s_set & h_set),
-        }
-    return diff
+    added: list[str] = []
+    updated: list[str] = []
+    unchanged: list[str] = []
+    inherited: list[str] = []
+
+    staged_ids = set(staged_resources.keys())
+    head_ids = set(head_resources.keys())
+
+    for sid in staged_ids - head_ids:
+        added.append(staged_resources[sid])
+    for sid in staged_ids & head_ids:
+        if staged_resources[sid] != head_resources[sid]:
+            updated.append(staged_resources[sid])
+        else:
+            unchanged.append(staged_resources[sid])
+    for sid in head_ids - staged_ids:
+        inherited.append(head_resources[sid])
+
+    head_releases = {head_release} if head_release else set()
+    staged_releases = set(session.staged.releases)
+
+    return {
+        "channel": session.channel,
+        "head": head_hash,
+        "resources": {
+            "added": sorted(added),
+            "updated": sorted(updated),
+            "unchanged": sorted(unchanged),
+            "inherited": sorted(inherited),
+        },
+        "releases": {
+            "added": sorted(staged_releases - head_releases),
+            "updated": [],
+            "unchanged": sorted(staged_releases & head_releases),
+            "inherited": sorted(head_releases - staged_releases),
+        },
+    }
 
 
 def _check_staged_resource_blobs(root: Path, hash_value: str, issues: list) -> None:
@@ -744,23 +781,33 @@ def register_remote_session(remote: click.Group) -> None:
         }
         for snap_type in ("resources", "releases"):
             data = diff[snap_type]
-            if not data["added"] and not data["removed"] and not data["unchanged"]:
+            display_type = snap_type.rstrip("s")
+
+            if not any(data.values()):
                 continue
+
             click.echo(f"\n{type_labels[snap_type]}:")
+
             for h in data["added"]:
-                summary = _get_snapshot_summary(root, snap_type.rstrip("s"), h)
+                summary = _get_snapshot_summary(root, display_type, h)
                 click.echo(
                     styled([Style.BRIGHT, Fore.GREEN], f"  + {h[:16]}...")
                     + styled(Style.DIM, f"  {summary}")
                 )
-            for h in data["removed"]:
-                summary = _get_snapshot_summary(root, snap_type.rstrip("s"), h)
+            for h in data["updated"]:
+                summary = _get_snapshot_summary(root, display_type, h)
                 click.echo(
-                    styled([Style.BRIGHT, Fore.RED], f"  - {h[:16]}...")
+                    styled([Style.BRIGHT, Fore.YELLOW], f"  * {h[:16]}...")
+                    + styled(Style.DIM, f"  {summary}")
+                )
+            for h in data["inherited"]:
+                summary = _get_snapshot_summary(root, display_type, h)
+                click.echo(
+                    styled([Style.BRIGHT, Fore.CYAN], f"  ~ {h[:16]}...")
                     + styled(Style.DIM, f"  {summary}")
                 )
             for h in data["unchanged"]:
-                summary = _get_snapshot_summary(root, snap_type.rstrip("s"), h)
+                summary = _get_snapshot_summary(root, display_type, h)
                 click.echo(styled(Style.DIM, f"  = {h[:16]}...  {summary}"))
 
     @remote_session.command("verify")
@@ -860,49 +907,99 @@ def register_remote_session(remote: click.Group) -> None:
 
         resolved_channel = validate_remote_channel(session.channel)
 
+        current_head = head_store._safe_get_head(resolved_channel)
+        parent = (
+            current_head.generation_hash if current_head and current_head.generation_hash else None
+        )
+
+        parent_gen = mgr.gen_store.load(parent) if parent else None
+
         server_index = ServerIndex()
         server_index.schema_version = 1
 
         gen_resources = GenerationResources()
         gen_resources.schema_version = 1
 
+        # ── Seed from parent generation ──────────────────────────────────────
+        if parent_gen is not None:
+            for srv in parent_gen.server_index.servers:
+                srv_entry = server_index.servers.add()
+                srv_entry.CopyFrom(srv)
+            for res in parent_gen.resources.entries:
+                res_entry = gen_resources.entries.add()
+                res_entry.CopyFrom(res)
+
+        # ── Overlay staged snapshots ─────────────────────────────────────────
         server_ids: list[str] = []
         for hash_val in session.staged.resources:
             meta, _index = snap_store.load_resource_snapshot(hash_val)
-            entry = server_index.servers.add()
-            entry.server_id = meta.server_id
-            if meta.name:
-                for locale, display_name in meta.name.items():
-                    entry.name[locale] = display_name
-            else:
-                entry.name["en"] = meta.server_id
-            entry.game_build = meta.game_build
-            entry.game_version = meta.game_version
-            if meta.game_region:
-                entry.region = meta.game_region
-            if meta.game_sync:
-                entry.sync = meta.game_sync
-            if meta.game_branch:
-                entry.branch = meta.game_branch
 
-            gentry = gen_resources.entries.add()
-            gentry.server_id = meta.server_id
-            gentry.snapshot_hash = hash_val
+            srv_existing = None
+            for srv in server_index.servers:
+                if srv.server_id == meta.server_id:
+                    srv_existing = srv
+                    break
+
+            if srv_existing is not None:
+                srv_existing.game_build = meta.game_build
+                srv_existing.game_version = meta.game_version
+                srv_existing.ClearField("region")
+                srv_existing.ClearField("sync")
+                srv_existing.ClearField("branch")
+                if meta.game_region:
+                    srv_existing.region = meta.game_region
+                if meta.game_sync:
+                    srv_existing.sync = meta.game_sync
+                if meta.game_branch:
+                    srv_existing.branch = meta.game_branch
+                srv_existing.name.clear()
+                if meta.name:
+                    for locale, display_name in meta.name.items():
+                        srv_existing.name[locale] = display_name
+                else:
+                    srv_existing.name["en"] = meta.server_id
+            else:
+                srv_entry = server_index.servers.add()
+                srv_entry.server_id = meta.server_id
+                if meta.name:
+                    for locale, display_name in meta.name.items():
+                        srv_entry.name[locale] = display_name
+                else:
+                    srv_entry.name["en"] = meta.server_id
+                srv_entry.game_build = meta.game_build
+                srv_entry.game_version = meta.game_version
+                if meta.game_region:
+                    srv_entry.region = meta.game_region
+                if meta.game_sync:
+                    srv_entry.sync = meta.game_sync
+                if meta.game_branch:
+                    srv_entry.branch = meta.game_branch
+
+            res_existing = None
+            for res in gen_resources.entries:
+                if res.server_id == meta.server_id:
+                    res_existing = res
+                    break
+
+            if res_existing is not None:
+                res_existing.snapshot_hash = hash_val
+            else:
+                gentry = gen_resources.entries.add()
+                gentry.server_id = meta.server_id
+                gentry.snapshot_hash = hash_val
 
             server_ids.append(meta.server_id)
 
         release_ptr = GenerationPointer()
         release_ptr.schema_version = 1
-        release_ptr.snapshot_hash = ""
+        if parent_gen is not None:
+            release_ptr.snapshot_hash = parent_gen.release_pointer.snapshot_hash
+        else:
+            release_ptr.snapshot_hash = ""
         release_hash: str | None = None
         if session.staged.releases:
             release_hash = session.staged.releases[-1]
             release_ptr.snapshot_hash = release_hash
-
-        current_head = head_store._safe_get_head(resolved_channel)
-        parent = (
-            current_head.generation_hash if current_head and current_head.generation_hash else None
-        )
 
         ts = utc_timestamp()
         meta = GenerationMetadata(

--- a/bootstrap/tests/test_session_cli.py
+++ b/bootstrap/tests/test_session_cli.py
@@ -190,6 +190,109 @@ def _make_full_generation(
     return gen_hash, res_hash
 
 
+def _commit_from_session(
+    store: SessionStore,
+    mgr: SessionManager,
+    tmp_root: Path,
+    parent: str = "",
+) -> str:
+    """Build and create a generation from the current session's staged data.
+
+    Returns the generation hash. Does NOT push the head or mark committed.
+    """
+    session = store.load()
+    snap_store = mgr.snap_store
+
+    server_index = ServerIndex()
+    server_index.schema_version = 1
+    gen_resources = GenerationResources()
+    gen_resources.schema_version = 1
+
+    parent_gen = None
+    if parent:
+        parent_gen = mgr.gen_store.load(parent)
+        for srv in parent_gen.server_index.servers:
+            entry = server_index.servers.add()
+            entry.CopyFrom(srv)
+        for res in parent_gen.resources.entries:
+            gentry = gen_resources.entries.add()
+            gentry.CopyFrom(res)
+
+    for hash_val in session.staged.resources:
+        meta, _ = snap_store.load_resource_snapshot(hash_val)
+
+        srv_existing = next(
+            (s for s in server_index.servers if s.server_id == meta.server_id), None
+        )
+        if srv_existing is not None:
+            srv_existing.game_build = meta.game_build
+            srv_existing.game_version = meta.game_version
+            srv_existing.ClearField("region")
+            srv_existing.ClearField("sync")
+            srv_existing.ClearField("branch")
+            if meta.game_region:
+                srv_existing.region = meta.game_region
+            if meta.game_sync:
+                srv_existing.sync = meta.game_sync
+            if meta.game_branch:
+                srv_existing.branch = meta.game_branch
+            srv_existing.name.clear()
+            if meta.name:
+                for locale, display_name in meta.name.items():
+                    srv_existing.name[locale] = display_name
+            else:
+                srv_existing.name["en"] = meta.server_id
+        else:
+            srv_entry = server_index.servers.add()
+            srv_entry.server_id = meta.server_id
+            if meta.name:
+                for locale, display_name in meta.name.items():
+                    srv_entry.name[locale] = display_name
+            else:
+                srv_entry.name["en"] = meta.server_id
+            srv_entry.game_build = meta.game_build
+            srv_entry.game_version = meta.game_version
+            if meta.game_region:
+                srv_entry.region = meta.game_region
+            if meta.game_sync:
+                srv_entry.sync = meta.game_sync
+            if meta.game_branch:
+                srv_entry.branch = meta.game_branch
+
+        res_existing = next(
+            (r for r in gen_resources.entries if r.server_id == meta.server_id), None
+        )
+        if res_existing is not None:
+            res_existing.snapshot_hash = hash_val
+        else:
+            gentry = gen_resources.entries.add()
+            gentry.server_id = meta.server_id
+            gentry.snapshot_hash = hash_val
+
+    release_ptr = GenerationPointer()
+    release_ptr.schema_version = 1
+    if parent_gen is not None:
+        release_ptr.snapshot_hash = parent_gen.release_pointer.snapshot_hash
+    else:
+        release_ptr.snapshot_hash = ""
+    if session.staged.releases:
+        release_ptr.snapshot_hash = session.staged.releases[-1]
+
+    gen_meta = GenerationMetadata(
+        channel=session.channel,
+        timestamp=utc_timestamp(),
+        parent=parent or "",
+        subject="",
+    )
+
+    return mgr.create_generation(
+        metadata=gen_meta,
+        server_index=server_index,
+        resources=gen_resources,
+        release_pointer=release_ptr,
+    )
+
+
 # ===========================================================================
 # 1. session init
 # ===========================================================================
@@ -398,17 +501,17 @@ class TestSessionRemove:
 
 
 def _compute_diff_style(tmp_root: Path, store: SessionStore) -> dict:
+    """Accumulation-aware diff — mirrors production _compute_diff."""
     from bootstrap.remote.generation import GenerationStore
 
     head_store = ChannelHeadStore(tmp_root)
     gen_store = GenerationStore(tmp_root)
+    snap_store = SnapshotStore(tmp_root)
     session = store.load()
 
     head_hash: str | None = None
-    head_sets: dict[str, set[str]] = {
-        "resources": set(),
-        "releases": set(),
-    }
+    head_resources: dict[str, str] = {}
+    head_release: str | None = None
 
     try:
         head = head_store._safe_get_head(session.channel)
@@ -416,27 +519,57 @@ def _compute_diff_style(tmp_root: Path, store: SessionStore) -> dict:
             head_hash = head.generation_hash
             generation = gen_store.load(head.generation_hash)
             for entry in generation.resources.entries:
-                head_sets["resources"].add(entry.snapshot_hash)
+                head_resources[entry.server_id] = entry.snapshot_hash
             if generation.release_pointer.snapshot_hash:
-                head_sets["releases"].add(generation.release_pointer.snapshot_hash)
+                head_release = generation.release_pointer.snapshot_hash
     except Exception:
         pass
 
-    session_sets = {
-        "resources": set(session.staged.resources),
-        "releases": set(session.staged.releases),
-    }
+    staged_resources: dict[str, str] = {}
+    for h in session.staged.resources:
+        try:
+            meta, _ = snap_store.load_resource_snapshot(h)
+            staged_resources[meta.server_id] = h
+        except Exception:
+            pass
 
-    diff: dict = {"channel": session.channel, "head": head_hash}
-    for snap_type in ("resources", "releases"):
-        s_set = session_sets[snap_type]
-        h_set = head_sets[snap_type]
-        diff[snap_type] = {
-            "added": sorted(s_set - h_set),
-            "removed": sorted(h_set - s_set),
-            "unchanged": sorted(s_set & h_set),
-        }
-    return diff
+    added: list[str] = []
+    updated: list[str] = []
+    unchanged: list[str] = []
+    inherited: list[str] = []
+
+    staged_ids = set(staged_resources.keys())
+    head_ids = set(head_resources.keys())
+
+    for sid in staged_ids - head_ids:
+        added.append(staged_resources[sid])
+    for sid in staged_ids & head_ids:
+        if staged_resources[sid] != head_resources[sid]:
+            updated.append(staged_resources[sid])
+        else:
+            unchanged.append(staged_resources[sid])
+    for sid in head_ids - staged_ids:
+        inherited.append(head_resources[sid])
+
+    head_releases = {head_release} if head_release else set()
+    staged_releases = set(session.staged.releases)
+
+    return {
+        "channel": session.channel,
+        "head": head_hash,
+        "resources": {
+            "added": sorted(added),
+            "updated": sorted(updated),
+            "unchanged": sorted(unchanged),
+            "inherited": sorted(inherited),
+        },
+        "releases": {
+            "added": sorted(staged_releases - head_releases),
+            "updated": [],
+            "unchanged": sorted(staged_releases & head_releases),
+            "inherited": sorted(head_releases - staged_releases),
+        },
+    }
 
 
 class TestSessionDiff:
@@ -495,6 +628,10 @@ class TestSessionDiff:
         assert res_hash2 in diff["resources"]["added"]
         assert res_hash1 not in diff["resources"]["added"]
 
+        assert res_hash1 in diff["resources"]["inherited"]
+        assert diff["resources"]["updated"] == []
+        assert diff["resources"]["unchanged"] == []
+
     def test_diff_json_output(self, store: SessionStore, tmp_root: Path) -> None:
         _init_session(store)
         res_hash = _make_resource_snapshot(tmp_root)
@@ -503,6 +640,10 @@ class TestSessionDiff:
         output = json.dumps(diff)
         assert diff["channel"] == "testing"
         assert "added" in output
+        assert "inherited" in output
+        assert "updated" in output
+        assert "unchanged" in output
+        assert "removed" not in output
 
 
 # ===========================================================================
@@ -1160,3 +1301,245 @@ class TestSessionEdgeCases:
         assert len(reflog.entries) >= 1
         last_entry = reflog.entries[-1]
         assert last_entry.op == "push"
+
+
+# ===========================================================================
+# 11. Generation accumulation
+# ===========================================================================
+
+
+class TestSessionCommitAccumulation:
+    """Accumulation: commit seeds from parent, overlays staged."""
+
+    def test_root_commit_no_seeding(
+        self, store: SessionStore, mgr: SessionManager, tmp_root: Path
+    ) -> None:
+        """First commit with no parent — same as current behavior."""
+        _init_session(store)
+        mgr.ensure_channel("testing")
+        res_a = _make_resource_snapshot(
+            tmp_root,
+            server_id="tranquility",
+            resources=[("aa" * 4, "bb" * 4, 100)],
+        )
+        store.add_snapshot("resource", res_a)
+
+        gen_a = _commit_from_session(store, mgr, tmp_root, parent="")
+        mgr.push("testing", gen_a)
+        store.mark_committed()
+
+        gen = mgr.load_generation(gen_a)
+        assert len(gen.resources.entries) == 1
+        assert gen.resources.entries[0].server_id == "tranquility"
+        assert gen.resources.entries[0].snapshot_hash == res_a
+        assert len(gen.server_index.servers) == 1
+        assert gen.server_index.servers[0].server_id == "tranquility"
+
+    def test_accumulate_new_server(
+        self, store: SessionStore, mgr: SessionManager, tmp_root: Path
+    ) -> None:
+        """Commit A1, then commit B1 → B1 gen has both A and B."""
+        _init_session(store)
+        mgr.ensure_channel("testing")
+
+        res_a = _make_resource_snapshot(
+            tmp_root,
+            server_id="tranquility",
+            resources=[("aa" * 4, "bb" * 4, 100)],
+        )
+        store.add_snapshot("resource", res_a)
+        gen_a = _commit_from_session(store, mgr, tmp_root)
+        mgr.push("testing", gen_a)
+        store.mark_committed()
+
+        store.init("testing", force_overwrite=True)
+        res_b = _make_resource_snapshot(
+            tmp_root,
+            server_id="serenity",
+            resources=[("cc" * 4, "dd" * 4, 200)],
+        )
+        store.add_snapshot("resource", res_b)
+        gen_b = _commit_from_session(store, mgr, tmp_root, parent=gen_a)
+        mgr.push("testing", gen_b)
+        store.mark_committed()
+
+        gen = mgr.load_generation(gen_b)
+        assert len(gen.resources.entries) == 2
+        server_hashes = {e.server_id: e.snapshot_hash for e in gen.resources.entries}
+        assert server_hashes["tranquility"] == res_a
+        assert server_hashes["serenity"] == res_b
+        assert len(gen.server_index.servers) == 2
+        server_ids = {e.server_id for e in gen.server_index.servers}
+        assert server_ids == {"tranquility", "serenity"}
+
+    def test_update_existing_server(
+        self, store: SessionStore, mgr: SessionManager, tmp_root: Path
+    ) -> None:
+        """Commit A1, then commit A2 → A2 replaces A1 for same server_id."""
+        _init_session(store)
+        mgr.ensure_channel("testing")
+
+        res_a1 = _make_resource_snapshot(
+            tmp_root,
+            server_id="tranquility",
+            resources=[("aa" * 4, "bb" * 4, 100)],
+        )
+        store.add_snapshot("resource", res_a1)
+        gen_a = _commit_from_session(store, mgr, tmp_root)
+        mgr.push("testing", gen_a)
+        store.mark_committed()
+
+        store.init("testing", force_overwrite=True)
+        res_a2 = _make_resource_snapshot(
+            tmp_root,
+            server_id="tranquility",
+            resources=[("ee" * 4, "ff" * 4, 300)],
+        )
+        store.add_snapshot("resource", res_a2)
+        gen_b = _commit_from_session(store, mgr, tmp_root, parent=gen_a)
+        mgr.push("testing", gen_b)
+        store.mark_committed()
+
+        gen = mgr.load_generation(gen_b)
+        assert len(gen.resources.entries) == 1
+        assert gen.resources.entries[0].server_id == "tranquility"
+        assert gen.resources.entries[0].snapshot_hash == res_a2
+
+    def test_mixed_add_and_update(
+        self, store: SessionStore, mgr: SessionManager, tmp_root: Path
+    ) -> None:
+        """Commit {A, B}, then stage {C, B2} → new gen has A(keep), B(B2), C(C)."""
+        _init_session(store)
+        mgr.ensure_channel("testing")
+
+        res_a = _make_resource_snapshot(
+            tmp_root,
+            server_id="tranquility",
+            resources=[("a1" * 4, "a2" * 4, 100)],
+        )
+        res_b = _make_resource_snapshot(
+            tmp_root,
+            server_id="serenity",
+            resources=[("b1" * 4, "b2" * 4, 200)],
+        )
+        store.add_snapshot("resource", res_a)
+        store.add_snapshot("resource", res_b)
+        gen_ab = _commit_from_session(store, mgr, tmp_root)
+        mgr.push("testing", gen_ab)
+        store.mark_committed()
+
+        store.init("testing", force_overwrite=True)
+        res_c = _make_resource_snapshot(
+            tmp_root,
+            server_id="singularity",
+            resources=[("c1" * 4, "c2" * 4, 300)],
+        )
+        res_b2 = _make_resource_snapshot(
+            tmp_root,
+            server_id="serenity",
+            resources=[("b3" * 4, "b4" * 4, 400)],
+        )
+        store.add_snapshot("resource", res_c)
+        store.add_snapshot("resource", res_b2)
+        gen_cb2 = _commit_from_session(store, mgr, tmp_root, parent=gen_ab)
+        mgr.push("testing", gen_cb2)
+        store.mark_committed()
+
+        gen = mgr.load_generation(gen_cb2)
+        assert len(gen.resources.entries) == 3
+        server_hashes = {e.server_id: e.snapshot_hash for e in gen.resources.entries}
+        assert server_hashes["tranquility"] == res_a
+        assert server_hashes["serenity"] == res_b2
+        assert server_hashes["singularity"] == res_c
+
+    def test_preserves_release_ptr_from_parent(
+        self, store: SessionStore, mgr: SessionManager, tmp_root: Path
+    ) -> None:
+        """Commit with release, then commit without → new gen carries release."""
+        _init_session(store)
+        mgr.ensure_channel("testing")
+
+        res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        rel = _make_release_snapshot(tmp_root, version="1.0.0")
+        store.add_snapshot("resource", res_a)
+        store.add_snapshot("release", rel)
+        gen_a = _commit_from_session(store, mgr, tmp_root)
+        mgr.push("testing", gen_a)
+        store.mark_committed()
+
+        store.init("testing", force_overwrite=True)
+        res_b = _make_resource_snapshot(
+            tmp_root,
+            server_id="serenity",
+            resources=[("cc" * 4, "dd" * 4, 200)],
+        )
+        store.add_snapshot("resource", res_b)
+        gen_b = _commit_from_session(store, mgr, tmp_root, parent=gen_a)
+        mgr.push("testing", gen_b)
+        store.mark_committed()
+
+        gen = mgr.load_generation(gen_b)
+        assert gen.release_pointer.snapshot_hash == rel
+
+    def test_release_override(
+        self, store: SessionStore, mgr: SessionManager, tmp_root: Path
+    ) -> None:
+        """Commit R1, then commit R2 → new gen uses R2."""
+        _init_session(store)
+        mgr.ensure_channel("testing")
+
+        res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        rel1 = _make_release_snapshot(tmp_root, version="1.0.0")
+        store.add_snapshot("resource", res_a)
+        store.add_snapshot("release", rel1)
+        gen_a = _commit_from_session(store, mgr, tmp_root)
+        mgr.push("testing", gen_a)
+        store.mark_committed()
+
+        store.init("testing", force_overwrite=True)
+        rel2 = _make_release_snapshot(tmp_root, version="1.1.0")
+        store.add_snapshot("release", rel2)
+        gen_b = _commit_from_session(store, mgr, tmp_root, parent=gen_a)
+        mgr.push("testing", gen_b)
+        store.mark_committed()
+
+        gen = mgr.load_generation(gen_b)
+        assert gen.release_pointer.snapshot_hash == rel2
+
+    def test_diff_shows_inherited(
+        self, store: SessionStore, mgr: SessionManager, tmp_root: Path
+    ) -> None:
+        """After committing A+B, staging only C → diff shows A, B inherited."""
+        _init_session(store)
+        mgr.ensure_channel("testing")
+
+        res_a = _make_resource_snapshot(
+            tmp_root,
+            server_id="tranquility",
+            resources=[("a1" * 4, "a2" * 4, 100)],
+        )
+        res_b = _make_resource_snapshot(
+            tmp_root,
+            server_id="serenity",
+            resources=[("b1" * 4, "b2" * 4, 200)],
+        )
+        store.add_snapshot("resource", res_a)
+        store.add_snapshot("resource", res_b)
+        gen_hash = _commit_from_session(store, mgr, tmp_root)
+        mgr.push("testing", gen_hash)
+        store.mark_committed()
+
+        store.init("testing", force_overwrite=True)
+        res_c = _make_resource_snapshot(
+            tmp_root,
+            server_id="singularity",
+            resources=[("c1" * 4, "c2" * 4, 300)],
+        )
+        store.add_snapshot("resource", res_c)
+
+        diff = _compute_diff_style(tmp_root, store)
+        assert res_c in diff["resources"]["added"]
+        assert res_a in diff["resources"]["inherited"]
+        assert res_b in diff["resources"]["inherited"]
+        assert len(diff["resources"]["updated"]) == 0
+        assert len(diff["resources"]["unchanged"]) == 0

--- a/bootstrap/tests/test_session_cli.py
+++ b/bootstrap/tests/test_session_cli.py
@@ -199,84 +199,21 @@ def _commit_from_session(
     """Build and create a generation from the current session's staged data.
 
     Returns the generation hash. Does NOT push the head or mark committed.
+    Delegates accumulation to the production _build_generation_data helper.
     """
+    from bootstrap.cli.remote.session import _build_generation_data
+
     session = store.load()
     snap_store = mgr.snap_store
 
-    server_index = ServerIndex()
-    server_index.schema_version = 1
-    gen_resources = GenerationResources()
-    gen_resources.schema_version = 1
+    parent_gen = mgr.gen_store.load(parent) if parent else None
 
-    parent_gen = None
-    if parent:
-        parent_gen = mgr.gen_store.load(parent)
-        for srv in parent_gen.server_index.servers:
-            entry = server_index.servers.add()
-            entry.CopyFrom(srv)
-        for res in parent_gen.resources.entries:
-            gentry = gen_resources.entries.add()
-            gentry.CopyFrom(res)
-
-    for hash_val in session.staged.resources:
-        meta, _ = snap_store.load_resource_snapshot(hash_val)
-
-        srv_existing = next(
-            (s for s in server_index.servers if s.server_id == meta.server_id), None
-        )
-        if srv_existing is not None:
-            srv_existing.game_build = meta.game_build
-            srv_existing.game_version = meta.game_version
-            srv_existing.ClearField("region")
-            srv_existing.ClearField("sync")
-            srv_existing.ClearField("branch")
-            if meta.game_region:
-                srv_existing.region = meta.game_region
-            if meta.game_sync:
-                srv_existing.sync = meta.game_sync
-            if meta.game_branch:
-                srv_existing.branch = meta.game_branch
-            srv_existing.name.clear()
-            if meta.name:
-                for locale, display_name in meta.name.items():
-                    srv_existing.name[locale] = display_name
-            else:
-                srv_existing.name["en"] = meta.server_id
-        else:
-            srv_entry = server_index.servers.add()
-            srv_entry.server_id = meta.server_id
-            if meta.name:
-                for locale, display_name in meta.name.items():
-                    srv_entry.name[locale] = display_name
-            else:
-                srv_entry.name["en"] = meta.server_id
-            srv_entry.game_build = meta.game_build
-            srv_entry.game_version = meta.game_version
-            if meta.game_region:
-                srv_entry.region = meta.game_region
-            if meta.game_sync:
-                srv_entry.sync = meta.game_sync
-            if meta.game_branch:
-                srv_entry.branch = meta.game_branch
-
-        res_existing = next(
-            (r for r in gen_resources.entries if r.server_id == meta.server_id), None
-        )
-        if res_existing is not None:
-            res_existing.snapshot_hash = hash_val
-        else:
-            gentry = gen_resources.entries.add()
-            gentry.server_id = meta.server_id
-            gentry.snapshot_hash = hash_val
-
-    release_ptr = GenerationPointer()
-    release_ptr.schema_version = 1
-    if parent_gen is not None:
-        release_ptr.snapshot_hash = parent_gen.release_pointer.snapshot_hash
-    else:
-        release_ptr.snapshot_hash = ""
-    if session.staged.releases:
-        release_ptr.snapshot_hash = session.staged.releases[-1]
+    server_index, gen_resources, release_ptr = _build_generation_data(
+        snap_store=snap_store,
+        staged_resources=session.staged.resources,
+        staged_releases=session.staged.releases,
+        parent_gen=parent_gen,
+    )
 
     gen_meta = GenerationMetadata(
         channel=session.channel,
@@ -501,75 +438,10 @@ class TestSessionRemove:
 
 
 def _compute_diff_style(tmp_root: Path, store: SessionStore) -> dict:
-    """Accumulation-aware diff — mirrors production _compute_diff."""
-    from bootstrap.remote.generation import GenerationStore
+    """Accumulation-aware diff — delegates to production _compute_diff."""
+    from bootstrap.cli.remote.session import _compute_diff
 
-    head_store = ChannelHeadStore(tmp_root)
-    gen_store = GenerationStore(tmp_root)
-    snap_store = SnapshotStore(tmp_root)
-    session = store.load()
-
-    head_hash: str | None = None
-    head_resources: dict[str, str] = {}
-    head_release: str | None = None
-
-    try:
-        head = head_store._safe_get_head(session.channel)
-        if head and head.generation_hash:
-            head_hash = head.generation_hash
-            generation = gen_store.load(head.generation_hash)
-            for entry in generation.resources.entries:
-                head_resources[entry.server_id] = entry.snapshot_hash
-            if generation.release_pointer.snapshot_hash:
-                head_release = generation.release_pointer.snapshot_hash
-    except Exception:
-        pass
-
-    staged_resources: dict[str, str] = {}
-    for h in session.staged.resources:
-        try:
-            meta, _ = snap_store.load_resource_snapshot(h)
-            staged_resources[meta.server_id] = h
-        except Exception:
-            pass
-
-    added: list[str] = []
-    updated: list[str] = []
-    unchanged: list[str] = []
-    inherited: list[str] = []
-
-    staged_ids = set(staged_resources.keys())
-    head_ids = set(head_resources.keys())
-
-    for sid in staged_ids - head_ids:
-        added.append(staged_resources[sid])
-    for sid in staged_ids & head_ids:
-        if staged_resources[sid] != head_resources[sid]:
-            updated.append(staged_resources[sid])
-        else:
-            unchanged.append(staged_resources[sid])
-    for sid in head_ids - staged_ids:
-        inherited.append(head_resources[sid])
-
-    head_releases = {head_release} if head_release else set()
-    staged_releases = set(session.staged.releases)
-
-    return {
-        "channel": session.channel,
-        "head": head_hash,
-        "resources": {
-            "added": sorted(added),
-            "updated": sorted(updated),
-            "unchanged": sorted(unchanged),
-            "inherited": sorted(inherited),
-        },
-        "releases": {
-            "added": sorted(staged_releases - head_releases),
-            "updated": [],
-            "unchanged": sorted(staged_releases & head_releases),
-            "inherited": sorted(head_releases - staged_releases),
-        },
-    }
+    return _compute_diff(tmp_root, store.load())
 
 
 class TestSessionDiff:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session commit generation now correctly accumulates metadata from parent generations instead of creating isolated entries.

* **Changes**
  * Session diff output format updated: resources now categorized as **added**, **updated**, **inherited**, or **unchanged** (removed category no longer appears).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->