### PR TITLE
feat(history): implement per-server generation history and cross-generation revert foundation

### DIFF
--- a/bootstrap/cli/remote/lifecycle.py
+++ b/bootstrap/cli/remote/lifecycle.py
@@ -91,13 +91,20 @@ def register_remote_lifecycle(remote: click.Group) -> None:
         default=False,
         help="List what would be deleted without actually deleting.",
     )
+    @click.option(
+        "--retention-depth",
+        type=click.IntRange(min=0),
+        default=0,
+        show_default=True,
+        help="Ancestor generations kept per head (head-only = 0; head + last N = N).",
+    )
     @_SCHEMA_ROOT_OPTION
-    def remote_gc(dry_run: bool, schema_root: Path | None):
+    def remote_gc(dry_run: bool, retention_depth: int, schema_root: Path | None):
         """Garbage collect unreferenced entities from local V2 storage."""
         root = runtime.resolve_schema_root(schema_root)
         mgr = SessionManager(root)
 
-        deleted = mgr.gc(dry_run=dry_run)
+        deleted = mgr.gc(dry_run=dry_run, retention_depth=retention_depth)
 
         if dry_run:
             if not deleted:

--- a/bootstrap/cli/remote/session.py
+++ b/bootstrap/cli/remote/session.py
@@ -113,10 +113,24 @@ def _resolve_snapshot_hash_from_prefix(root: Path, snap_type: str, prefix: str) 
     )
 
 
-def _add_snapshot_by_hash(store: SessionStore, root: Path, snap_type: str, hash_value: str) -> None:
-    """Verify snapshot existence + metadata type, then stage."""
+def _add_snapshot_by_hash(
+    store: SessionStore,
+    root: Path,
+    snap_type: str,
+    hash_value: str,
+    *,
+    replace_hash: str | None = None,
+) -> None:
+    """Verify snapshot existence + metadata type, then stage.
+
+    When *snap_type* is ``"resource"``:
+      - If *replace_hash* is given, validates the replace target exists, its
+        server_id matches the new snapshot, and calls ``replace_snapshot``.
+      - Otherwise rejects the add if the server_id is already staged.
+    """
     from bootstrap.remote.paths import release_snapshot_dir
     from bootstrap.remote.paths import resource_snapshot_dir
+    from bootstrap.remote.snapshot import SnapshotStore
 
     dir_for_type = {
         "resource": resource_snapshot_dir,
@@ -126,7 +140,48 @@ def _add_snapshot_by_hash(store: SessionStore, root: Path, snap_type: str, hash_
     if not snap_dir.is_dir():
         raise click.ClickException(f"Snapshot {hash_value[:16]}... not found at {snap_dir}")
     _check_snapshot_metadata(snap_type, snap_dir)
-    store.add_snapshot(snap_type, hash_value)  # type: ignore[arg-type]
+
+    if snap_type == "resource":
+        snap_store = SnapshotStore(root)
+        meta, _ = snap_store.load_resource_snapshot(hash_value)
+        candidate_server_id = meta.server_id
+
+        session = store.load()
+        staged_ids = _staged_server_ids(root, session)
+
+        if replace_hash is not None:
+            if replace_hash not in session.staged.resources:
+                raise click.ClickException(
+                    f"Replace target {replace_hash[:16]}... is not currently staged."
+                )
+            replace_meta, _ = snap_store.load_resource_snapshot(replace_hash)
+            if replace_meta.server_id != candidate_server_id:
+                raise click.ClickException(
+                    f"Server mismatch: --replace targets server "
+                    f"'{replace_meta.server_id}' but new snapshot is for "
+                    f"server '{candidate_server_id}'."
+                )
+            store.replace_snapshot(replace_hash, hash_value)
+        else:
+            if candidate_server_id in staged_ids:
+                conflict = staged_ids[candidate_server_id]
+                raise click.ClickException(
+                    f"Server '{candidate_server_id}' already has a staged snapshot "
+                    f"({conflict[:16]}...) in this session. "
+                    "A session may stage at most one snapshot per server. "
+                    "Commit and release this session, then run "
+                    "`./x remote session init <channel>` to start a new "
+                    "session for the additional "
+                    f"'{candidate_server_id}' snapshot."
+                )
+            store.add_snapshot(
+                "resource",
+                hash_value,
+                server_id=candidate_server_id,
+                staged_server_ids=staged_ids,
+            )
+    else:
+        store.add_snapshot(snap_type, hash_value)  # type: ignore[arg-type]
 
 
 def _add_snapshot_by_file(
@@ -238,7 +293,47 @@ def _add_snapshot_by_file(
     else:
         raise click.ClickException(f"Unknown snapshot type: {snap_type}")
 
-    store.add_snapshot(snap_type, hash_value)  # type: ignore[arg-type]
+    if snap_type == "resource":
+        session = store.load()
+        staged_ids = _staged_server_ids(root, session)
+        candidate_server_id = metadata.server_id
+        if candidate_server_id in staged_ids:
+            conflict = staged_ids[candidate_server_id]
+            raise click.ClickException(
+                f"Server '{candidate_server_id}' already has a staged snapshot "
+                f"({conflict[:16]}...) in this session. "
+                "A session may stage at most one snapshot per server. "
+                "Commit and release this session, then run "
+                "`./x remote session init <channel>` to start a new "
+                "session for the additional "
+                f"'{candidate_server_id}' snapshot."
+            )
+        store.add_snapshot(
+            snap_type,
+            hash_value,
+            server_id=candidate_server_id,
+            staged_server_ids=staged_ids,
+        )
+    else:
+        store.add_snapshot(snap_type, hash_value)  # type: ignore[arg-type]
+
+
+def _staged_server_ids(root: Path, session: Session) -> dict[str, str]:
+    """Build a map of server_id → hash for all staged resource snapshots.
+
+    Skips unloadable hashes (same tolerance as _compute_diff).
+    """
+    from bootstrap.remote.snapshot import SnapshotStore
+
+    snap_store = SnapshotStore(root)
+    result: dict[str, str] = {}
+    for h in session.staged.resources:
+        try:
+            meta, _ = snap_store.load_resource_snapshot(h)
+            result[meta.server_id] = h
+        except Exception:
+            warning("Failed to load staged resource snapshot %s; omitted from server-id map", h)
+    return result
 
 
 def _get_snapshot_summary(root: Path, snap_type: str, hash_value: str) -> str:
@@ -294,10 +389,17 @@ def _compute_diff(root: Path, session: Session) -> dict:
         pass
 
     staged_resources: dict[str, str] = {}
+    duplicate_servers: dict[str, list[str]] = {}
     for h in session.staged.resources:
         try:
             meta, _ = snap_store.load_resource_snapshot(h)
-            staged_resources[meta.server_id] = h
+            if meta.server_id in staged_resources:
+                duplicate_servers.setdefault(meta.server_id, []).append(
+                    staged_resources[meta.server_id]
+                )
+                duplicate_servers[meta.server_id].append(h)
+            else:
+                staged_resources[meta.server_id] = h
         except Exception:
             warning("Failed to load staged resource snapshot %s; omitted from diff", h)
 
@@ -322,7 +424,7 @@ def _compute_diff(root: Path, session: Session) -> dict:
     head_releases = {head_release} if head_release else set()
     staged_releases = set(session.staged.releases)
 
-    return {
+    result: dict = {
         "channel": session.channel,
         "head": head_hash,
         "resources": {
@@ -338,6 +440,11 @@ def _compute_diff(root: Path, session: Session) -> dict:
             "inherited": sorted(head_releases - staged_releases),
         },
     }
+
+    if duplicate_servers:
+        result["duplicate_servers"] = duplicate_servers
+
+    return result
 
 
 def _check_staged_resource_blobs(root: Path, hash_value: str, issues: list) -> None:
@@ -404,9 +511,42 @@ def _check_staged_resource_blobs(root: Path, hash_value: str, issues: list) -> N
             )
 
 
+def _check_duplicate_server_ids(root: Path, session: Session, issues: list) -> None:
+    """Check for multiple staged resource snapshots with the same server_id.
+
+    Appends ``Issue`` (severity ``"error"``) for each duplicated server.
+    This is a hard gate — even ``--force`` must not bypass it.
+    """
+    from bootstrap.remote.snapshot import SnapshotStore
+    from bootstrap.remote.verify import Issue
+
+    snap_store = SnapshotStore(root)
+    seen: dict[str, str] = {}
+    for h in session.staged.resources:
+        try:
+            meta, _ = snap_store.load_resource_snapshot(h)
+        except Exception:
+            continue
+        if meta.server_id in seen:
+            issues.append(
+                Issue(
+                    entity=f"{meta.server_id}",
+                    entity_type="server_id",
+                    severity="error",
+                    message=(
+                        f"Duplicate server '{meta.server_id}' in staged resources: "
+                        f"{seen[meta.server_id][:12]}... and {h[:12]}... "
+                        "A session may stage at most one snapshot per server."
+                    ),
+                )
+            )
+        else:
+            seen[meta.server_id] = h
+
+
 def _verify_staged(root: Path, session: Session) -> list:
     """Validate staged snapshots across all four verification phases."""
-    from bootstrap.remote.hash import snapshot_hash as _snapshot_hash
+    from bootstrap.remote.hash import verify_snapshot_hash as _verify_snapshot_hash
     from bootstrap.remote.paths import release_snapshot_dir
     from bootstrap.remote.paths import resource_snapshot_dir
     from bootstrap.remote.verify import Issue
@@ -472,16 +612,14 @@ def _verify_staged(root: Path, session: Session) -> list:
                     "metadata.json": meta_path.read_bytes(),
                     proto_name: proto_path.read_bytes(),
                 }
-                computed = _snapshot_hash(snap_type, files)
-                if computed != h:
+                # Dual-read: accept either v4 (binds the .pb2 index) or legacy v3.
+                if not _verify_snapshot_hash(snap_type, files, h):
                     issues.append(
                         Issue(
                             entity=h[:12] + "...",
                             entity_type=f"{snap_type}_snapshot",
                             severity="error",
-                            message=(
-                                f"Hash mismatch: expected {h[:12]}..., computed {computed[:12]}..."
-                            ),
+                            message=f"Hash mismatch: {h[:12]}... does not verify (v4/v3)",
                         )
                     )
             except Exception as exc:
@@ -499,6 +637,8 @@ def _verify_staged(root: Path, session: Session) -> list:
                 snap_dir = dir_for_type[snap_type](root, h)
                 if snap_dir.is_dir() and (snap_dir / proto_name).is_file():
                     _check_staged_resource_blobs(root, h, issues)
+
+            _check_duplicate_server_ids(root, session, issues)
 
     try:
         from bootstrap.remote.head import ChannelHeadStore
@@ -766,6 +906,12 @@ def register_remote_session(remote: click.Group) -> None:
         help="File to compute snapshot hash from (checkout catalog, registry).",
     )
     @click.option("--force", is_flag=True, default=False, help="Add to a committed session.")
+    @click.option(
+        "--replace",
+        "replace_hash",
+        default=None,
+        help="Replace an existing staged snapshot hash (only for resources).",
+    )
     @_SCHEMA_ROOT_OPTION
     def remote_session_add(
         resource_flag: bool,
@@ -773,6 +919,7 @@ def register_remote_session(remote: click.Group) -> None:
         source_hash: str | None,
         source_file: Path | None,
         force: bool,
+        replace_hash: str | None,
         schema_root: Path | None,
     ):
         """Stage a snapshot for the next generation commit."""
@@ -787,12 +934,14 @@ def register_remote_session(remote: click.Group) -> None:
 
         if source_hash is not None:
             full_hash = _resolve_snapshot_hash_from_prefix(root, snap_type, source_hash)
-            _add_snapshot_by_hash(store, root, snap_type, full_hash)
+            _add_snapshot_by_hash(store, root, snap_type, full_hash, replace_hash=replace_hash)
             click.echo(
                 styled([Style.BRIGHT, Fore.GREEN], f"Staged {snap_type} snapshot ")
                 + f"{full_hash[:16]}..."
             )
         elif source_file is not None:
+            if replace_hash is not None:
+                raise click.ClickException("--replace is not supported with --file.")
             _add_snapshot_by_file(store, root, snap_type, source_file)
             click.echo(
                 styled([Style.BRIGHT, Fore.GREEN], f"Staged {snap_type} snapshot ")
@@ -994,6 +1143,18 @@ def register_remote_session(remote: click.Group) -> None:
                 raise click.ClickException(
                     "Verification failed. Use --force to skip or fix issues first."
                 )
+
+        dupe_issues: list = []
+        _check_duplicate_server_ids(root, session, dupe_issues)
+        if dupe_issues:
+            click.echo()
+            _print_issues(dupe_issues)
+            raise click.ClickException(
+                "Duplicate server IDs in staged resources. "
+                "This error cannot be bypassed with --force. "
+                "Use './x remote session remove <hash>' to correct the duplicates, "
+                "then run commit again."
+            )
 
         mgr = SessionManager(root)
         snap_store = mgr.snap_store

--- a/bootstrap/cli/remote/session.py
+++ b/bootstrap/cli/remote/session.py
@@ -181,6 +181,10 @@ def _add_snapshot_by_hash(
                 staged_server_ids=staged_ids,
             )
     else:
+        if replace_hash is not None:
+            raise click.ClickException(
+                "--replace is only supported for resource snapshots, not release snapshots."
+            )
         store.add_snapshot(snap_type, hash_value)  # type: ignore[arg-type]
 
 
@@ -394,10 +398,10 @@ def _compute_diff(root: Path, session: Session) -> dict:
         try:
             meta, _ = snap_store.load_resource_snapshot(h)
             if meta.server_id in staged_resources:
-                duplicate_servers.setdefault(meta.server_id, []).append(
-                    staged_resources[meta.server_id]
-                )
-                duplicate_servers[meta.server_id].append(h)
+                dupes = duplicate_servers.setdefault(meta.server_id, [])
+                if not dupes:
+                    dupes.append(staged_resources[meta.server_id])
+                dupes.append(h)
             else:
                 staged_resources[meta.server_id] = h
         except Exception:
@@ -526,6 +530,7 @@ def _check_duplicate_server_ids(root: Path, session: Session, issues: list) -> N
         try:
             meta, _ = snap_store.load_resource_snapshot(h)
         except Exception:
+            warning("Failed to load staged resource snapshot %s; omitted from duplicate check", h)
             continue
         if meta.server_id in seen:
             issues.append(

--- a/bootstrap/remote/__init__.py
+++ b/bootstrap/remote/__init__.py
@@ -197,8 +197,11 @@ class SessionManager:
 
     # --- Maintenance ---------------------------------------------------------
 
-    def gc(self, dry_run: bool = False) -> list[str]:
-        return self._gc.prune(dry_run=dry_run)
+    def gc(self, dry_run: bool = False, retention_depth: int = 0) -> list[str]:
+        collector = (
+            self._gc if retention_depth <= 0 else GarbageCollector(self.root, retention_depth)
+        )
+        return collector.prune(dry_run=dry_run)
 
     def verify(self) -> dict[str, list[Issue]]:
         return self._verifier.verify_all()

--- a/bootstrap/remote/gc.py
+++ b/bootstrap/remote/gc.py
@@ -119,10 +119,7 @@ class GarbageCollector:
         history_path = generation_dir(self.root, head_hash) / "history.pb2"
         if not history_path.is_file():
             return None
-        try:
-            return read_pb2(history_path, ServerHistory)
-        except Exception:
-            return None
+        return read_pb2(history_path, ServerHistory)
 
     def _head_hashes(self) -> set[str]:
         heads: set[str] = set()

--- a/bootstrap/remote/gc.py
+++ b/bootstrap/remote/gc.py
@@ -1,11 +1,17 @@
 """Garbage collection — reachability-based pruning of unreferenced entities.
 
-Reachability algorithm (spec §12):
-  1. Start from every channel head → collect all generationHash values.
-  2. For each head generation, walk parent chain → collect all reachable gens.
-  3. For each reachable generation, collect all snapshot hashes.
-  4. For each reachable resource snapshot, collect all blob (ident_hash, content_hash) pairs.
-  5. Delete everything not in the reachable set.
+Reachability algorithm (spec §8.1, §8.3):
+  1. Start from every channel head → load its `history.pb2`.
+  2. The head history is the authoritative reachability root for resource
+     snapshots: every `snapshot_hash` it records (and the snapshot's blobs) is
+     kept, decoupled from the generation that introduced it.
+  3. Generation retention is policy-driven: keep only the head + the last N
+     ancestor generations (``retention_depth``). Resource snapshots of pruned
+     generations survive solely via the history root from step 2.
+  4. Heads without a `history.pb2` (pre-feature, no feature-era commit yet)
+     fall back to the legacy full parent-chain walk so nothing is lost.
+  5. Delete everything not in the reachable set, then strip dead `history.pb2`
+     copies from retained non-head generations.
 """
 
 from __future__ import annotations
@@ -19,6 +25,7 @@ from bootstrap.remote.hash import ident_hash
 from bootstrap.remote.head import ChannelHeadStore
 from bootstrap.remote.models import ReachabilitySet
 from bootstrap.remote.models import read_pb2
+from bootstrap.remote.paths import generation_dir
 from bootstrap.remote.paths import resource_snapshot_dir
 
 
@@ -27,10 +34,17 @@ if TYPE_CHECKING:
 
 
 class GarbageCollector:
-    """Reachability-based GC for both local workspace and remote tiers."""
+    """Reachability-based GC for both local workspace and remote tiers.
 
-    def __init__(self, root: Path) -> None:
+    ``retention_depth`` is the number of ancestor (non-head) generations kept
+    per channel head, walked from the tip; the head itself is always kept, so a
+    head retains ``retention_depth + 1`` generations total. ``0`` (default)
+    keeps the head only.
+    """
+
+    def __init__(self, root: Path, retention_depth: int = 0) -> None:
         self.root = root
+        self.retention_depth = max(retention_depth, 0)
         self.gen_store = GenerationStore(root)
         self.head_store = ChannelHeadStore(root)
 
@@ -45,25 +59,82 @@ class GarbageCollector:
                 continue
             if not head.generation_hash:
                 continue
-
-            try:
-                for gen in self.gen_store.walk_parent_chain(head.generation_hash):
-                    reachable.generations.add(gen.hash)
-
-                    if gen.release_pointer.snapshot_hash:
-                        reachable.release_snapshots.add(gen.release_pointer.snapshot_hash)
-
-                    for entry in gen.resources.entries:
-                        snap_hash = entry.snapshot_hash
-                        if not snap_hash:
-                            continue
-                        reachable.resource_snapshots.add(snap_hash)
-                        self._collect_resource_blobs(snap_hash, reachable)
-
-            except FileNotFoundError:
-                continue
+            self._collect_for_head(head.generation_hash, reachable)
 
         return reachable
+
+    def _collect_for_head(self, head_hash: str, reachable: ReachabilitySet) -> None:
+        history = self._load_head_history(head_hash)
+        if history is None:
+            # §8.1 step 4: pre-feature head — legacy full parent-chain walk.
+            self._collect_full_chain(head_hash, reachable)
+            return
+
+        # §8.1: head history is the reachability root for resource snapshots and
+        # their blobs, decoupled from the introducing generation.
+        for server in history.servers:
+            for snap in server.snapshots:
+                if not snap.snapshot_hash:
+                    continue
+                reachable.resource_snapshots.add(snap.snapshot_hash)
+                self._collect_resource_blobs(snap.snapshot_hash, reachable)
+
+        # §8.3: retention policy — keep head + last N generations and their
+        # release snapshots. Pruned generations' resource snapshots survive via
+        # the history root above.
+        self._collect_retained_generations(head_hash, reachable)
+
+    def _collect_retained_generations(self, head_hash: str, reachable: ReachabilitySet) -> None:
+        keep = self.retention_depth + 1
+        try:
+            for idx, gen in enumerate(self.gen_store.walk_parent_chain(head_hash)):
+                if idx >= keep:
+                    break
+                reachable.generations.add(gen.hash)
+                if gen.release_pointer.snapshot_hash:
+                    reachable.release_snapshots.add(gen.release_pointer.snapshot_hash)
+        except FileNotFoundError:
+            pass
+
+    def _collect_full_chain(self, head_hash: str, reachable: ReachabilitySet) -> None:
+        try:
+            for gen in self.gen_store.walk_parent_chain(head_hash):
+                reachable.generations.add(gen.hash)
+
+                if gen.release_pointer.snapshot_hash:
+                    reachable.release_snapshots.add(gen.release_pointer.snapshot_hash)
+
+                for entry in gen.resources.entries:
+                    snap_hash = entry.snapshot_hash
+                    if not snap_hash:
+                        continue
+                    reachable.resource_snapshots.add(snap_hash)
+                    self._collect_resource_blobs(snap_hash, reachable)
+        except FileNotFoundError:
+            pass
+
+    def _load_head_history(self, head_hash: str):
+        from bootstrap.remote.models import ServerHistory
+
+        history_path = generation_dir(self.root, head_hash) / "history.pb2"
+        if not history_path.is_file():
+            return None
+        try:
+            return read_pb2(history_path, ServerHistory)
+        except Exception:
+            return None
+
+    def _head_hashes(self) -> set[str]:
+        heads: set[str] = set()
+        registry = self.head_store.get_registry()
+        for channel_name in registry.channels:
+            try:
+                head = self.head_store.get_head(channel_name)
+            except FileNotFoundError:
+                continue
+            if head.generation_hash:
+                heads.add(head.generation_hash)
+        return heads
 
     def _collect_resource_blobs(self, snap_hash: str, reachable: ReachabilitySet) -> None:
         from bootstrap.remote.models import ResourceIndex
@@ -81,6 +152,7 @@ class GarbageCollector:
 
     def prune(self, dry_run: bool = False) -> list[str]:
         reachable = self.collect_reachable()
+        head_hashes = self._head_hashes()
         deleted: list[str] = []
 
         deleted.extend(self._prune_entities("generations", reachable.generations, dry_run))
@@ -91,8 +163,28 @@ class GarbageCollector:
             self._prune_entities("release_snapshots", reachable.release_snapshots, dry_run)
         )
         deleted.extend(self._prune_blobs(reachable.blobs, dry_run))
+        deleted.extend(self._strip_nonhead_history(head_hashes, reachable.generations, dry_run))
         deleted.extend(self._prune_tmp_dirs(dry_run))
 
+        return deleted
+
+    def _strip_nonhead_history(
+        self,
+        head_hashes: set[str],
+        retained: set[str],
+        dry_run: bool,
+    ) -> list[str]:
+        """§8.2: only the head's `history.pb2` is ever read by clients; strip the
+        dead copies from retained non-head generations. Never touch a head."""
+        deleted: list[str] = []
+        for gen_hash in sorted(retained):
+            if gen_hash in head_hashes:
+                continue
+            history_path = generation_dir(self.root, gen_hash) / "history.pb2"
+            if history_path.is_file():
+                deleted.append(str(history_path))
+                if not dry_run:
+                    history_path.unlink(missing_ok=True)
         return deleted
 
     def _prune_entities(self, label: str, reachable_hashes: set[str], dry_run: bool) -> list[str]:

--- a/bootstrap/remote/generation.py
+++ b/bootstrap/remote/generation.py
@@ -1,7 +1,7 @@
 """Generation store — immutable generation CRUD and parent-chain walking.
 
-Generations are stored at channels/refs/{generation_hash}/ with four files:
-  metadata.json, server.pb2, resources.pb2, releases.pb2
+Generations are stored at channels/refs/{generation_hash}/ with five files:
+  metadata.json, server.pb2, resources.pb2, releases.pb2, history.pb2
 """
 
 from __future__ import annotations
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 
 from bootstrap.remote.hash import generation_hash as _compute_generation_hash
 from bootstrap.remote.models import GenerationMetadata
+from bootstrap.remote.models import make_server_history
+from bootstrap.remote.models import merge_generation_into_history
 from bootstrap.remote.models import read_json
 from bootstrap.remote.models import read_pb2
 from bootstrap.remote.models import write_json
@@ -55,7 +57,7 @@ class GenerationStore:
     ) -> str:
         """Create a generation atomically, returning its hash.
 
-        Writes all four files to a temp directory, computes the structured
+        Writes all five files to a temp directory, computes the structured
         generation hash, then renames to the final location.
         """
         temp_dir = temp_generation_dir(self.root)
@@ -73,6 +75,17 @@ class GenerationStore:
         }
 
         gen_hash = _compute_generation_hash(files)
+
+        parent_history = self._load_parent_history(metadata.parent)
+        merged = merge_generation_into_history(
+            parent_history,
+            generation_hash=gen_hash,
+            timestamp=metadata.timestamp,
+            resources=resources_msg,
+            server_index=server_index_msg,
+        )
+        write_pb2(temp_dir / "history.pb2", merged)
+
         target_dir = generation_dir(self.root, gen_hash)
 
         if not target_dir.exists():
@@ -132,6 +145,16 @@ class GenerationStore:
         gen_dir = generation_dir(self.root, gen_hash)
         if gen_dir.exists():
             shutil.rmtree(gen_dir, ignore_errors=True)
+
+    def _load_parent_history(self, parent_hash: str | None):
+        if not parent_hash:
+            return make_server_history()
+        from bootstrap.remote.models import ServerHistory
+
+        history_path = generation_dir(self.root, parent_hash) / "history.pb2"
+        if history_path.is_file():
+            return read_pb2(history_path, ServerHistory)
+        return make_server_history()
 
 
 def utc_timestamp() -> str:

--- a/bootstrap/remote/generation.py
+++ b/bootstrap/remote/generation.py
@@ -91,6 +91,9 @@ class GenerationStore:
         if not target_dir.exists():
             temp_dir.rename(target_dir)
         else:
+            history_path = temp_dir / "history.pb2"
+            if history_path.is_file():
+                shutil.copy2(history_path, target_dir / "history.pb2")
             shutil.rmtree(temp_dir, ignore_errors=True)
 
         return gen_hash

--- a/bootstrap/remote/hash.py
+++ b/bootstrap/remote/hash.py
@@ -1,12 +1,26 @@
-"""Structured hash engine for EFA V2/V3 schema.
+"""Structured hash engine for EFA V2/V3/V4 schema.
 
 Primitives:
   ident_hash(uri_string)  → SHA-256 hex of identifier URI
   content_hash(bytes)     → SHA-256 hex of raw bytes
 
-Structured hashes (v3 — only canonical JSON files are hashed):
-  snapshot_hash(type, files)  → "efa:{type}:v3\\n" + metadata.json hash
-  generation_hash(files)      → "efa:generation:v3\\n" + metadata.json hash
+Structured hashes:
+  v3 (legacy, metadata-only — still callable for reads/verification):
+    snapshot_hash(type, files)  → "efa:{type}:v3\\n" + metadata.json hash
+    generation_hash(files)      → "efa:generation:v3\\n" + metadata.json hash
+  v4 (canonical for new snapshots — also binds the typed .pb2 index, spec §7):
+    snapshot_hash_v4(type, files)
+      → "efa:{type}:v4\\n" + metadata.json hash + "\\n" + {proto}.pb2 hash
+
+Dual-read: ``verify_snapshot_hash`` accepts an entity addressed by either
+protocol (v4 preferred, v3 legacy fallback), enabling a greenfield migration
+where new commits are v4 while pre-existing v3 entities still verify (spec §7).
+
+Note: ``generation_hash`` intentionally remains v3. The v4 generation protocol
+(spec §7) would cover ``history.pb2``, but each generation's ``history.pb2``
+records the generation's own hash in its newest snapshot entries
+(``merge_generation_into_history``), making a v4 generation hash self-referential.
+That is deferred until the §5 revert feature mandates it.
 """
 
 from __future__ import annotations
@@ -18,6 +32,12 @@ from typing import Literal
 
 SnapshotType = Literal["resource", "release"]
 HASH_ALGORITHM = hashlib.sha256
+
+# Typed .pb2 index file bound into the v4 snapshot hash, per snapshot type.
+SNAPSHOT_PROTO_NAME: dict[SnapshotType, str] = {
+    "resource": "resources.pb2",
+    "release": "releases.pb2",
+}
 
 
 def ident_hash(uri_string: str) -> str:
@@ -57,6 +77,48 @@ def snapshot_hash(snapshot_type: SnapshotType, files: dict[str, bytes]) -> str:
     line = _file_hash("metadata.json", files["metadata.json"])
     payload = f"efa:{snapshot_type}:v3\n{line}\n"
     return HASH_ALGORITHM(payload.encode("utf-8")).hexdigest()
+
+
+def snapshot_hash_v4(snapshot_type: SnapshotType, files: dict[str, bytes]) -> str:
+    """Compute the v4 structured snapshot hash (spec §7).
+
+    The hash input binds both the canonical ``metadata.json`` and the typed
+    ``.pb2`` index file, so tampering with the resource/release index now
+    changes the address (v3 covered only ``metadata.json``):
+
+        "efa:{type}:v4\\n"
+        "metadata.json <sha256>\\n"
+        "{resources|releases}.pb2 <sha256>\\n"
+
+    Args:
+        snapshot_type: One of "resource", "release".
+        files: Dict containing at least "metadata.json" and the type's
+            ``.pb2`` index (``resources.pb2`` / ``releases.pb2``) → bytes.
+    """
+    proto_name = SNAPSHOT_PROTO_NAME[snapshot_type]
+    if "metadata.json" not in files:
+        raise ValueError("Missing required file: metadata.json")
+    if proto_name not in files:
+        raise ValueError(f"Missing required file: {proto_name}")
+    meta_line = _file_hash("metadata.json", files["metadata.json"])
+    proto_line = _file_hash(proto_name, files[proto_name])
+    payload = f"efa:{snapshot_type}:v4\n{meta_line}\n{proto_line}\n"
+    return HASH_ALGORITHM(payload.encode("utf-8")).hexdigest()
+
+
+def verify_snapshot_hash(
+    snapshot_type: SnapshotType, files: dict[str, bytes], expected: str
+) -> bool:
+    """Return whether ``expected`` matches this snapshot under v4 or legacy v3.
+
+    Dual-read for the greenfield migration (spec §7): new snapshots are v4, but
+    pre-existing v3-addressed snapshots must still verify. v4 is preferred when
+    the typed ``.pb2`` index is available; v3 is the metadata-only fallback.
+    """
+    proto_name = SNAPSHOT_PROTO_NAME[snapshot_type]
+    if proto_name in files and snapshot_hash_v4(snapshot_type, files) == expected:
+        return True
+    return snapshot_hash(snapshot_type, files) == expected
 
 
 def generation_hash(files: dict[str, bytes]) -> str:

--- a/bootstrap/remote/models.py
+++ b/bootstrap/remote/models.py
@@ -182,6 +182,7 @@ _PB2_ALIAS_MAP: dict[str, tuple[str, str]] = {
     "GenerationPointer": ("generation_pointer_pb2", "GenerationPointer"),
     "HeadReflog": ("head_reflog_pb2", "HeadReflog"),
     "CheckoutReflog": ("checkout_reflog_pb2", "CheckoutReflog"),
+    "ServerHistory": ("server_history_pb2", "ServerHistory"),
 }
 
 
@@ -245,6 +246,88 @@ def make_generation_resources(
         entry.server_id = sid
         entry.snapshot_hash = snap_hash
     return msg
+
+
+def make_server_history() -> ServerHistory:
+    msg = _load_pb2_type("ServerHistory")()
+    msg.schema_version = 1
+    return msg
+
+
+def _server_index_lookup(
+    server_index: ServerIndex,
+) -> dict[str, tuple[str, str]]:
+    """Build a {server_id: (game_build, game_version)} lookup."""
+    result: dict[str, tuple[str, str]] = {}
+    for entry in server_index.servers:
+        result[entry.server_id] = (entry.game_build, entry.game_version)
+    return result
+
+
+def merge_generation_into_history(
+    history: ServerHistory,
+    *,
+    generation_hash: str,
+    timestamp: str,
+    resources: GenerationResources,
+    server_index: ServerIndex,
+) -> ServerHistory:
+    """Merge one generation's resource changes into a ServerHistory.
+
+    Returns a *new* ServerHistory message. The original *history* is not
+    mutated. Servers not present in *resources* are carried forward unchanged.
+    Servers that are present get a new Snapshot prepended only when the
+    snapshot hash differs from the current head (or when the server has no
+    prior snapshots).
+    """
+    idx = _server_index_lookup(server_index)
+
+    existing: dict[str, ServerHistory.ServerEntry] = {}
+    for entry in history.servers:
+        existing[entry.server_id] = entry
+
+    result = make_server_history()
+
+    changed_ids: set[str] = set()
+
+    for res_entry in resources.entries:
+        sid = res_entry.server_id
+        snap_hash = res_entry.snapshot_hash
+        changed_ids.add(sid)
+
+        entry = result.servers.add()
+        entry.server_id = sid
+
+        old = existing.get(sid)
+
+        if old is not None and old.snapshots and old.snapshots[0].snapshot_hash == snap_hash:
+            for s in old.snapshots:
+                ns = entry.snapshots.add()
+                ns.CopyFrom(s)
+        else:
+            game_build, game_version = idx.get(sid, ("", ""))
+            ns = entry.snapshots.add()
+            ns.snapshot_hash = snap_hash
+            ns.generation_hash = generation_hash
+            ns.timestamp = timestamp
+            if game_build:
+                ns.game_build = game_build
+            if game_version:
+                ns.game_version = game_version
+            if old is not None:
+                for s in old.snapshots:
+                    ns2 = entry.snapshots.add()
+                    ns2.CopyFrom(s)
+
+    for sid, old in existing.items():
+        if sid not in changed_ids:
+            entry = result.servers.add()
+            entry.server_id = sid
+            for s in old.snapshots:
+                ns = entry.snapshots.add()
+                ns.CopyFrom(s)
+
+    return result
 
 
 def make_generation_pointer(snapshot_hash: str) -> GenerationPointer:

--- a/bootstrap/remote/session_model.py
+++ b/bootstrap/remote/session_model.py
@@ -29,6 +29,10 @@ class SessionExistsError(Exception):
     """Raised when init is called but a session already exists."""
 
 
+class SessionDuplicateServerError(Exception):
+    """Raised when staging a second resource snapshot for an already-staged server."""
+
+
 class StagedSnapshots(BaseModel):
     resources: list[str] = Field(default_factory=list)
     releases: list[str] = Field(default_factory=list)
@@ -160,15 +164,71 @@ class SessionStore:
         if self.is_committed():
             raise SessionManagerCommittedError("Session is committed. Use --force to override.")
 
-    def add_snapshot(self, snap_type: SnapshotType, hash_value: str) -> Session:
-        """Stage a snapshot hash. Raises SessionManagerCommittedError if committed."""
+    def add_snapshot(
+        self,
+        snap_type: SnapshotType,
+        hash_value: str,
+        *,
+        server_id: str | None = None,
+        staged_server_ids: dict[str, str] | None = None,
+    ) -> Session:
+        """Stage a snapshot hash.
+
+        When *snap_type* is ``"resource"`` and *server_id* and
+        *staged_server_ids* are both supplied, rejects the operation if
+        *server_id* is already present in *staged_server_ids* (defense-in-depth
+        — the CLI is expected to have already performed this check).
+
+        Raises SessionManagerCommittedError if committed.
+        Raises SessionDuplicateServerError on per-server duplicate.
+        """
         self.ensure_editable()
         session = self.load()
         staged = session.staged
+        if (
+            snap_type == "resource"
+            and server_id is not None
+            and staged_server_ids is not None
+            and server_id in staged_server_ids
+        ):
+            conflict = staged_server_ids[server_id]
+            raise SessionDuplicateServerError(
+                f"Server '{server_id}' already has a staged snapshot "
+                f"({conflict[:16]}...) in this session."
+            )
+
         if snap_type == "resource":
             staged.resources.append(hash_value)
         elif snap_type == "release":
             staged.releases.append(hash_value)
+        self.save(session)
+        return session
+
+    def replace_snapshot(
+        self,
+        old_hash: str,
+        new_hash: str,
+        *,
+        snap_type: SnapshotType = "resource",
+    ) -> Session:
+        """Atomically replace a staged snapshot hash with a new one.
+
+        Raises ValueError if *old_hash* is not currently staged.
+        Server-ID matching is expected to be validated by the caller.
+        """
+        self.ensure_editable()
+        session = self.load()
+        staged = session.staged
+        if snap_type == "resource":
+            if old_hash not in staged.resources:
+                raise ValueError(f"Replace target {old_hash} is not currently staged as resource.")
+            idx = staged.resources.index(old_hash)
+            staged.resources[idx] = new_hash
+        elif snap_type == "release":
+            if old_hash not in staged.releases:
+                raise ValueError(f"Replace target {old_hash} is not currently staged as release.")
+            idx = staged.releases.index(old_hash)
+            staged.releases[idx] = new_hash
         self.save(session)
         return session
 

--- a/bootstrap/remote/snapshot.py
+++ b/bootstrap/remote/snapshot.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Literal
 
-from bootstrap.remote.hash import snapshot_hash as _compute_snapshot_hash
+from bootstrap.remote.hash import snapshot_hash_v4 as _compute_snapshot_hash
 from bootstrap.remote.models import ReleaseSnapshotMetadata
 from bootstrap.remote.models import ResourceSnapshotMetadata
 from bootstrap.remote.models import read_json
@@ -131,9 +131,11 @@ class SnapshotStore:
         write_json(temp_dir / "metadata.json", metadata)
         write_pb2(temp_dir / proto_name, index_msg)
 
-        metadata_bytes = (temp_dir / "metadata.json").read_bytes()
-
-        files = {"metadata.json": metadata_bytes}
+        # v4 binds both metadata.json and the typed .pb2 index (spec §7).
+        files = {
+            "metadata.json": (temp_dir / "metadata.json").read_bytes(),
+            proto_name: (temp_dir / proto_name).read_bytes(),
+        }
         snap_hash = _compute_snapshot_hash(snap_type, files)
 
         target_dir = dir_map[snap_type](self.root, snap_hash)

--- a/bootstrap/remote/verify.py
+++ b/bootstrap/remote/verify.py
@@ -346,6 +346,17 @@ class Verifier:
                 for res_entry in resources.entries:
                     resources_map[res_entry.server_id] = res_entry.snapshot_hash
 
+                history_server_ids = {hist_entry.server_id for hist_entry in history.servers}
+                for server_id in sorted(set(resources_map) - history_server_ids):
+                    issues.append(
+                        Issue(
+                            entity=gen_hash[:12] + "...",
+                            entity_type="history",
+                            severity="warning",
+                            message=f"Server {server_id!r}: resources entry missing from history",
+                        )
+                    )
+
                 for hist_entry in history.servers:
                     if not hist_entry.snapshots:
                         continue
@@ -390,7 +401,15 @@ class Verifier:
         for channel_name in registry.channels:
             try:
                 head = self.head_store.get_head(channel_name)
-            except Exception:
+            except Exception as exc:
+                issues.append(
+                    Issue(
+                        entity=channel_name,
+                        entity_type="channel",
+                        severity="error",
+                        message=f"Failed to load head: {exc}",
+                    )
+                )
                 continue
 
             if not head.generation_hash:

--- a/bootstrap/remote/verify.py
+++ b/bootstrap/remote/verify.py
@@ -10,10 +10,13 @@ Verification levels (spec workflow.md §3.7):
 
 from __future__ import annotations
 
+import json
 import shutil
 
 from dataclasses import dataclass
 from pathlib import Path
+
+from pydantic import ValidationError
 
 from bootstrap.remote.generation import GenerationStore
 from bootstrap.remote.hash import SNAPSHOT_PROTO_NAME as _SNAPSHOT_PROTO_NAME
@@ -80,7 +83,7 @@ class Verifier:
 
             try:
                 head = self.head_store.get_head(channel_name)
-            except Exception as exc:
+            except (FileNotFoundError, json.JSONDecodeError, ValidationError) as exc:
                 issues.append(
                     Issue(
                         entity=channel_name,
@@ -222,8 +225,9 @@ class Verifier:
                 files = {"metadata.json": meta_path.read_bytes()}
                 proto_name = _SNAPSHOT_PROTO_NAME[snap_type]  # type: ignore[index]
                 proto_path = snap_dir / proto_name
-                if proto_path.is_file():
-                    files[proto_name] = proto_path.read_bytes()
+                if not proto_path.is_file():
+                    raise FileNotFoundError(f"Missing snapshot index: {proto_path}")
+                files[proto_name] = proto_path.read_bytes()
 
                 # Dual-read: accept either v4 (binds the .pb2 index) or legacy v3.
                 if not _verify_snapshot_hash(snap_type, files, expected):  # type: ignore[arg-type]
@@ -401,7 +405,7 @@ class Verifier:
         for channel_name in registry.channels:
             try:
                 head = self.head_store.get_head(channel_name)
-            except Exception as exc:
+            except (FileNotFoundError, json.JSONDecodeError, ValidationError) as exc:
                 issues.append(
                     Issue(
                         entity=channel_name,

--- a/bootstrap/remote/verify.py
+++ b/bootstrap/remote/verify.py
@@ -16,16 +16,18 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from bootstrap.remote.generation import GenerationStore
+from bootstrap.remote.hash import SNAPSHOT_PROTO_NAME as _SNAPSHOT_PROTO_NAME
 from bootstrap.remote.hash import content_hash as _content_hash
 from bootstrap.remote.hash import generation_hash as _generation_hash
 from bootstrap.remote.hash import ident_hash as _ident_hash
-from bootstrap.remote.hash import snapshot_hash as _snapshot_hash
+from bootstrap.remote.hash import verify_snapshot_hash as _verify_snapshot_hash
 from bootstrap.remote.head import ChannelHeadStore
 from bootstrap.remote.models import read_pb2 as _models_read_pb2
 from bootstrap.remote.paths import blob_path
 from bootstrap.remote.paths import generation_dir
 from bootstrap.remote.paths import head_metadata_path
 from bootstrap.remote.paths import head_reflog_path
+from bootstrap.remote.paths import resource_snapshot_dir
 
 
 @dataclass
@@ -53,6 +55,8 @@ class Verifier:
             "generations": self.verify_generation_integrity(),
             "snapshots": self.verify_snapshot_integrity(),
             "blobs": self.verify_blob_integrity(),
+            "history": self.verify_history_consistency(),
+            "history_reachability": self.verify_history_reachability(),
         }
 
     # --- Head integrity ------------------------------------------------------
@@ -216,17 +220,19 @@ class Verifier:
                     raise FileNotFoundError(f"Missing file: {meta_path}")
 
                 files = {"metadata.json": meta_path.read_bytes()}
-                computed = _snapshot_hash(snap_type, files)  # type: ignore[arg-type]
-                if computed != expected:
+                proto_name = _SNAPSHOT_PROTO_NAME[snap_type]  # type: ignore[index]
+                proto_path = snap_dir / proto_name
+                if proto_path.is_file():
+                    files[proto_name] = proto_path.read_bytes()
+
+                # Dual-read: accept either v4 (binds the .pb2 index) or legacy v3.
+                if not _verify_snapshot_hash(snap_type, files, expected):  # type: ignore[arg-type]
                     issues.append(
                         Issue(
                             entity=expected[:12] + "...",
                             entity_type=f"{snap_type}_snapshot",
                             severity="error",
-                            message=(
-                                f"Hash mismatch: expected {expected[:12]}..."
-                                f", computed {computed[:12]}..."
-                            ),
+                            message=f"Hash mismatch: {expected[:12]}... does not verify (v4/v3)",
                         )
                     )
             except Exception as exc:
@@ -302,6 +308,139 @@ class Verifier:
                             message=str(exc),
                         )
                     )
+
+        return issues
+
+    # --- History consistency (§4.3) -----------------------------------------
+
+    def verify_history_consistency(self) -> list[Issue]:
+        """Check that each generation's `history.pb2` newest snapshots match its
+        `resources.pb2`. Warnings only — does not block."""
+        issues: list[Issue] = []
+        refs_dir = self.root / "channels" / "refs"
+        if not refs_dir.is_dir():
+            return issues
+
+        from bootstrap.remote.models import GenerationResources
+        from bootstrap.remote.models import ServerHistory
+
+        for entry in sorted(refs_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            if entry.name.startswith("tmp"):
+                continue
+            if not (entry / "metadata.json").is_file():
+                continue
+
+            history_path = entry / "history.pb2"
+            resources_path = entry / "resources.pb2"
+            if not history_path.is_file() or not resources_path.is_file():
+                continue
+
+            gen_hash = entry.name
+            try:
+                history = _models_read_pb2(history_path, ServerHistory)
+                resources = _models_read_pb2(resources_path, GenerationResources)
+
+                resources_map: dict[str, str] = {}
+                for res_entry in resources.entries:
+                    resources_map[res_entry.server_id] = res_entry.snapshot_hash
+
+                for hist_entry in history.servers:
+                    if not hist_entry.snapshots:
+                        continue
+                    newest_hash = hist_entry.snapshots[0].snapshot_hash
+                    res_hash = resources_map.get(hist_entry.server_id)
+                    if res_hash is not None and newest_hash != res_hash:
+                        issues.append(
+                            Issue(
+                                entity=gen_hash[:12] + "...",
+                                entity_type="history",
+                                severity="warning",
+                                message=(
+                                    f"Server {hist_entry.server_id!r}: history"
+                                    f" newest {newest_hash[:12]}..."
+                                    f" != resources {res_hash[:12]}..."
+                                ),
+                            )
+                        )
+            except Exception as exc:
+                issues.append(
+                    Issue(
+                        entity=gen_hash[:12] + "...",
+                        entity_type="history",
+                        severity="warning",
+                        message=str(exc),
+                    )
+                )
+
+        return issues
+
+    # --- History reachability (§8.5) ----------------------------------------
+
+    def verify_history_reachability(self) -> list[Issue]:
+        """For each channel head, verify every `snapshot_hash` in the head's
+        `history.pb2` resolves to an existing resource-snapshot directory.
+        Missing → error (blocks verify exit)."""
+        issues: list[Issue] = []
+        registry = self.head_store.get_registry()
+
+        from bootstrap.remote.models import ServerHistory
+
+        for channel_name in registry.channels:
+            try:
+                head = self.head_store.get_head(channel_name)
+            except Exception:
+                continue
+
+            if not head.generation_hash:
+                continue
+
+            gen_dir = generation_dir(self.root, head.generation_hash)
+            history_path = gen_dir / "history.pb2"
+            if not history_path.is_file():
+                issues.append(
+                    Issue(
+                        entity=channel_name,
+                        entity_type="history_reachability",
+                        severity="warning",
+                        message=(
+                            f"Head generation {head.generation_hash[:12]}..."
+                            " has no history.pb2 (run backfill-history)"
+                        ),
+                    )
+                )
+                continue
+
+            try:
+                history = _models_read_pb2(history_path, ServerHistory)
+            except Exception as exc:
+                issues.append(
+                    Issue(
+                        entity=head.generation_hash[:12] + "...",
+                        entity_type="history_reachability",
+                        severity="error",
+                        message=f"Failed to read history.pb2: {exc}",
+                    )
+                )
+                continue
+
+            for hist_entry in history.servers:
+                for snap in hist_entry.snapshots:
+                    snap_dir = resource_snapshot_dir(self.root, snap.snapshot_hash)
+                    if not snap_dir.is_dir() or not (snap_dir / "resources.pb2").is_file():
+                        issues.append(
+                            Issue(
+                                entity=snap.snapshot_hash[:12] + "...",
+                                entity_type="history_reachability",
+                                severity="error",
+                                message=(
+                                    f"Snapshot {snap.snapshot_hash[:12]}..."
+                                    f" (server {hist_entry.server_id!r})"
+                                    f" not found at {snap_dir}"
+                                ),
+                            )
+                        )
 
         return issues
 

--- a/bootstrap/tests/test_gc_history.py
+++ b/bootstrap/tests/test_gc_history.py
@@ -1,0 +1,227 @@
+"""Tests for GC stage 05 — history reachability root, non-head history
+stripping, and generation-retention policy (spec §8.1, §8.2, §8.3)."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+from pathlib import Path
+
+import pytest
+
+from bootstrap.remote.blob import BlobStore
+from bootstrap.remote.gc import GarbageCollector
+from bootstrap.remote.generation import GenerationStore
+from bootstrap.remote.hash import content_hash
+from bootstrap.remote.hash import ident_hash
+from bootstrap.remote.head import ChannelHeadStore
+from bootstrap.remote.models import GenerationMetadata
+from bootstrap.remote.models import GenerationPointer
+from bootstrap.remote.models import GenerationResources
+from bootstrap.remote.models import ResourceSnapshotMetadata
+from bootstrap.remote.models import ServerIndex
+from bootstrap.remote.models import make_resource_index
+from bootstrap.remote.paths import generation_dir
+from bootstrap.remote.paths import resource_snapshot_dir
+from bootstrap.remote.snapshot import SnapshotStore
+
+
+@pytest.fixture
+def tmp_root() -> Path:
+    d = tempfile.mkdtemp(prefix="efa-gc-hist-")
+    yield Path(d)
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _make_resource_snapshot(
+    snap_store: SnapshotStore,
+    blob_store: BlobStore,
+    server_id: str,
+    tag: str,
+) -> tuple[str, str, str]:
+    rid = f"resource://{server_id}/{tag}.bin"
+    ihash = ident_hash(rid)
+    data = f"blob-{server_id}-{tag}".encode()
+    chash = content_hash(data)
+    meta = ResourceSnapshotMetadata(
+        serverId=server_id,
+        gameBuild=f"build-{tag}",
+        gameVersion=f"v{tag}",
+        resourceCount=1,
+        createdAt="2026-06-14T12:00:00Z",
+        description=tag,
+    )
+    index = make_resource_index([(rid, chash, len(data))])
+    snap_hash = snap_store.create_resource_snapshot(meta, index)
+    blob_store.store(data, ihash)
+    return snap_hash, ihash, chash
+
+
+def _create_generation(
+    gen_store: GenerationStore,
+    server_id: str,
+    snap_hash: str,
+    parent: str | None,
+    ts: str,
+) -> str:
+    gen_meta = GenerationMetadata(channel="testing", timestamp=ts, parent=parent)
+
+    server_index = ServerIndex()
+    server_index.schema_version = 1
+    srv = server_index.servers.add()
+    srv.server_id = server_id
+    srv.game_build = "1.0.0"
+    srv.game_version = "v1.0.0"
+
+    resources = GenerationResources()
+    resources.schema_version = 1
+    r = resources.entries.add()
+    r.server_id = server_id
+    r.snapshot_hash = snap_hash
+
+    release_ptr = GenerationPointer()
+    release_ptr.schema_version = 1
+    release_ptr.snapshot_hash = ""
+
+    return gen_store.create(
+        metadata=gen_meta,
+        server_index_msg=server_index,
+        resources_msg=resources,
+        release_pointer=release_ptr,
+    )
+
+
+def _build_chain(
+    tmp_root: Path,
+    n: int,
+    server_id: str = "tranquility",
+) -> list[tuple[str, str, str, str]]:
+    """Build *n* generations in a parent chain (oldest first), advancing the
+    head to the tip. Returns ``(gen_hash, snap_hash, ident_hash, content_hash)``
+    per generation in creation order (head last)."""
+    snap_store = SnapshotStore(tmp_root)
+    blob_store = BlobStore(tmp_root)
+    gen_store = GenerationStore(tmp_root)
+    head_store = ChannelHeadStore(tmp_root)
+    head_store.ensure_channel("testing")
+
+    gens: list[tuple[str, str, str, str]] = []
+    parent: str | None = None
+    for i in range(n):
+        tag = f"{i:02d}"
+        snap_hash, ihash, chash = _make_resource_snapshot(snap_store, blob_store, server_id, tag)
+        gen_hash = _create_generation(
+            gen_store, server_id, snap_hash, parent, f"2026-06-14T12:00:{tag}Z"
+        )
+        head_store.push("testing", gen_hash)
+        parent = gen_hash
+        gens.append((gen_hash, snap_hash, ihash, chash))
+    return gens
+
+
+def _remaining_generations(tmp_root: Path) -> set[str]:
+    refs = tmp_root / "channels" / "refs"
+    return {d.name for d in refs.iterdir() if d.is_dir() and not d.name.startswith("tmp")}
+
+
+class TestHistoryReachabilityRoot:
+    def test_snapshot_survives_introducer_removal(self, tmp_root: Path) -> None:
+        """§8.1: a snapshot listed in head history stays reachable even when its
+        introducing generation is removed."""
+        gens = _build_chain(tmp_root, 2)
+        (g1, s1, ih1, ch1), (_g2, s2, _ih2, _ch2) = gens
+
+        shutil.rmtree(generation_dir(tmp_root, g1))
+
+        reachable = GarbageCollector(tmp_root).collect_reachable()
+
+        assert s1 in reachable.resource_snapshots
+        assert s2 in reachable.resource_snapshots
+        assert (ih1, ch1) in reachable.blobs
+
+    def test_no_history_head_falls_back_to_full_chain(self, tmp_root: Path) -> None:
+        """§8.1 step 4 / §8.3 test 4: a pre-feature head (no history.pb2) falls
+        back to the full parent-chain walk so nothing is wrongly pruned."""
+        gens = _build_chain(tmp_root, 2)
+        head_hash = gens[1][0]
+        (generation_dir(tmp_root, head_hash) / "history.pb2").unlink()
+
+        gc = GarbageCollector(tmp_root)
+        reachable = gc.collect_reachable()
+
+        assert gens[0][0] in reachable.generations
+        assert gens[1][0] in reachable.generations
+        assert gens[0][1] in reachable.resource_snapshots
+        assert gens[1][1] in reachable.resource_snapshots
+
+        gc.prune()
+        assert generation_dir(tmp_root, gens[0][0]).is_dir()
+        assert generation_dir(tmp_root, gens[1][0]).is_dir()
+
+
+class TestNonHeadHistoryStripping:
+    def test_strip_nonhead_history(self, tmp_root: Path) -> None:
+        """§8.2: after prune only head generations retain history.pb2; non-head
+        retained generations do not; dry_run lists but does not delete."""
+        gens = _build_chain(tmp_root, 3)
+        g_old, g_mid, g_head = gens[0][0], gens[1][0], gens[2][0]
+
+        gc = GarbageCollector(tmp_root, retention_depth=2)  # keep all three
+
+        deleted = gc.prune(dry_run=True)
+        for g in (g_mid, g_old):
+            path = generation_dir(tmp_root, g) / "history.pb2"
+            assert str(path) in deleted
+            assert path.is_file()
+
+        gc.prune()
+        assert (generation_dir(tmp_root, g_head) / "history.pb2").is_file()
+        for g in (g_mid, g_old):
+            assert not (generation_dir(tmp_root, g) / "history.pb2").is_file()
+            assert generation_dir(tmp_root, g).is_dir()
+
+
+class TestRetentionPolicy:
+    def test_head_only_prunes_intermediates_keeps_snapshots(self, tmp_root: Path) -> None:
+        """§8.3 test 1: head-only policy prunes intermediate generations while
+        every snapshot in head history (and its blobs) stays reachable."""
+        gens = _build_chain(tmp_root, 3)
+        gc = GarbageCollector(tmp_root)  # head-only
+
+        reachable = gc.collect_reachable()
+        for _g, s, ih, ch in gens:
+            assert s in reachable.resource_snapshots
+            assert (ih, ch) in reachable.blobs
+
+        gc.prune()
+        assert _remaining_generations(tmp_root) == {gens[-1][0]}
+        for _g, s, _ih, _ch in gens:
+            assert resource_snapshot_dir(tmp_root, s).is_dir()
+
+    def test_head_plus_n_retains_n_plus_one(self, tmp_root: Path) -> None:
+        """§8.3 test 2: head + last N keeps exactly N+1 generations."""
+        gens = _build_chain(tmp_root, 4)
+        GarbageCollector(tmp_root, retention_depth=1).prune()
+
+        remaining = _remaining_generations(tmp_root)
+        assert len(remaining) == 2
+        assert gens[-1][0] in remaining
+        assert gens[-2][0] in remaining
+        assert gens[0][0] not in remaining
+
+    def test_orphan_pruned_history_snapshot_kept(self, tmp_root: Path) -> None:
+        """§8.3 test 3: a snapshot referenced only by a pruned generation but
+        present in head history is kept; one referenced by neither is pruned."""
+        gens = _build_chain(tmp_root, 2)
+        snap_store = SnapshotStore(tmp_root)
+        blob_store = BlobStore(tmp_root)
+        orphan, _oih, _och = _make_resource_snapshot(snap_store, blob_store, "tranquility", "zz")
+
+        GarbageCollector(tmp_root).prune()  # head-only
+
+        # gen0 is pruned, but its snapshot lives on in the head history.
+        assert gens[0][0] not in _remaining_generations(tmp_root)
+        assert resource_snapshot_dir(tmp_root, gens[0][1]).is_dir()
+        # the orphan is referenced by neither a generation nor the history.
+        assert not resource_snapshot_dir(tmp_root, orphan).is_dir()

--- a/bootstrap/tests/test_schema_v2.py
+++ b/bootstrap/tests/test_schema_v2.py
@@ -659,10 +659,18 @@ class TestGenerationStore:
         assert len(history.servers[0].snapshots) == 1
         assert history.servers[0].snapshots[0].generation_hash == child
 
-    def test_history_deterministic(self, gen_store: GenerationStore) -> None:
-        gen1 = self._make_two_server_gen(gen_store)
-        gen2 = self._make_two_server_gen(gen_store)
-        assert gen1 == gen2
+    def test_history_deterministic(self, gen_store: GenerationStore, tmp_root: Path) -> None:
+        root2 = Path(tempfile.mkdtemp(prefix="efa-test-"))
+        try:
+            gen_store2 = GenerationStore(root2)
+            gen1 = self._make_two_server_gen(gen_store)
+            gen2 = self._make_two_server_gen(gen_store2)
+            assert gen1 == gen2
+            h1 = self._load_history(gen_store, gen1)
+            h2 = self._load_history(gen_store2, gen2)
+            assert h1.SerializeToString() == h2.SerializeToString()
+        finally:
+            shutil.rmtree(root2, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------

--- a/bootstrap/tests/test_schema_v2.py
+++ b/bootstrap/tests/test_schema_v2.py
@@ -27,8 +27,10 @@ from bootstrap.remote.models import GenerationResources
 from bootstrap.remote.models import ReachabilitySet
 from bootstrap.remote.models import ReleaseSnapshotMetadata
 from bootstrap.remote.models import ResourceSnapshotMetadata
+from bootstrap.remote.models import ServerHistory
 from bootstrap.remote.models import ServerIndex
 from bootstrap.remote.models import make_resource_index
+from bootstrap.remote.models import read_pb2
 from bootstrap.remote.paths import blob_path
 from bootstrap.remote.paths import generation_dir
 from bootstrap.remote.paths import resource_snapshot_dir
@@ -450,6 +452,217 @@ class TestGenerationStore:
         assert (gen_dir / "server.pb2").is_file()
         assert (gen_dir / "resources.pb2").is_file()
         assert (gen_dir / "releases.pb2").is_file()
+        assert (gen_dir / "history.pb2").is_file()
+
+    def _load_history(self, gen_store: GenerationStore, gen_hash: str) -> ServerHistory:
+        gen_dir = generation_dir(gen_store.root, gen_hash)
+        return read_pb2(gen_dir / "history.pb2", ServerHistory)
+
+    def _make_two_server_gen(self, gen_store: GenerationStore, **kwargs) -> str:
+        meta = GenerationMetadata(
+            channel="testing",
+            timestamp="2026-06-14T12:00:00Z",
+            **kwargs,
+        )
+        server_index = ServerIndex()
+        server_index.schema_version = 1
+        s1 = server_index.servers.add()
+        s1.server_id = "tranquility"
+        s1.game_build = "1.0.0"
+        s1.game_version = "v1.0.0"
+        s2 = server_index.servers.add()
+        s2.server_id = "serenity"
+        s2.game_build = "2.0.0"
+        s2.game_version = "v2.0.0"
+
+        resources = GenerationResources()
+        resources.schema_version = 1
+        r1 = resources.entries.add()
+        r1.server_id = "tranquility"
+        r1.snapshot_hash = "aa" * 32
+        r2 = resources.entries.add()
+        r2.server_id = "serenity"
+        r2.snapshot_hash = "bb" * 32
+
+        release_ptr = GenerationPointer()
+        release_ptr.schema_version = 1
+        release_ptr.snapshot_hash = "cc" * 32
+
+        return gen_store.create(
+            metadata=meta,
+            server_index_msg=server_index,
+            resources_msg=resources,
+            release_pointer=release_ptr,
+        )
+
+    def test_history_first_gen_has_all_servers(self, gen_store: GenerationStore) -> None:
+        gen_hash = self._make_two_server_gen(gen_store)
+        history = self._load_history(gen_store, gen_hash)
+        assert len(history.servers) == 2
+        sid_map = {e.server_id: e for e in history.servers}
+        assert "tranquility" in sid_map
+        assert "serenity" in sid_map
+
+        for sid in ("tranquility", "serenity"):
+            snaps = sid_map[sid].snapshots
+            assert len(snaps) == 1
+            assert snaps[0].snapshot_hash == ("aa" * 32 if sid == "tranquility" else "bb" * 32)
+            assert snaps[0].generation_hash == gen_hash
+            assert snaps[0].timestamp == "2026-06-14T12:00:00Z"
+
+    def test_history_second_gen_prepends_changed_server(self, gen_store: GenerationStore) -> None:
+        parent = self._make_two_server_gen(gen_store)
+
+        meta = GenerationMetadata(
+            channel="testing",
+            timestamp="2026-06-15T12:00:00Z",
+            parent=parent,
+        )
+        server_index = ServerIndex()
+        server_index.schema_version = 1
+        s1 = server_index.servers.add()
+        s1.server_id = "tranquility"
+        s1.game_build = "1.0.0"
+        s1.game_version = "v1.0.0"
+        s2 = server_index.servers.add()
+        s2.server_id = "serenity"
+        s2.game_build = "2.0.0"
+        s2.game_version = "v2.0.0"
+
+        resources = GenerationResources()
+        resources.schema_version = 1
+        r1 = resources.entries.add()
+        r1.server_id = "tranquility"
+        r1.snapshot_hash = "dd" * 32  # changed
+        r2 = resources.entries.add()
+        r2.server_id = "serenity"
+        r2.snapshot_hash = "bb" * 32  # unchanged
+
+        release_ptr = GenerationPointer()
+        release_ptr.schema_version = 1
+        release_ptr.snapshot_hash = "ee" * 32
+
+        child = gen_store.create(
+            metadata=meta,
+            server_index_msg=server_index,
+            resources_msg=resources,
+            release_pointer=release_ptr,
+        )
+        history = self._load_history(gen_store, child)
+        sid_map = {e.server_id: e for e in history.servers}
+        assert len(sid_map["tranquility"].snapshots) == 2
+
+        # tranquility: newest first
+        snaps_t = sid_map["tranquility"].snapshots
+        assert snaps_t[0].snapshot_hash == "dd" * 32
+        assert snaps_t[0].generation_hash == child
+        assert snaps_t[1].snapshot_hash == "aa" * 32
+        assert snaps_t[1].generation_hash == parent
+
+        # serenity: unchanged, single entry carried forward
+        snaps_s = sid_map["serenity"].snapshots
+        assert len(snaps_s) == 1
+        assert snaps_s[0].snapshot_hash == "bb" * 32
+        assert snaps_s[0].generation_hash == parent
+
+    def test_history_noop_gen_no_prepends(self, gen_store: GenerationStore) -> None:
+        parent = self._make_two_server_gen(gen_store)
+
+        meta = GenerationMetadata(
+            channel="testing",
+            timestamp="2026-06-16T12:00:00Z",
+            parent=parent,
+        )
+        server_index = ServerIndex()
+        server_index.schema_version = 1
+        s1 = server_index.servers.add()
+        s1.server_id = "tranquility"
+        s1.game_build = "1.0.0"
+        s1.game_version = "v1.0.0"
+        s2 = server_index.servers.add()
+        s2.server_id = "serenity"
+        s2.game_build = "2.0.0"
+        s2.game_version = "v2.0.0"
+
+        resources = GenerationResources()
+        resources.schema_version = 1
+        r1 = resources.entries.add()
+        r1.server_id = "tranquility"
+        r1.snapshot_hash = "aa" * 32  # same as parent
+        r2 = resources.entries.add()
+        r2.server_id = "serenity"
+        r2.snapshot_hash = "bb" * 32  # same as parent
+
+        release_ptr = GenerationPointer()
+        release_ptr.schema_version = 1
+        release_ptr.snapshot_hash = "cc" * 32
+
+        child = gen_store.create(
+            metadata=meta,
+            server_index_msg=server_index,
+            resources_msg=resources,
+            release_pointer=release_ptr,
+        )
+        history = self._load_history(gen_store, child)
+        for entry in history.servers:
+            assert len(entry.snapshots) == 1
+
+    def test_history_game_build_version_match(self, gen_store: GenerationStore) -> None:
+        gen_hash = self._make_two_server_gen(gen_store)
+        history = self._load_history(gen_store, gen_hash)
+        sid_map = {e.server_id: e for e in history.servers}
+        t_snap = sid_map["tranquility"].snapshots[0]
+        assert t_snap.game_build == "1.0.0"
+        assert t_snap.game_version == "v1.0.0"
+        s_snap = sid_map["serenity"].snapshots[0]
+        assert s_snap.game_build == "2.0.0"
+        assert s_snap.game_version == "v2.0.0"
+
+    def test_history_parent_missing_pb2_still_succeeds(
+        self, gen_store: GenerationStore, tmp_root: Path
+    ) -> None:
+        parent = self._make_two_server_gen(gen_store)
+        gen_dir = generation_dir(tmp_root, parent)
+        (gen_dir / "history.pb2").unlink()
+
+        meta = GenerationMetadata(
+            channel="testing",
+            timestamp="2026-06-17T12:00:00Z",
+            parent=parent,
+        )
+        server_index = ServerIndex()
+        server_index.schema_version = 1
+        s1 = server_index.servers.add()
+        s1.server_id = "tranquility"
+        s1.game_build = "1.0.0"
+        s1.game_version = "v1.0.0"
+
+        resources = GenerationResources()
+        resources.schema_version = 1
+        r1 = resources.entries.add()
+        r1.server_id = "tranquility"
+        r1.snapshot_hash = "dd" * 32
+
+        release_ptr = GenerationPointer()
+        release_ptr.schema_version = 1
+        release_ptr.snapshot_hash = "ee" * 32
+
+        child = gen_store.create(
+            metadata=meta,
+            server_index_msg=server_index,
+            resources_msg=resources,
+            release_pointer=release_ptr,
+        )
+        history = self._load_history(gen_store, child)
+        assert len(history.servers) == 1
+        assert history.servers[0].server_id == "tranquility"
+        assert len(history.servers[0].snapshots) == 1
+        assert history.servers[0].snapshots[0].generation_hash == child
+
+    def test_history_deterministic(self, gen_store: GenerationStore) -> None:
+        gen1 = self._make_two_server_gen(gen_store)
+        gen2 = self._make_two_server_gen(gen_store)
+        assert gen1 == gen2
 
 
 # ---------------------------------------------------------------------------

--- a/bootstrap/tests/test_server_history.py
+++ b/bootstrap/tests/test_server_history.py
@@ -1,0 +1,256 @@
+"""Tests for ServerHistory protobuf — schema, round-trip, and merge logic."""
+
+from __future__ import annotations
+
+from bootstrap.remote.models import GenerationResources
+from bootstrap.remote.models import ServerHistory
+from bootstrap.remote.models import ServerIndex
+from bootstrap.remote.models import make_server_history
+from bootstrap.remote.models import merge_generation_into_history
+
+
+def _server_index(
+    *servers: tuple[str, str, str],
+) -> ServerIndex:
+    idx = ServerIndex()
+    idx.schema_version = 1
+    for sid, build, version in servers:
+        e = idx.servers.add()
+        e.server_id = sid
+        e.game_build = build
+        e.game_version = version
+    return idx
+
+
+def _generation_resources(
+    *mappings: tuple[str, str],
+) -> GenerationResources:
+    res = GenerationResources()
+    res.schema_version = 1
+    for sid, snap_hash in mappings:
+        e = res.entries.add()
+        e.server_id = sid
+        e.snapshot_hash = snap_hash
+    return res
+
+
+class TestServerHistoryRoundTrip:
+    def test_empty_round_trip(self) -> None:
+        h = make_server_history()
+        data = h.SerializeToString()
+        h2 = ServerHistory()
+        h2.ParseFromString(data)
+        assert h2.schema_version == 1
+        assert len(h2.servers) == 0
+
+    def test_with_one_entry_round_trip(self) -> None:
+        h = make_server_history()
+        e = h.servers.add()
+        e.server_id = "tranquility"
+        s = e.snapshots.add()
+        s.snapshot_hash = "aa" * 32
+        s.generation_hash = "bb" * 32
+        s.timestamp = "2026-06-14T12:00:00Z"
+        s.game_build = "1.0.0"
+        s.game_version = "v1.0.0"
+
+        data = h.SerializeToString()
+        h2 = ServerHistory()
+        h2.ParseFromString(data)
+        assert h2.schema_version == 1
+        assert len(h2.servers) == 1
+        assert h2.servers[0].server_id == "tranquility"
+        assert len(h2.servers[0].snapshots) == 1
+        assert h2.servers[0].snapshots[0].snapshot_hash == "aa" * 32
+        assert h2.servers[0].snapshots[0].generation_hash == "bb" * 32
+        assert h2.servers[0].snapshots[0].timestamp == "2026-06-14T12:00:00Z"
+        assert h2.servers[0].snapshots[0].game_build == "1.0.0"
+        assert h2.servers[0].snapshots[0].game_version == "v1.0.0"
+
+
+class TestMergeGenerationIntoHistory:
+    def test_from_empty_creates_one_snapshot(self) -> None:
+        history = make_server_history()
+        resources = _generation_resources(("tranquility", "aa" * 32))
+        server_index = _server_index(
+            ("tranquility", "1.0.0", "v1.0.0"),
+        )
+
+        result = merge_generation_into_history(
+            history,
+            generation_hash="gen001",
+            timestamp="2026-06-14T12:00:00Z",
+            resources=resources,
+            server_index=server_index,
+        )
+
+        assert len(result.servers) == 1
+        assert result.servers[0].server_id == "tranquility"
+        assert len(result.servers[0].snapshots) == 1
+        snap = result.servers[0].snapshots[0]
+        assert snap.snapshot_hash == "aa" * 32
+        assert snap.generation_hash == "gen001"
+        assert snap.timestamp == "2026-06-14T12:00:00Z"
+        assert snap.game_build == "1.0.0"
+        assert snap.game_version == "v1.0.0"
+
+    def test_merge_same_snapshot_is_noop(self) -> None:
+        history = make_server_history()
+        resources = _generation_resources(("tranquility", "aa" * 32))
+        server_index = _server_index(("tranquility", "1.0.0", "v1.0.0"))
+
+        result1 = merge_generation_into_history(
+            history,
+            generation_hash="gen001",
+            timestamp="2026-06-14T12:00:00Z",
+            resources=resources,
+            server_index=server_index,
+        )
+
+        result2 = merge_generation_into_history(
+            result1,
+            generation_hash="gen002",
+            timestamp="2026-06-15T12:00:00Z",
+            resources=resources,
+            server_index=server_index,
+        )
+
+        assert len(result2.servers) == 1
+        assert len(result2.servers[0].snapshots) == 1
+        assert result2.servers[0].snapshots[0].snapshot_hash == "aa" * 32
+        assert result2.servers[0].snapshots[0].generation_hash == "gen001"
+
+    def test_merge_changed_snapshot_prepends(self) -> None:
+        history = make_server_history()
+        resources1 = _generation_resources(("tranquility", "aa" * 32))
+        server_index = _server_index(("tranquility", "1.0.0", "v1.0.0"))
+
+        result1 = merge_generation_into_history(
+            history,
+            generation_hash="gen001",
+            timestamp="2026-06-14T12:00:00Z",
+            resources=resources1,
+            server_index=server_index,
+        )
+
+        resources2 = _generation_resources(("tranquility", "bb" * 32))
+        result2 = merge_generation_into_history(
+            result1,
+            generation_hash="gen002",
+            timestamp="2026-06-15T12:00:00Z",
+            resources=resources2,
+            server_index=server_index,
+        )
+
+        assert len(result2.servers) == 1
+        snaps = result2.servers[0].snapshots
+        assert len(snaps) == 2
+        assert snaps[0].snapshot_hash == "bb" * 32
+        assert snaps[0].generation_hash == "gen002"
+        assert snaps[0].timestamp == "2026-06-15T12:00:00Z"
+        assert snaps[1].snapshot_hash == "aa" * 32
+        assert snaps[1].generation_hash == "gen001"
+        assert snaps[1].timestamp == "2026-06-14T12:00:00Z"
+
+    def test_server_absent_carried_forward(self) -> None:
+        history = make_server_history()
+        resources1 = _generation_resources(("tranquility", "aa" * 32))
+        server_index = _server_index(
+            ("tranquility", "1.0.0", "v1.0.0"),
+            ("serenity", "2.0.0", "v2.0.0"),
+        )
+
+        result1 = merge_generation_into_history(
+            history,
+            generation_hash="gen001",
+            timestamp="2026-06-14T12:00:00Z",
+            resources=resources1,
+            server_index=server_index,
+        )
+
+        resources2 = _generation_resources(("serenity", "bb" * 32))
+        result2 = merge_generation_into_history(
+            result1,
+            generation_hash="gen002",
+            timestamp="2026-06-15T12:00:00Z",
+            resources=resources2,
+            server_index=server_index,
+        )
+
+        assert len(result2.servers) == 2
+        found = {e.server_id: e for e in result2.servers}
+        assert len(found["tranquility"].snapshots) == 1
+        assert found["tranquility"].snapshots[0].snapshot_hash == "aa" * 32
+        assert len(found["serenity"].snapshots) == 1
+        assert found["serenity"].snapshots[0].snapshot_hash == "bb" * 32
+
+    def test_game_build_version_from_server_index(self) -> None:
+        history = make_server_history()
+        resources = _generation_resources(("tranquility", "aa" * 32))
+        server_index = _server_index(
+            ("tranquility", "1.5.0", "v2026.1"),
+        )
+
+        result = merge_generation_into_history(
+            history,
+            generation_hash="gen001",
+            timestamp="2026-06-14T12:00:00Z",
+            resources=resources,
+            server_index=server_index,
+        )
+
+        snap = result.servers[0].snapshots[0]
+        assert snap.game_build == "1.5.0"
+        assert snap.game_version == "v2026.1"
+
+    def test_original_history_not_mutated(self) -> None:
+        history = make_server_history()
+        resources = _generation_resources(("tranquility", "aa" * 32))
+        server_index = _server_index(("tranquility", "1.0.0", "v1.0.0"))
+
+        merge_generation_into_history(
+            history,
+            generation_hash="gen001",
+            timestamp="2026-06-14T12:00:00Z",
+            resources=resources,
+            server_index=server_index,
+        )
+
+        assert len(history.servers) == 0
+
+    def test_multi_server_merge(self) -> None:
+        history = make_server_history()
+        res1 = _generation_resources(
+            ("tranquility", "aa" * 32),
+            ("serenity", "bb" * 32),
+        )
+        si = _server_index(
+            ("tranquility", "1.0.0", "v1.0.0"),
+            ("serenity", "1.0.0", "v1.0.0"),
+        )
+        result1 = merge_generation_into_history(
+            history,
+            generation_hash="gen001",
+            timestamp="2026-06-14T12:00:00Z",
+            resources=res1,
+            server_index=si,
+        )
+        assert len(result1.servers) == 2
+        assert len(result1.servers[0].snapshots) == 1
+        assert len(result1.servers[1].snapshots) == 1
+
+        res2 = _generation_resources(("serenity", "cc" * 32))
+        result2 = merge_generation_into_history(
+            result1,
+            generation_hash="gen002",
+            timestamp="2026-06-15T12:00:00Z",
+            resources=res2,
+            server_index=si,
+        )
+        # tranquility unchanged, serenity gets prepended
+        found = {e.server_id: e for e in result2.servers}
+        assert len(found["tranquility"].snapshots) == 1
+        assert found["tranquility"].snapshots[0].snapshot_hash == "aa" * 32
+        assert len(found["serenity"].snapshots) == 2
+        assert found["serenity"].snapshots[0].snapshot_hash == "cc" * 32
+        assert found["serenity"].snapshots[1].snapshot_hash == "bb" * 32

--- a/bootstrap/tests/test_session_cli.py
+++ b/bootstrap/tests/test_session_cli.py
@@ -15,13 +15,14 @@ import tempfile
 
 from pathlib import Path
 
+import click
 import pytest
 
 from bootstrap.remote import SessionManager
 from bootstrap.remote.generation import utc_timestamp
 from bootstrap.remote.hash import content_hash as _content_hash
 from bootstrap.remote.hash import ident_hash
-from bootstrap.remote.hash import snapshot_hash as _snapshot_hash
+from bootstrap.remote.hash import verify_snapshot_hash as _verify_snapshot_hash
 from bootstrap.remote.head import ChannelHeadStore
 from bootstrap.remote.models import GenerationMetadata
 from bootstrap.remote.models import GenerationPointer
@@ -586,15 +587,15 @@ def _verify_staged_style(tmp_root: Path, store: SessionStore) -> list[Issue]:
             try:
                 files = {
                     "metadata.json": meta_path.read_bytes(),
+                    proto_name: proto_path.read_bytes(),
                 }
-                computed = _snapshot_hash(snap_type, files)
-                if computed != h:
+                if not _verify_snapshot_hash(snap_type, files, h):
                     issues.append(
                         Issue(
                             entity=h[:12] + "...",
                             entity_type=f"{snap_type}_snapshot",
                             severity="error",
-                            message=f"Hash mismatch: expected {h[:12]}..., computed {computed[:12]}...",
+                            message=f"Hash mismatch: {h[:12]}... does not verify (v4/v3)",
                         )
                     )
             except Exception as exc:
@@ -1415,3 +1416,106 @@ class TestSessionCommitAccumulation:
         assert res_b in diff["resources"]["inherited"]
         assert len(diff["resources"]["updated"]) == 0
         assert len(diff["resources"]["unchanged"]) == 0
+
+
+# ===========================================================================
+# 12. One-snapshot-per-server enforcement
+# ===========================================================================
+
+
+class TestSessionOneSnapshotPerServer:
+    """Enforcement: a session may stage at most one resource per server_id."""
+
+    def test_add_rejects_second_snapshot_same_server(
+        self, store: SessionStore, tmp_root: Path
+    ) -> None:
+        """add --hash of a second snapshot for the same server_id raises."""
+        _init_session(store)
+        res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        store.add_snapshot("resource", res_a)
+
+        from bootstrap.cli.remote.session import _add_snapshot_by_hash
+
+        with pytest.raises(click.ClickException, match="already has a staged snapshot"):
+            _add_snapshot_by_hash(store, tmp_root, "resource", res_b)
+
+    def test_add_replace_valid_swap(self, store: SessionStore, tmp_root: Path) -> None:
+        """add --replace <hash> of same server_id succeeds."""
+        _init_session(store)
+        res_a = _make_resource_snapshot(tmp_root, server_id="tranquility", game_build="11111")
+        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility", game_build="22222")
+        store.add_snapshot("resource", res_a)
+
+        from bootstrap.cli.remote.session import _add_snapshot_by_hash
+
+        _add_snapshot_by_hash(store, tmp_root, "resource", res_b, replace_hash=res_a)
+        session = store.load()
+        assert res_b in session.staged.resources
+        assert res_a not in session.staged.resources
+
+    def test_add_replace_wrong_hash_raises(self, store: SessionStore, tmp_root: Path) -> None:
+        """add --replace <wrong-hash> where target is not staged raises."""
+        _init_session(store)
+        res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility")
+
+        from bootstrap.cli.remote.session import _add_snapshot_by_hash
+
+        with pytest.raises(click.ClickException, match="not currently staged"):
+            _add_snapshot_by_hash(store, tmp_root, "resource", res_b, replace_hash=res_a)
+
+    def test_add_replace_server_mismatch_raises(self, store: SessionStore, tmp_root: Path) -> None:
+        """add --replace where replace-target server differs from new raises."""
+        _init_session(store)
+        res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        res_b = _make_resource_snapshot(tmp_root, server_id="serenity")
+        store.add_snapshot("resource", res_a)
+
+        from bootstrap.cli.remote.session import _add_snapshot_by_hash
+
+        with pytest.raises(click.ClickException, match="Server mismatch"):
+            _add_snapshot_by_hash(store, tmp_root, "resource", res_b, replace_hash=res_a)
+
+    def test_diff_reports_duplicate_servers(self, store: SessionStore, tmp_root: Path) -> None:
+        """diff includes duplicate_servers when staged hashes collide on server_id."""
+        _init_session(store)
+        res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        store.add_snapshot("resource", res_a)
+
+        from bootstrap.cli.remote.session import _compute_diff
+
+        session = store.load()
+        diff = _compute_diff(tmp_root, session)
+        assert "duplicate_servers" not in diff
+
+        session.staged.resources.append(res_b)
+        store.save(session)
+        diff = _compute_diff(tmp_root, store.load())
+        assert "duplicate_servers" in diff
+        assert "tranquility" in diff["duplicate_servers"]
+
+    def test_check_duplicate_server_ids_detects_collision(
+        self, store: SessionStore, tmp_root: Path
+    ) -> None:
+        """_check_duplicate_server_ids appends error Issue for duplicated server_id."""
+        _init_session(store)
+        res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        store.add_snapshot("resource", res_a)
+
+        from bootstrap.cli.remote.session import _check_duplicate_server_ids
+
+        session = store.load()
+        issues: list[Issue] = []
+        _check_duplicate_server_ids(tmp_root, session, issues)
+        assert len(issues) == 0
+
+        session.staged.resources.append(res_b)
+        store.save(session)
+        issues = []
+        _check_duplicate_server_ids(tmp_root, store.load(), issues)
+        assert len(issues) == 1
+        assert issues[0].severity == "error"
+        assert "Duplicate server" in issues[0].message

--- a/bootstrap/tests/test_session_cli.py
+++ b/bootstrap/tests/test_session_cli.py
@@ -1432,7 +1432,7 @@ class TestSessionOneSnapshotPerServer:
         """add --hash of a second snapshot for the same server_id raises."""
         _init_session(store)
         res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
-        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility", game_build="22222")
         store.add_snapshot("resource", res_a)
 
         from bootstrap.cli.remote.session import _add_snapshot_by_hash
@@ -1481,7 +1481,7 @@ class TestSessionOneSnapshotPerServer:
         """diff includes duplicate_servers when staged hashes collide on server_id."""
         _init_session(store)
         res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
-        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility", game_build="22222")
         store.add_snapshot("resource", res_a)
 
         from bootstrap.cli.remote.session import _compute_diff
@@ -1502,7 +1502,7 @@ class TestSessionOneSnapshotPerServer:
         """_check_duplicate_server_ids appends error Issue for duplicated server_id."""
         _init_session(store)
         res_a = _make_resource_snapshot(tmp_root, server_id="tranquility")
-        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility")
+        res_b = _make_resource_snapshot(tmp_root, server_id="tranquility", game_build="22222")
         store.add_snapshot("resource", res_a)
 
         from bootstrap.cli.remote.session import _check_duplicate_server_ids

--- a/bootstrap/tests/test_session_model.py
+++ b/bootstrap/tests/test_session_model.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from bootstrap.remote import SessionManagerInvalidError
 from bootstrap.remote.session_model import Session
+from bootstrap.remote.session_model import SessionDuplicateServerError
 from bootstrap.remote.session_model import SessionExistsError
 from bootstrap.remote.session_model import SessionStore
 
@@ -288,3 +289,64 @@ class TestSessionStore:
         store.remove_snapshot("resource", "dup")
         session = store.load()
         assert session.staged.resources == ["dup"]
+
+    # --- server-id dedup + replace_snapshot tests -----------------------------
+
+    def test_add_snapshot_rejects_duplicate_server_id(self, tmp_path: pytest.fixture) -> None:
+        store = SessionStore(tmp_path)
+        store.init(channel="testing")
+        store.add_snapshot("resource", "aaa")
+        with pytest.raises(SessionDuplicateServerError, match="already has a staged snapshot"):
+            store.add_snapshot(
+                "resource",
+                "bbb",
+                server_id="tranquility",
+                staged_server_ids={"tranquility": "aaa"},
+            )
+
+    def test_add_snapshot_ok_with_different_server_id(self, tmp_path: pytest.fixture) -> None:
+        store = SessionStore(tmp_path)
+        store.init(channel="testing")
+        store.add_snapshot("resource", "aaa")
+        store.add_snapshot(
+            "resource",
+            "bbb",
+            server_id="serenity",
+            staged_server_ids={"tranquility": "aaa"},
+        )
+        session = store.load()
+        assert session.staged.resources == ["aaa", "bbb"]
+
+    def test_add_snapshot_no_server_id_check_when_not_provided(
+        self, tmp_path: pytest.fixture
+    ) -> None:
+        store = SessionStore(tmp_path)
+        store.init(channel="testing")
+        store.add_snapshot("resource", "aaa")
+        store.add_snapshot("resource", "bbb")
+        session = store.load()
+        assert session.staged.resources == ["aaa", "bbb"]
+
+    def test_replace_snapshot_swaps_in_place(self, tmp_path: pytest.fixture) -> None:
+        store = SessionStore(tmp_path)
+        store.init(channel="testing")
+        store.add_snapshot("resource", "aaa")
+        store.add_snapshot("resource", "bbb")
+        store.replace_snapshot("aaa", "ccc")
+        session = store.load()
+        assert session.staged.resources == ["ccc", "bbb"]
+
+    def test_replace_snapshot_raises_on_unstaged_old_hash(self, tmp_path: pytest.fixture) -> None:
+        store = SessionStore(tmp_path)
+        store.init(channel="testing")
+        store.add_snapshot("resource", "aaa")
+        with pytest.raises(ValueError, match="not currently staged"):
+            store.replace_snapshot("missing", "ccc")
+
+    def test_replace_snapshot_works_for_release(self, tmp_path: pytest.fixture) -> None:
+        store = SessionStore(tmp_path)
+        store.init(channel="testing")
+        store.add_snapshot("release", "rrr")
+        store.replace_snapshot("rrr", "sss", snap_type="release")
+        session = store.load()
+        assert session.staged.releases == ["sss"]

--- a/bootstrap/tests/test_verify.py
+++ b/bootstrap/tests/test_verify.py
@@ -6,12 +6,24 @@ import tempfile
 
 from pathlib import Path
 
+from bootstrap.remote.generation import GenerationMetadata
+from bootstrap.remote.generation import GenerationStore
 from bootstrap.remote.hash import content_hash
 from bootstrap.remote.hash import ident_hash
 from bootstrap.remote.hash import snapshot_hash
+from bootstrap.remote.hash import snapshot_hash_v4
+from bootstrap.remote.hash import verify_snapshot_hash
+from bootstrap.remote.head import ChannelHeadStore
 from bootstrap.remote.models import ResourceIndex
 from bootstrap.remote.models import ResourceSnapshotMetadata
+from bootstrap.remote.models import make_generation_pointer
+from bootstrap.remote.models import make_generation_resources
+from bootstrap.remote.models import make_server_index
+from bootstrap.remote.models import read_pb2
+from bootstrap.remote.models import write_pb2
 from bootstrap.remote.paths import blob_path
+from bootstrap.remote.paths import generation_dir
+from bootstrap.remote.paths import resource_snapshot_dir
 from bootstrap.remote.snapshot import SnapshotStore
 from bootstrap.remote.verify import Verifier
 
@@ -136,3 +148,215 @@ class TestSnapshotHash:
         h1 = snapshot_hash("resource", files)
         h2 = snapshot_hash("resource", files)
         assert h1 == h2
+
+
+class TestSnapshotHashV4:
+    """v4 binds the typed .pb2 index in addition to metadata.json (spec §7)."""
+
+    _META = b'{"schemaVersion":1,"serverId":"test"}'
+    _PROTO = b"\x08\x01proto-index-bytes"
+
+    def test_deterministic_and_hex(self):
+        files = {"metadata.json": self._META, "resources.pb2": self._PROTO}
+        h1 = snapshot_hash_v4("resource", files)
+        h2 = snapshot_hash_v4("resource", files)
+        assert h1 == h2
+        assert len(h1) == 64
+        assert all(c in "0123456789abcdef" for c in h1)
+
+    def test_known_value_parity(self):
+        # Cross-language parity anchor: a payload built from fixed component
+        # hashes must produce the same digest as the Dart mirror.
+        from bootstrap.remote.hash import HASH_ALGORITHM
+
+        a, b = "a" * 64, "b" * 64
+        resource = HASH_ALGORITHM(
+            f"efa:resource:v4\nmetadata.json {a}\nresources.pb2 {b}\n".encode()
+        ).hexdigest()
+        release = HASH_ALGORITHM(
+            f"efa:release:v4\nmetadata.json {a}\nreleases.pb2 {b}\n".encode()
+        ).hexdigest()
+        assert resource == "a76dfbcd80a9457f09b32241c7a9b239de581d1db784786279e59b90a3891c69"
+        assert release == "8e3558913730e810d6bcf65fe1ae9b6a859f4166976cc69e94dc60953ee665cd"
+
+    def test_v4_differs_from_v3(self):
+        files = {"metadata.json": self._META, "resources.pb2": self._PROTO}
+        assert snapshot_hash_v4("resource", files) != snapshot_hash("resource", files)
+
+    def test_tampering_proto_changes_v4_but_not_v3(self):
+        base = {"metadata.json": self._META, "resources.pb2": self._PROTO}
+        tampered = {"metadata.json": self._META, "resources.pb2": self._PROTO + b"!"}
+        # v4 is sensitive to the index; v3 (metadata-only) is not.
+        assert snapshot_hash_v4("resource", base) != snapshot_hash_v4("resource", tampered)
+        assert snapshot_hash("resource", base) == snapshot_hash("resource", tampered)
+
+    def test_missing_proto_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            snapshot_hash_v4("resource", {"metadata.json": self._META})
+
+    def test_domain_separation_between_types(self):
+        files = {"metadata.json": self._META}
+        res = snapshot_hash_v4("resource", {**files, "resources.pb2": self._PROTO})
+        rel = snapshot_hash_v4("release", {**files, "releases.pb2": self._PROTO})
+        assert res != rel
+
+    def test_verify_dual_read_accepts_v4_and_v3(self):
+        files = {"metadata.json": self._META, "resources.pb2": self._PROTO}
+        v4 = snapshot_hash_v4("resource", files)
+        v3 = snapshot_hash("resource", files)
+        assert verify_snapshot_hash("resource", files, v4)
+        assert verify_snapshot_hash("resource", files, v3)
+        assert not verify_snapshot_hash("resource", files, "0" * 64)
+
+    def test_verify_v3_only_when_proto_absent(self):
+        files = {"metadata.json": self._META}
+        v3 = snapshot_hash("resource", files)
+        assert verify_snapshot_hash("resource", files, v3)
+
+
+class TestSnapshotStoreV4RoundTrip:
+    """Snapshots created by SnapshotStore are v4-addressed and verify cleanly."""
+
+    def test_create_then_verify(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            snap_store = SnapshotStore(root)
+
+            index = ResourceIndex()
+            index.schema_version = 1
+            entry = index.entries.add()
+            entry.resource_id = "resource://test/file.bin"
+            entry.content_hash = "a" * 64
+            entry.size = 1
+
+            meta = ResourceSnapshotMetadata(
+                serverId="test",
+                gameBuild="1.0",
+                gameVersion="Test",
+                resourceCount=1,
+                createdAt="2026-01-01T00:00:00Z",
+            )
+            snap_hash = snap_store.create_resource_snapshot(meta, index)
+
+            snap_dir = resource_snapshot_dir(root, snap_hash)
+            files = {
+                "metadata.json": (snap_dir / "metadata.json").read_bytes(),
+                "resources.pb2": (snap_dir / "resources.pb2").read_bytes(),
+            }
+            # Directory name is the v4 hash.
+            assert snapshot_hash_v4("resource", files) == snap_hash
+            assert verify_snapshot_hash("resource", files, snap_hash)
+
+            verifier = Verifier(root)
+            assert verifier.verify_snapshot_integrity() == []
+
+
+class TestVerifierHistory:
+    """Tests for history consistency (§4.3) and reachability (§8.5)."""
+
+    _SERVER_ID = "test-server"
+
+    def _setup(self, root: Path, server_id: str | None = None) -> tuple[str, str]:
+        sid = server_id or self._SERVER_ID
+        snap_store = SnapshotStore(root)
+
+        meta = ResourceSnapshotMetadata(
+            serverId=sid,
+            gameBuild="1.0",
+            gameVersion="1.0",
+            resourceCount=0,
+            createdAt="2026-01-01T00:00:00Z",
+        )
+        index = ResourceIndex()
+        index.schema_version = 1
+        snap_hash = snap_store.create_resource_snapshot(meta, index)
+
+        gen_store = GenerationStore(root)
+        gen_meta = GenerationMetadata(
+            channel="stable",
+            timestamp="2026-01-01T00:00:00Z",
+        )
+        server_index = make_server_index(
+            [
+                (sid, {"en": "Test"}, "1.0", "1.0", "", "", ""),
+            ]
+        )
+        resources = make_generation_resources([(sid, snap_hash)])
+        release_ptr = make_generation_pointer("0" * 64)
+        gen_hash = gen_store.create(gen_meta, server_index, resources, release_ptr)
+
+        head_store = ChannelHeadStore(root)
+        head_store.ensure_channel("stable")
+        head_store.push("stable", gen_hash)
+
+        return snap_hash, gen_hash
+
+    # -- History consistency (§4.3) --
+
+    def test_consistent_history(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._setup(root)
+            verifier = Verifier(root)
+            issues = verifier.verify_history_consistency()
+            assert len(issues) == 0
+
+    def test_tampered_history(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _snap_hash, gen_hash = self._setup(root)
+
+            from bootstrap.remote.models import ServerHistory
+
+            history_path = generation_dir(root, gen_hash) / "history.pb2"
+            history = read_pb2(history_path, ServerHistory)
+            history.servers[0].snapshots[0].snapshot_hash = "a" * 64
+            write_pb2(history_path, history)
+
+            verifier = Verifier(root)
+            issues = verifier.verify_history_consistency()
+            assert len(issues) == 1
+            assert issues[0].entity_type == "history"
+            assert issues[0].severity == "warning"
+
+    # -- Head history reachability (§8.5) --
+
+    def test_reachable_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._setup(root)
+            verifier = Verifier(root)
+            issues = verifier.verify_history_reachability()
+            assert len(issues) == 0
+
+    def test_deleted_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            snap_hash, _gen_hash = self._setup(root)
+
+            import shutil
+
+            shutil.rmtree(resource_snapshot_dir(root, snap_hash))
+
+            verifier = Verifier(root)
+            issues = verifier.verify_history_reachability()
+            assert len(issues) == 1
+            assert issues[0].entity_type == "history_reachability"
+            assert issues[0].severity == "error"
+
+    def test_pre_backfill_head(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _snap_hash, gen_hash = self._setup(root)
+
+            history_path = generation_dir(root, gen_hash) / "history.pb2"
+            history_path.unlink()
+
+            verifier = Verifier(root)
+            issues = verifier.verify_history_reachability()
+            assert len(issues) == 1
+            assert issues[0].entity_type == "history_reachability"
+            assert issues[0].severity == "warning"
+            assert "backfill" in issues[0].message.lower()

--- a/data/schema/server_history.proto
+++ b/data/schema/server_history.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+package efa.v2;
+
+/// Per-server snapshot timeline as of one generation.
+/// Built cumulatively from the parent generation's history plus this
+/// generation's resource changes. Snapshots are ordered newest -> oldest.
+message ServerHistory {
+  required int32 schema_version = 1;
+  repeated ServerEntry servers = 2;
+
+  message ServerEntry {
+    required string server_id = 1;
+    repeated Snapshot snapshots = 2;   // newest first
+  }
+
+  message Snapshot {
+    required string snapshot_hash = 1;
+    required string generation_hash = 2;
+    required string timestamp = 3;       // ISO 8601 (generation timestamp)
+    optional string game_build = 4;
+    optional string game_version = 5;
+  }
+}

--- a/lib/storage/repo/assets.dart
+++ b/lib/storage/repo/assets.dart
@@ -82,7 +82,7 @@ class AssetStore {
   ///
   /// Steps:
   /// 1. Write metadata.json and resources.pb2 to a temp directory
-  /// 2. Compute snapshot_hash from the metadata.json file hash only
+  /// 2. Compute snapshot_hash (v4) binding metadata.json + resources.pb2
   /// 3. Rename temp → assets/resources/{snapshot_hash}/
   ///
   /// Returns the computed snapshot_hash. Idempotent: skips if the snapshot
@@ -106,10 +106,15 @@ class AssetStore {
     // Serialize metadata.json as canonical JSON
     _writeMetadataJson("${tempDir.path}/$metaPath", meta);
 
-    // Compute snapshot hash from metadata.json only
+    // Compute snapshot hash (v4) binding metadata.json + resources.pb2 (spec §7).
     final metaBytes = File("${tempDir.path}/$metaPath").readAsBytesSync();
+    final indexBytes = File("${tempDir.path}/$indexPath").readAsBytesSync();
     final metaHash = RepoHash.hashContent(metaBytes);
-    final snapshotHash = RepoHash.hashResourceSnapshot(metaHash);
+    final indexHash = RepoHash.hashContent(indexBytes);
+    final snapshotHash = RepoHash.hashResourceSnapshotV4(
+      metadataJsonHash: metaHash,
+      resourcesPb2Hash: indexHash,
+    );
 
     final targetDir = Directory(RepoPaths.resourceSnapshotPath(snapshotHash));
     if (targetDir.existsSync()) {

--- a/lib/storage/repo/hash.dart
+++ b/lib/storage/repo/hash.dart
@@ -46,4 +46,34 @@ class RepoHash {
   ///   )
   static String hashGeneration({required String metadataJsonHash}) =>
       hashString("efa:generation:v3\nmetadata.json $metadataJsonHash\n");
+
+  // ── Structured hashes (v4 — also binds the typed .pb2 index, spec §7) ───────
+  //
+  // v4 is the canonical protocol for new snapshots. It binds the `.pb2` index
+  // in addition to `metadata.json`, so tampering with the resource/release
+  // index changes the content address. Must stay byte-for-byte identical to the
+  // Python side (`bootstrap/remote/hash.py: snapshot_hash_v4`) so the client and
+  // dev CLI agree on snapshot directory names (no split-brain hash).
+
+  /// Computes the structured resource snapshot hash (v4).
+  ///
+  ///   snapshot_hash = SHA-256(
+  ///     "efa:resource:v4\n"
+  ///     "metadata.json {sha256_of_canonical_metadata_json_bytes}\n"
+  ///     "resources.pb2 {sha256_of_resources_pb2_bytes}\n"
+  ///   )
+  static String hashResourceSnapshotV4({
+    required String metadataJsonHash,
+    required String resourcesPb2Hash,
+  }) => hashString(
+    "efa:resource:v4\nmetadata.json $metadataJsonHash\nresources.pb2 $resourcesPb2Hash\n",
+  );
+
+  /// Computes the structured release snapshot hash (v4).
+  static String hashReleaseSnapshotV4({
+    required String metadataJsonHash,
+    required String releasesPb2Hash,
+  }) => hashString(
+    "efa:release:v4\nmetadata.json $metadataJsonHash\nreleases.pb2 $releasesPb2Hash\n",
+  );
 }

--- a/test/storage/repo/hash_test.dart
+++ b/test/storage/repo/hash_test.dart
@@ -1,4 +1,3 @@
-import "dart:convert";
 import "dart:typed_data";
 
 import "package:eve_fit_assistant/storage/repo/hash.dart";
@@ -100,6 +99,73 @@ void main() {
       final metaHash = RepoHash.hashContent(metaBytes);
       final genHash = RepoHash.hashGeneration(metadataJsonHash: metaHash);
       expect(genHash, "ef7c9ac6cc8c3c2ab2583af5027a4b1fd11c4aaca4e029a5293710b07e0e78dd");
+    });
+  });
+
+  group("hashResourceSnapshotV4", () {
+    test("produces deterministic hash", () {
+      final a = RepoHash.hashResourceSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        resourcesPb2Hash: "b" * 64,
+      );
+      final b = RepoHash.hashResourceSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        resourcesPb2Hash: "b" * 64,
+      );
+      expect(a, b);
+      expect(a.length, 64);
+    });
+
+    test("binds the resources.pb2 index (tamper sensitivity)", () {
+      final base = RepoHash.hashResourceSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        resourcesPb2Hash: "b" * 64,
+      );
+      final tampered = RepoHash.hashResourceSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        resourcesPb2Hash: "c" * 64,
+      );
+      expect(base, isNot(tampered));
+    });
+
+    test("differs from v3 (which ignores the index)", () {
+      final v3 = RepoHash.hashResourceSnapshot("a" * 64);
+      final v4 = RepoHash.hashResourceSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        resourcesPb2Hash: "b" * 64,
+      );
+      expect(v3, isNot(v4));
+    });
+
+    test("Python parity for known component hashes", () {
+      // Must match bootstrap/tests/test_verify.py::test_known_value_parity.
+      final h = RepoHash.hashResourceSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        resourcesPb2Hash: "b" * 64,
+      );
+      expect(h, "a76dfbcd80a9457f09b32241c7a9b239de581d1db784786279e59b90a3891c69");
+    });
+  });
+
+  group("hashReleaseSnapshotV4", () {
+    test("Python parity for known component hashes", () {
+      final h = RepoHash.hashReleaseSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        releasesPb2Hash: "b" * 64,
+      );
+      expect(h, "8e3558913730e810d6bcf65fe1ae9b6a859f4166976cc69e94dc60953ee665cd");
+    });
+
+    test("domain separation from resource snapshot v4", () {
+      final res = RepoHash.hashResourceSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        resourcesPb2Hash: "b" * 64,
+      );
+      final rel = RepoHash.hashReleaseSnapshotV4(
+        metadataJsonHash: "a" * 64,
+        releasesPb2Hash: "b" * 64,
+      );
+      expect(res, isNot(rel));
     });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--retention-depth` to `remote gc` to control how many ancestor generations are kept.
  * Added `--replace` for `remote session add` to replace an already-staged resource snapshot by hash (with safety checks).
  * Snapshot integrity now supports v4 hashing (with legacy fallback) and verification includes new history/history-reachability results.

* **Bug Fixes**
  * Improved duplicate `server_id` handling across staging, diff/verification, and `remote session commit`.
  * Garbage collection and verification now preserve reachable snapshots/blobs correctly using generation history when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->