### PR TITLE
fix(cli): redesign remote mock for from-scratch v2 workflow

### DIFF
--- a/bootstrap/cli/remote/helpers.py
+++ b/bootstrap/cli/remote/helpers.py
@@ -15,7 +15,6 @@ import bootstrap.config
 
 from bootstrap.cli import runtime
 from bootstrap.color import styled
-from bootstrap.constant import PROJECT_ROOT
 from bootstrap.log import warning
 from bootstrap.remote.channel import Channel
 from bootstrap.utils import get_command
@@ -325,18 +324,3 @@ def resolve_announce_remote_target(
         )
     else:
         raise click.ClickException(f"Invalid target: {target!r} (expected minio or s3)")
-
-
-def materialize_remote_mock(origin_dir: Path, clean: bool) -> None:
-    source_dir = PROJECT_ROOT / "docs" / "examples" / "remote" / "mock-origin"
-    if not source_dir.exists():
-        raise click.ClickException(f"Missing remote mock fixture directory: {source_dir}")
-
-    if clean and origin_dir.exists():
-        shutil.rmtree(origin_dir)
-
-    origin_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source_dir, origin_dir, dirs_exist_ok=True)
-    click.echo(
-        styled([Style.BRIGHT, Fore.GREEN], "Materialized remote mock origin: ") + str(origin_dir)
-    )

--- a/bootstrap/cli/remote/mock.py
+++ b/bootstrap/cli/remote/mock.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import click
 
@@ -15,17 +14,10 @@ from colorama import Style
 import bootstrap.config
 
 from bootstrap.cli import runtime
-from bootstrap.cli.remote.helpers import materialize_remote_mock
-from bootstrap.cli.remote.helpers import publish_remote_origin_to_s3
 from bootstrap.cli.remote.helpers import run_foreground
-from bootstrap.cli.remote.helpers import validate_remote_channel
 from bootstrap.cli.remote.helpers import wait_for_http
 from bootstrap.color import styled
 from bootstrap.utils import get_command
-
-
-if TYPE_CHECKING:
-    from bootstrap.remote.channel import Channel
 
 
 def _start_minio_remote_mock(
@@ -33,15 +25,11 @@ def _start_minio_remote_mock(
     host: str,
     port: int,
     console_port: int,
-    origin_dir: Path,
     data_dir: Path,
     bucket: str,
     access_key: str,
     secret_key: str,
     alias_name: str,
-    resource_root: str,
-    channel: Channel,
-    clean_bucket: bool,
     public_download: bool,
 ) -> None:
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -68,58 +56,36 @@ def _start_minio_remote_mock(
     process = subprocess.Popen(command, env=env, text=True)
     try:
         wait_for_http(f"{endpoint}/minio/health/ready")
-        if clean_bucket:
-            mc = get_command("mc")
-            bucket_target = f"{alias_name}/{bucket}"
-            redacted = "<redacted>"
-            runtime.execute_redacted(
-                [mc, "alias", "set", alias_name, endpoint, access_key, secret_key, "--api", "s3v4"],
-                [mc, "alias", "set", alias_name, endpoint, redacted, redacted, "--api", "s3v4"],
-                "REMOTE PUBLISH ALIAS",
-            )
-            runtime.execute_redacted(
-                [mc, "mb", "--ignore-existing", bucket_target],
-                [mc, "mb", "--ignore-existing", bucket_target],
-                "REMOTE CLEAN BUCKET (CREATE)",
-            )
-            runtime.execute_redacted(
-                [mc, "rm", "--recursive", "--force", bucket_target],
-                [mc, "rm", "--recursive", "--force", bucket_target],
-                "REMOTE CLEAN BUCKET",
-            )
-        from bootstrap.remote.generation import utc_timestamp
 
-        mock_generation = utc_timestamp().replace("-", "").replace(":", "") + "Z"
-        publish_remote_origin_to_s3(
-            source_dir=origin_dir,
-            endpoint=endpoint,
-            bucket=bucket,
-            access_key=access_key,
-            secret_key=secret_key,
-            alias_name=alias_name,
-            resource_root=resource_root,
-            channel=channel,
-            generation=mock_generation,
-            public_download=public_download,
+        mc = get_command("mc")
+        bucket_target = f"{alias_name}/{bucket}"
+        redacted = "<redacted>"
+        runtime.execute_redacted(
+            [mc, "alias", "set", alias_name, endpoint, access_key, secret_key, "--api", "s3v4"],
+            [mc, "alias", "set", alias_name, endpoint, redacted, redacted, "--api", "s3v4"],
+            "REMOTE MOCK ALIAS",
         )
-
-        v2_heads_dir = origin_dir / resource_root / "channels" / "heads"
-        if v2_heads_dir.is_dir():
-            from bootstrap.remote import Publisher as V2Publisher
-
-            pub = V2Publisher(
-                local_root=origin_dir / resource_root,
-                endpoint=endpoint,
-                bucket=bucket,
-                access_key=access_key,
-                secret_key=secret_key,
-                alias_name=alias_name,
+        runtime.execute(
+            [mc, "mb", "--ignore-existing", bucket_target],
+            "REMOTE MOCK BUCKET",
+        )
+        if public_download:
+            runtime.execute(
+                [mc, "anonymous", "set", "download", bucket_target],
+                "REMOTE MOCK ANONYMOUS",
             )
-            pub.publish_all_for_head(channel.value)
-            click.echo(styled(Style.DIM, "  V2 head published."))
         else:
-            click.echo(styled(Style.DIM, "  No V2 data in mock origin; skipping V2 publish."))
+            runtime.execute(
+                [mc, "anonymous", "set", "none", bucket_target],
+                "REMOTE MOCK ANONYMOUS",
+            )
 
+        click.echo(
+            styled(
+                Style.DIM,
+                "  No pre-existing data published. Use `./x remote session` to build from scratch.",
+            )
+        )
         click.echo(styled([Style.BRIGHT, Fore.GREEN], "MinIO console: ") + console_endpoint)
         run_foreground(process, "\nMinIO remote mock interrupted by user.")
     except Exception:
@@ -132,20 +98,43 @@ def _start_minio_remote_mock(
         raise
 
 
+def _remove_mock_path(path: Path, label: str) -> bool:
+    if not path.exists():
+        return False
+    click.echo(styled(Style.DIM, f"  Removing {label}: {path}"))
+    import shutil
+
+    shutil.rmtree(path)
+    return True
+
+
 def register_remote_mock(remote: click.Group) -> None:
     @remote.group(cls=ClickAliasedGroup)
     def mock():
         """Remote mock origin commands."""
 
-    @mock.command("materialize")
+    @mock.command("clean")
     @click.option("--origin-dir", type=click.Path(path_type=Path), default=None)
-    @click.option("--clean", is_flag=True, default=False, help="Remove the origin directory first.")
-    def remote_mock_materialize(origin_dir: Path | None, clean: bool):
-        """Copy committed remote mock fixtures into the configured origin directory."""
+    @click.option("--data-dir", type=click.Path(path_type=Path), default=None)
+    def remote_mock_clean(origin_dir: Path | None, data_dir: Path | None):
+        """Remove all persisted remote mock data (MinIO storage + origin directory)."""
         bootstrap.config.DeveloperConfiguration.ensure_loaded()
         remote_cfg = bootstrap.config.DEV_CONFIGURATION.remote
+        minio = remote_cfg.require_minio("clean")
+
+        resolved_data_dir = runtime.resolve_dev_path(data_dir or minio.data_dir)
         resolved_origin_dir = runtime.resolve_dev_path(origin_dir or remote_cfg.mock_origin_dir)
-        materialize_remote_mock(resolved_origin_dir, clean)
+
+        any_removed = False
+        if _remove_mock_path(resolved_data_dir, "MinIO data directory"):
+            any_removed = True
+        if _remove_mock_path(resolved_origin_dir, "mock origin directory"):
+            any_removed = True
+
+        if any_removed:
+            click.echo(styled([Style.BRIGHT, Fore.GREEN], "Remote mock cleaned."))
+        else:
+            click.echo(styled(Style.DIM, "Nothing to clean."))
 
     @mock.command("launch")
     @click.option("--host", default=None, help="Override remote mock host.")
@@ -155,19 +144,7 @@ def register_remote_mock(remote: click.Group) -> None:
     @click.option("--access-key", default=None, help="Override MinIO access key.")
     @click.option("--secret-key", default=None, help="Override MinIO secret key.")
     @click.option("--alias", "alias_name", default=None, help="Override mc alias name.")
-    @click.option("--origin-dir", type=click.Path(path_type=Path), default=None)
     @click.option("--data-dir", type=click.Path(path_type=Path), default=None)
-    @click.option("--resource-root", default=None, help="Override remote resource root.")
-    @click.option("--channel", default=None, help="Override remote channel.")
-    @click.option(
-        "--no-materialize", is_flag=True, default=False, help="Do not refresh origin fixtures."
-    )
-    @click.option(
-        "--clean-origin", is_flag=True, default=False, help="Clean origin before materializing."
-    )
-    @click.option(
-        "--clean-bucket", is_flag=True, default=False, help="Clean MinIO bucket before mirroring."
-    )
     @click.option(
         "--public-download/--private",
         "public_download",
@@ -182,62 +159,47 @@ def register_remote_mock(remote: click.Group) -> None:
         access_key: str | None,
         secret_key: str | None,
         alias_name: str | None,
-        origin_dir: Path | None,
         data_dir: Path | None,
-        resource_root: str | None,
-        channel: str | None,
-        no_materialize: bool,
-        clean_origin: bool,
-        clean_bucket: bool,
         public_download: bool | None,
     ):
-        """Launch a local MinIO remote mock."""
+        """Launch a local MinIO remote mock against persisted storage.
+
+        No pre-existing data is published - use `./x remote session` commands
+        to build data from scratch. Run `./x remote mock clean` first to
+        start with a completely empty store.
+        """
         bootstrap.config.DeveloperConfiguration.ensure_loaded()
         bootstrap.config.ProjectConfiguration.ensure_loaded()
         remote_cfg = bootstrap.config.DEV_CONFIGURATION.remote
         minio = remote_cfg.require_minio("mock")
 
         resolved_host = host or remote_cfg.host
-        resolved_resource_root = (
-            resource_root or bootstrap.config.CONFIGURATION.data_schema.resource_root
-        )
-        resolved_channel = validate_remote_channel(channel or remote_cfg.channel.value)
-        resolved_origin_dir = runtime.resolve_dev_path(origin_dir or remote_cfg.mock_origin_dir)
-
-        if not no_materialize:
-            materialize_remote_mock(resolved_origin_dir, clean_origin)
-        elif not resolved_origin_dir.exists():
-            raise click.ClickException(f"Remote mock origin does not exist: {resolved_origin_dir}")
-
+        resolved_data_dir = runtime.resolve_dev_path(data_dir or minio.data_dir)
         resolved_port = port or minio.port
         resolved_console_port = console_port or minio.console_port
         resolved_bucket = bucket or minio.bucket
         resolved_access_key = access_key or minio.access_key
         resolved_secret_key = secret_key or minio.secret_key
-        resolved_data_dir = runtime.resolve_dev_path(data_dir or minio.data_dir)
         resolved_alias = alias_name or minio.alias
         resolved_public_download = (
             public_download if public_download is not None else minio.public_download
         )
 
-        origin_url = f"http://{resolved_host}:{resolved_port}/{resolved_bucket}"
-        click.echo(
-            styled([Style.BRIGHT, Fore.GREEN], "Remote index URL: ")
-            + f"{origin_url.rstrip('/')}/{resolved_resource_root.strip('/')}/channels/{resolved_channel.value}/index.json"
-        )
         click.echo(styled([Style.BRIGHT, Fore.GREEN], "MinIO data path: ") + str(resolved_data_dir))
+        click.echo(
+            styled(
+                Style.DIM,
+                "  Using persisted storage. Run `./x remote mock clean` for a fresh start.",
+            )
+        )
         _start_minio_remote_mock(
             host=resolved_host,
             port=resolved_port,
             console_port=resolved_console_port,
-            origin_dir=resolved_origin_dir,
             data_dir=resolved_data_dir,
             bucket=resolved_bucket,
             access_key=resolved_access_key,
             secret_key=resolved_secret_key,
             alias_name=resolved_alias,
-            resource_root=resolved_resource_root,
-            channel=resolved_channel,
-            clean_bucket=clean_bucket,
             public_download=resolved_public_download,
         )

--- a/bootstrap/cli/remote/mock.py
+++ b/bootstrap/cli/remote/mock.py
@@ -20,6 +20,35 @@ from bootstrap.color import styled
 from bootstrap.utils import get_command
 
 
+_PROTECTED_PATHS: tuple[Path, ...] | None = None
+
+
+def _get_protected_paths() -> tuple[Path, ...]:
+    global _PROTECTED_PATHS
+    if _PROTECTED_PATHS is None:
+        cfg = bootstrap.config.DEV_CONFIGURATION
+        dev_root = cfg.paths.root.resolve()
+        _PROTECTED_PATHS = (
+            Path("/"),
+            Path.home(),
+            dev_root,
+        )
+    return _PROTECTED_PATHS
+
+
+def _is_safe_rmtree_target(path: Path) -> bool:
+    resolved = path.resolve()
+    if not resolved.is_dir():
+        raise click.ClickException(f"Refusing to remove non-directory path: {resolved}")
+    protected = _get_protected_paths()
+    for p in protected:
+        if resolved == p or p in resolved.parents:
+            raise click.ClickException(
+                f"Refusing to remove protected path: {resolved} (conflicts with {p})"
+            )
+    return True
+
+
 def _start_minio_remote_mock(
     *,
     host: str,
@@ -101,6 +130,7 @@ def _start_minio_remote_mock(
 def _remove_mock_path(path: Path, label: str) -> bool:
     if not path.exists():
         return False
+    _is_safe_rmtree_target(path)
     click.echo(styled(Style.DIM, f"  Removing {label}: {path}"))
     import shutil
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote mock now starts with persisted storage and configures anonymous download access when enabled.
  * Added a cleanup command to remove stored mock data and reset the mock origin directory.

* **Bug Fixes**
  * Simplified remote mock startup to avoid publishing preloaded fixture content unexpectedly.
  * Updated launch behavior to rely on the configured MinIO data directory and bucket setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->