### PR TITLE
feat(remote): deduplicate blob uploads with ResourceManager

### DIFF
--- a/bootstrap/remote/publish.py
+++ b/bootstrap/remote/publish.py
@@ -83,10 +83,6 @@ class Publisher:
 
         self._ensure_alias()
 
-        self._upload_dir(
-            generation_dir(self.local_root, gen_hash), prefixes + f"channels/refs/{gen_hash}"
-        )
-
         rm = ResourceManager(self, expected_total=self._count_unique_blobs(gen, prefixes))
         with rm.progress(), ThreadPoolExecutor(max_workers=self.workers) as ex:
             futures: list[Future[None]] = []
@@ -104,6 +100,9 @@ class Publisher:
             self._upload_dir(snap_dir, remote)
         if release_dir_upload is not None:
             self._upload_dir(*release_dir_upload)
+        self._upload_dir(
+            generation_dir(self.local_root, gen_hash), prefixes + f"channels/refs/{gen_hash}"
+        )
 
     def publish_head(self, channel: str) -> None:
         """Upload channel head metadata and reflog to remote."""
@@ -226,20 +225,24 @@ class Publisher:
 
             snap_dir = resource_snapshot_dir(self.local_root, snap_hash)
             if not snap_dir.is_dir():
-                continue
+                raise FileNotFoundError(
+                    f"Resource snapshot directory missing: {snap_dir} "
+                    f"(referenced by generation {resources.gen_hash})"
+                )
 
             snapshot_uploads.append((snap_dir, prefixes + f"assets/resources/{snap_hash}"))
 
-            try:
-                index = read_pb2(snap_dir / "resources.pb2", ResourceIndex)
-            except Exception:
-                continue
+            index = read_pb2(snap_dir / "resources.pb2", ResourceIndex)
             for ri_entry in index.entries:
                 ihash = ident_hash(ri_entry.resource_id)
                 bpath = blob_path(self.local_root, ihash, ri_entry.content_hash)
-                if bpath.is_file():
-                    remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}"
-                    futures.append(ex.submit(rm.process_blob, bpath, remote))
+                if not bpath.is_file():
+                    raise FileNotFoundError(
+                        f"Resource blob missing: {bpath} "
+                        f"(snapshot {snap_hash}, resource {ri_entry.resource_id})"
+                    )
+                remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}"
+                futures.append(ex.submit(rm.process_blob, bpath, remote))
         return snapshot_uploads
 
     def _enumerate_release_blobs(
@@ -265,12 +268,12 @@ class Publisher:
 
         pb2_file = snap_dir / "releases.pb2"
         if not pb2_file.is_file():
-            return dir_upload
+            raise FileNotFoundError(
+                f"Release index file missing: {pb2_file} "
+                f"(snapshot {snap_hash}, referenced by generation)"
+            )
 
-        try:
-            index = read_pb2(pb2_file, ReleaseIndex)
-        except Exception:
-            return dir_upload
+        index = read_pb2(pb2_file, ReleaseIndex)
 
         if not index.HasField("android"):
             return dir_upload
@@ -282,9 +285,12 @@ class Publisher:
             v = getattr(android, variant_name)
             ihash = ident_hash(v.identifier)
             bpath = blob_path(self.local_root, ihash, v.content_hash)
-            if bpath.is_file():
-                remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
-                futures.append(ex.submit(rm.process_blob, bpath, remote))
+            if not bpath.is_file():
+                raise FileNotFoundError(
+                    f"Release blob missing: {bpath} (snapshot {snap_hash}, variant {variant_name})"
+                )
+            remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
+            futures.append(ex.submit(rm.process_blob, bpath, remote))
         return dir_upload
 
     def _count_unique_blobs(self, gen: Generation, prefixes: str) -> int:

--- a/bootstrap/remote/publish.py
+++ b/bootstrap/remote/publish.py
@@ -25,6 +25,7 @@ from bootstrap.remote.paths import channel_registry_path
 from bootstrap.remote.paths import generation_dir
 from bootstrap.remote.paths import release_snapshot_dir
 from bootstrap.remote.paths import resource_snapshot_dir
+from bootstrap.remote.resource_manager import ResourceManager
 from bootstrap.remote.snapshot import SnapshotStore
 
 
@@ -32,8 +33,10 @@ _RELEASE_VARIANT_NAMES = ("general", "armv7", "arm64", "x64")
 
 
 if TYPE_CHECKING:
+    from concurrent.futures import Future
     from pathlib import Path
 
+    from bootstrap.remote.generation import Generation
     from bootstrap.remote.models import GenerationPointer
     from bootstrap.remote.models import GenerationResources
 
@@ -84,8 +87,23 @@ class Publisher:
             generation_dir(self.local_root, gen_hash), prefixes + f"channels/refs/{gen_hash}"
         )
 
-        self._publish_resource_snapshots(gen.resources, prefixes)
-        self._publish_pointer_snapshot(gen.release_pointer, "releases", prefixes)
+        rm = ResourceManager(self, expected_total=self._count_unique_blobs(gen, prefixes))
+        with rm.progress(), ThreadPoolExecutor(max_workers=self.workers) as ex:
+            futures: list[Future[None]] = []
+            snapshot_uploads = self._enumerate_resource_blobs(
+                gen.resources, prefixes, rm, ex, futures
+            )
+            release_dir_upload = self._enumerate_release_blobs(
+                gen.release_pointer, prefixes, rm, ex, futures
+            )
+            for fut in as_completed(futures):
+                fut.result()
+        rm.log_summary()
+
+        for snap_dir, remote in snapshot_uploads:
+            self._upload_dir(snap_dir, remote)
+        if release_dir_upload is not None:
+            self._upload_dir(*release_dir_upload)
 
     def publish_head(self, channel: str) -> None:
         """Upload channel head metadata and reflog to remote."""
@@ -108,8 +126,23 @@ class Publisher:
 
         self._ensure_alias()
 
-        self._publish_resource_snapshots(gen.resources, prefixes)
-        self._publish_pointer_snapshot(gen.release_pointer, "releases", prefixes)
+        rm = ResourceManager(self, expected_total=self._count_unique_blobs(gen, prefixes))
+        with rm.progress(), ThreadPoolExecutor(max_workers=self.workers) as ex:
+            futures: list[Future[None]] = []
+            snapshot_uploads = self._enumerate_resource_blobs(
+                gen.resources, prefixes, rm, ex, futures
+            )
+            release_dir_upload = self._enumerate_release_blobs(
+                gen.release_pointer, prefixes, rm, ex, futures
+            )
+            for fut in as_completed(futures):
+                fut.result()
+        rm.log_summary()
+
+        for snap_dir, remote in snapshot_uploads:
+            self._upload_dir(snap_dir, remote)
+        if release_dir_upload is not None:
+            self._upload_dir(*release_dir_upload)
         self._upload_dir(
             generation_dir(self.local_root, head.generation_hash),
             prefixes + f"channels/refs/{head.generation_hash}",
@@ -172,18 +205,19 @@ class Publisher:
             )
             self._alias_set = True
 
-    def _publish_resource_snapshots(
+    def _enumerate_resource_blobs(
         self,
         resources: GenerationResources,
         prefixes: str,
-    ) -> None:
+        rm: ResourceManager,
+        ex: ThreadPoolExecutor,
+        futures: list[Future[None]],
+    ) -> list[tuple[Path, str]]:
+        """Collect unique snapshot dir uploads (direct) and dispatch their blobs to the RM."""
         from bootstrap.remote.models import ResourceIndex
 
         seen: set[str] = set()
         snapshot_uploads: list[tuple[Path, str]] = []
-        blob_uploads: list[tuple[Path, str]] = []
-
-        # Phase 1: collect unique snapshot directories and their blobs
         for entry in resources.entries:
             snap_hash = entry.snapshot_hash
             if snap_hash in seen:
@@ -204,61 +238,44 @@ class Publisher:
                 ihash = ident_hash(ri_entry.resource_id)
                 bpath = blob_path(self.local_root, ihash, ri_entry.content_hash)
                 if bpath.is_file():
-                    blob_uploads.append(
-                        (
-                            bpath,
-                            prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}",
-                        )
-                    )
+                    remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}"
+                    futures.append(ex.submit(rm.process_blob, bpath, remote))
+        return snapshot_uploads
 
-        # Phase 2: upload snapshot directories
-        for snap_dir, remote_path in snapshot_uploads:
-            self._upload_dir(snap_dir, remote_path)
-
-        # Phase 3: upload all blobs in parallel with progress bar
-        if blob_uploads:
-            self._upload_files_parallel(blob_uploads, desc="Uploading blobs")
-
-    def _publish_pointer_snapshot(
+    def _enumerate_release_blobs(
         self,
         pointer: GenerationPointer,
-        snap_type: str,
         prefixes: str,
-    ) -> None:
+        rm: ResourceManager,
+        ex: ThreadPoolExecutor,
+        futures: list[Future[None]],
+    ) -> tuple[Path, str] | None:
+        """Dispatch release APK blobs to the RM; return the release snapshot dir upload."""
+        from bootstrap.remote.models import ReleaseIndex
+
         snap_hash = pointer.snapshot_hash
         if not snap_hash:
-            return
+            return None
 
-        dir_map = {
-            "releases": release_snapshot_dir,
-        }
-        snap_dir = dir_map[snap_type](self.local_root, snap_hash)
+        snap_dir = release_snapshot_dir(self.local_root, snap_hash)
         if not snap_dir.is_dir():
-            return
+            return None
 
-        self._upload_dir(snap_dir, prefixes + f"assets/{snap_type}/{snap_hash}")
-
-        if snap_type == "releases":
-            self._publish_release_blobs(snap_dir, prefixes)
-
-    def _publish_release_blobs(self, snap_dir: Path, prefixes: str) -> None:
-        from bootstrap.remote.models import ReleaseIndex
+        dir_upload = (snap_dir, prefixes + f"assets/releases/{snap_hash}")
 
         pb2_file = snap_dir / "releases.pb2"
         if not pb2_file.is_file():
-            return
+            return dir_upload
 
         try:
             index = read_pb2(pb2_file, ReleaseIndex)
         except Exception:
-            return
+            return dir_upload
 
         if not index.HasField("android"):
-            return
+            return dir_upload
 
         android = index.android
-        blob_uploads: list[tuple[Path, str]] = []
-
         for variant_name in _RELEASE_VARIANT_NAMES:
             if not android.HasField(variant_name):
                 continue
@@ -266,18 +283,79 @@ class Publisher:
             ihash = ident_hash(v.identifier)
             bpath = blob_path(self.local_root, ihash, v.content_hash)
             if bpath.is_file():
-                blob_uploads.append(
-                    (bpath, prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}")
-                )
+                remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
+                futures.append(ex.submit(rm.process_blob, bpath, remote))
+        return dir_upload
 
-        if blob_uploads:
-            self._upload_files_parallel(blob_uploads, desc="Uploading release blobs")
+    def _count_unique_blobs(self, gen: Generation, prefixes: str) -> int:
+        """Pre-count unique blob remote paths to seed the progress bar total (spec §4)."""
+        from bootstrap.remote.models import ReleaseIndex
+        from bootstrap.remote.models import ResourceIndex
+
+        unique: set[str] = set()
+
+        seen: set[str] = set()
+        for entry in gen.resources.entries:
+            snap_hash = entry.snapshot_hash
+            if snap_hash in seen:
+                continue
+            seen.add(snap_hash)
+            snap_dir = resource_snapshot_dir(self.local_root, snap_hash)
+            if not snap_dir.is_dir():
+                continue
+            try:
+                index = read_pb2(snap_dir / "resources.pb2", ResourceIndex)
+            except Exception:
+                continue
+            for ri_entry in index.entries:
+                ihash = ident_hash(ri_entry.resource_id)
+                bpath = blob_path(self.local_root, ihash, ri_entry.content_hash)
+                if bpath.is_file():
+                    unique.add(
+                        prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}"
+                    )
+
+        snap_hash = gen.release_pointer.snapshot_hash
+        if snap_hash:
+            snap_dir = release_snapshot_dir(self.local_root, snap_hash)
+            pb2_file = snap_dir / "releases.pb2"
+            if snap_dir.is_dir() and pb2_file.is_file():
+                try:
+                    rel_index = read_pb2(pb2_file, ReleaseIndex)
+                except Exception:
+                    rel_index = None
+                if rel_index is not None and rel_index.HasField("android"):
+                    android = rel_index.android
+                    for variant_name in _RELEASE_VARIANT_NAMES:
+                        if not android.HasField(variant_name):
+                            continue
+                        v = getattr(android, variant_name)
+                        ihash = ident_hash(v.identifier)
+                        bpath = blob_path(self.local_root, ihash, v.content_hash)
+                        if bpath.is_file():
+                            unique.add(
+                                prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
+                            )
+
+        return len(unique)
 
     def _upload_file(self, src: Path, remote_path: str) -> None:
         if self.origin_dir is not None:
             self._upload_local(src, remote_path)
         else:
             self._upload_s3(src, remote_path)
+
+    def _remote_exists(self, remote_path: str) -> bool:
+        """True if the blob already exists at the destination (spec §3.1)."""
+        if self.origin_dir is not None:
+            return (self.origin_dir / remote_path).exists()
+        if self.mc_bin is None:
+            from bootstrap.utils import get_command
+
+            self.mc_bin = get_command("mc")
+        bucket_target = f"{self.alias_name}/{self.bucket}"
+        s3_path = f"{bucket_target}/{remote_path}"
+        return _stat_ok([self.mc_bin, "stat", s3_path])
 
     def _upload_dir(self, src_dir: Path, remote_path: str) -> None:
         if self.origin_dir is not None:
@@ -361,3 +439,18 @@ def _run(
         if stderr:
             msg += f"\n{stderr}"
         raise OSError(msg)
+
+
+def _stat_ok(cmd: list[str], timeout: float = 60) -> bool:
+    try:
+        out = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+    return out.returncode == 0

--- a/bootstrap/remote/resource_manager.py
+++ b/bootstrap/remote/resource_manager.py
@@ -1,0 +1,132 @@
+"""ResourceManager — cross-snapshot blob dedup + differential upload (spec v2-reg).
+
+Per-publish singleton (publisher side only). For each unique blob remote path it
+HEAD-checks the destination and skips the PUT when the blob already exists.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tqdm import tqdm
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from bootstrap.remote.publish import Publisher
+
+
+@dataclass
+class _Stats:
+    total_registered: int = 0  # every process_blob call, incl. dupes (§5)
+    existing: int = 0  # HEAD hit on remote
+    uploaded: int = 0  # processed unique blobs (existing + PUT) — see §4
+
+
+class ResourceManager:
+    def __init__(
+        self,
+        publisher: Publisher,
+        *,
+        expected_total: int | None = None,
+        show_progress: bool = True,
+    ) -> None:
+        self._pub = publisher
+        self.expected_total = expected_total
+        self._show_progress = show_progress
+        self._bar: tqdm | None = None
+        self._dedup: dict[str, Path] = {}  # remote_path -> local_path (unique)
+        self._stats = _Stats()
+        self._lock = threading.Lock()
+
+    # --- progress bar (§4) ---------------------------------------------------
+
+    @contextmanager
+    def progress(self) -> Iterator[ResourceManager]:
+        """Open the single blob progress bar for the duration of a publish."""
+        if not self._show_progress:
+            self._bar = None
+            yield self
+            return
+        self._bar = tqdm(
+            total=self.expected_total,  # None => absolute-count mode (§4)
+            desc="Blobs",
+            unit="file",
+            unit_scale=False,
+            smoothing=0.3,  # rolling throughput, ~last few seconds
+        )
+        try:
+            yield self
+        finally:
+            self._bar.close()
+            self._bar = None
+
+    def _tick(self) -> None:
+        if self._bar is None:
+            return
+        self._bar.update(1)
+        self._bar.set_postfix_str(
+            f"{self.existing} Existing  {self.uploaded}/{self.unique_count} Uploaded",
+            refresh=False,
+        )
+
+    # --- enumeration (single pass, called inline by the publisher) -----------
+
+    def process_blob(self, local_path: Path, remote_path: str) -> None:
+        """Register a blob (dedup) and, if new, HEAD-check + upload.
+
+        Inline contract per spec §3.1. Safe to call from worker threads.
+        """
+        with self._lock:
+            self._stats.total_registered += 1
+            if remote_path in self._dedup:
+                return
+            self._dedup[remote_path] = local_path
+        self._handle_unique(local_path, remote_path)
+
+    def _handle_unique(self, local_path: Path, remote_path: str) -> None:
+        exists = self._pub._remote_exists(remote_path)
+        if exists:
+            with self._lock:
+                self._stats.existing += 1
+                self._stats.uploaded += 1
+        else:
+            self._pub._upload_file(local_path, remote_path)
+            with self._lock:
+                self._stats.uploaded += 1
+        self._tick()
+
+    # --- summary (§5) --------------------------------------------------------
+
+    def log_summary(self) -> None:
+        s = self._stats
+        actually_uploaded = s.uploaded - s.existing
+        print("ResourceManager:")
+        print(f"  Total blobs registered (with dupes): {s.total_registered}")
+        print(f"  Unique blobs after dedup:             {len(self._dedup)}")
+        print(f"    Existing on remote:  {s.existing}")
+        print(f"    Uploaded:            {actually_uploaded}")
+
+    # --- read-only accessors (for the progress bar in Stage 02) --------------
+
+    @property
+    def unique_count(self) -> int:
+        return len(self._dedup)
+
+    @property
+    def existing(self) -> int:
+        return self._stats.existing
+
+    @property
+    def uploaded(self) -> int:
+        return self._stats.uploaded
+
+    @property
+    def total_registered(self) -> int:
+        return self._stats.total_registered

--- a/bootstrap/tests/test_resource_manager.py
+++ b/bootstrap/tests/test_resource_manager.py
@@ -1,0 +1,497 @@
+"""Tests for the V2 ResourceManager — cross-snapshot blob dedup + differential upload.
+
+Locks in the spec §8 behavioral guarantees: dedup, existing-skip, summary math,
+progress no-op equivalence, and parallel safety. All tests run with
+``Publisher(origin_dir=...)`` (local filesystem transport) so no ``mc`` binary, S3,
+or network is required — ``_remote_exists`` and ``_upload_file`` both resolve to
+local-fs operations in this mode.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from bootstrap.remote.generation import GenerationMetadata
+from bootstrap.remote.generation import GenerationStore
+from bootstrap.remote.hash import content_hash
+from bootstrap.remote.hash import ident_hash
+from bootstrap.remote.head import ChannelHeadStore
+from bootstrap.remote.models import ReleaseSnapshotMetadata
+from bootstrap.remote.models import ResourceIndex
+from bootstrap.remote.models import ResourceSnapshotMetadata
+from bootstrap.remote.models import make_generation_pointer
+from bootstrap.remote.models import make_generation_resources
+from bootstrap.remote.models import make_release_index
+from bootstrap.remote.models import make_server_index
+from bootstrap.remote.paths import blob_path
+from bootstrap.remote.publish import Publisher
+from bootstrap.remote.resource_manager import ResourceManager
+from bootstrap.remote.snapshot import SnapshotStore
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_PREFIX = "efa/v2/"
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_origin(tmp_path: Path) -> Path:
+    """Return an empty origin (remote) dir."""
+    origin = tmp_path / "origin"
+    origin.mkdir(parents=True, exist_ok=True)
+    return origin
+
+
+def make_publisher(tmp_path: Path) -> tuple[Publisher, Path, Path]:
+    """Build a Publisher in origin mode; return (publisher, local_root, origin_dir)."""
+    local_root = tmp_path / "local"
+    local_root.mkdir(parents=True, exist_ok=True)
+    origin = make_origin(tmp_path)
+    return Publisher(local_root, origin_dir=origin), local_root, origin
+
+
+def make_blob(local_root: Path, resource_id: str, chash: str, data: bytes) -> Path:
+    """Write ``blob_path(local_root, ident_hash(resource_id), chash)`` and return it."""
+    bpath = blob_path(local_root, ident_hash(resource_id), chash)
+    bpath.parent.mkdir(parents=True, exist_ok=True)
+    bpath.write_bytes(data)
+    return bpath
+
+
+def remote_blob_path(resource_id: str, chash: str) -> str:
+    """The content-addressed remote key for a blob (matches the publisher)."""
+    ihash = ident_hash(resource_id)
+    return _PREFIX + f"assets/blobs/{ihash[:2]}/{ihash}/{chash}"
+
+
+def seed_remote_blob(origin_dir: Path, remote_path: str, data: bytes) -> None:
+    """Pre-create a blob under the origin so ``_remote_exists`` returns True."""
+    dst = origin_dir / remote_path
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_bytes(data)
+
+
+def blob_puts(spy: mock.MagicMock) -> list[str]:
+    """Remote paths of blob PUTs recorded by a wrapped ``_upload_file`` spy."""
+    return [c.args[1] for c in spy.call_args_list if "/assets/blobs/" in c.args[1]]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — ResourceManager
+# ---------------------------------------------------------------------------
+
+
+class TestResourceManager:
+    def test_dedup_single_pass(self, tmp_path: Path) -> None:
+        pub, local_root, _origin = make_publisher(tmp_path)
+        data = b"shared-bytes"
+        chash = content_hash(data)
+        make_blob(local_root, "resource://dup.bin", chash, data)
+        remote = remote_blob_path("resource://dup.bin", chash)
+        local = blob_path(local_root, ident_hash("resource://dup.bin"), chash)
+
+        rm = ResourceManager(pub, show_progress=False)
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            rm.process_blob(local, remote)
+            rm.process_blob(local, remote)
+
+        assert rm.total_registered == 2
+        assert rm.unique_count == 1
+        assert spy.call_count == 1
+
+    def test_existing_skip(self, tmp_path: Path) -> None:
+        pub, local_root, origin = make_publisher(tmp_path)
+        data = b"already-there"
+        chash = content_hash(data)
+        make_blob(local_root, "resource://exists.bin", chash, data)
+        remote = remote_blob_path("resource://exists.bin", chash)
+        local = blob_path(local_root, ident_hash("resource://exists.bin"), chash)
+        seed_remote_blob(origin, remote, data)
+
+        rm = ResourceManager(pub, show_progress=False)
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            rm.process_blob(local, remote)
+
+        assert spy.call_count == 0
+        assert rm.existing == 1
+        assert rm.uploaded == 1
+
+    def test_new_upload(self, tmp_path: Path) -> None:
+        pub, local_root, origin = make_publisher(tmp_path)
+        data = b"fresh-bytes"
+        chash = content_hash(data)
+        make_blob(local_root, "resource://new.bin", chash, data)
+        remote = remote_blob_path("resource://new.bin", chash)
+        local = blob_path(local_root, ident_hash("resource://new.bin"), chash)
+
+        rm = ResourceManager(pub, show_progress=False)
+        rm.process_blob(local, remote)
+
+        assert rm.existing == 0
+        assert rm.uploaded == 1
+        dst = origin / remote
+        assert dst.is_file()
+        assert dst.read_bytes() == data
+
+    def test_summary_math(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        pub, local_root, origin = make_publisher(tmp_path)
+
+        for i in range(2):
+            data = f"existing-{i}".encode()
+            chash = content_hash(data)
+            rid = f"resource://exist-{i}.bin"
+            make_blob(local_root, rid, chash, data)
+            remote = remote_blob_path(rid, chash)
+            seed_remote_blob(origin, remote, data)
+        for i in range(3):
+            data = f"new-{i}".encode()
+            chash = content_hash(data)
+            rid = f"resource://new-{i}.bin"
+            make_blob(local_root, rid, chash, data)
+
+        rm = ResourceManager(pub, show_progress=False)
+        for i in range(2):
+            data = f"existing-{i}".encode()
+            chash = content_hash(data)
+            rid = f"resource://exist-{i}.bin"
+            local = blob_path(local_root, ident_hash(rid), chash)
+            rm.process_blob(local, remote_blob_path(rid, chash))
+        for i in range(3):
+            data = f"new-{i}".encode()
+            chash = content_hash(data)
+            rid = f"resource://new-{i}.bin"
+            local = blob_path(local_root, ident_hash(rid), chash)
+            rm.process_blob(local, remote_blob_path(rid, chash))
+
+        capsys.readouterr()
+        rm.log_summary()
+        out = capsys.readouterr().out
+
+        parsed = _parse_summary(out)
+        assert parsed["unique"] == rm.unique_count == 5
+        assert parsed["existing"] == rm.existing == 2
+        assert parsed["uploaded"] == rm.uploaded - rm.existing == 3
+
+    def test_progress_noop_equiv(self, tmp_path: Path) -> None:
+        _pub, local_root, _origin = make_publisher(tmp_path)
+        blobs: list[tuple[Path, str]] = []
+        for i in range(6):
+            data = f"blob-{i}".encode()
+            chash = content_hash(data)
+            rid = f"resource://p-{i}.bin"
+            local = make_blob(local_root, rid, chash, data)
+            blobs.append((local, remote_blob_path(rid, chash)))
+
+        def run(show: bool) -> tuple[int, int, int, int]:
+            pub2, _root, _orig = make_publisher(tmp_path / f"run-{show}")
+            rm = ResourceManager(pub2, expected_total=len(blobs), show_progress=show)
+            with rm.progress():
+                for local, remote in blobs:
+                    rm.process_blob(local, remote)
+            return (rm.total_registered, rm.unique_count, rm.existing, rm.uploaded)
+
+        assert run(False) == run(True)
+
+    def test_progress_closes_on_error(self, tmp_path: Path) -> None:
+        pub, local_root, _origin = make_publisher(tmp_path)
+        data = b"boom"
+        chash = content_hash(data)
+        rid = "resource://boom.bin"
+        local = make_blob(local_root, rid, chash, data)
+        remote = remote_blob_path(rid, chash)
+
+        rm = ResourceManager(pub, show_progress=True)
+        with (
+            mock.patch.object(pub, "_upload_file", side_effect=RuntimeError("forced")),
+            pytest.raises(RuntimeError, match="forced"),
+            rm.progress(),
+        ):
+            rm.process_blob(local, remote)
+
+        assert rm._bar is None
+
+    def test_parallel_safety(self, tmp_path: Path) -> None:
+        pub, _local_root, _origin = make_publisher(tmp_path)
+
+        unique_paths = [remote_blob_path(f"resource://par-{i}.bin", "0" * 64) for i in range(250)]
+        existing = {p for idx, p in enumerate(unique_paths) if idx % 2 == 0}
+
+        put_count = 0
+        put_lock = threading.Lock()
+
+        def fake_remote_exists(remote_path: str) -> bool:
+            return remote_path in existing
+
+        def fake_upload_file(src: Path, remote_path: str) -> None:
+            nonlocal put_count
+            with put_lock:
+                put_count += 1
+
+        pub._remote_exists = fake_remote_exists  # type: ignore[method-assign]
+        pub._upload_file = fake_upload_file  # type: ignore[method-assign]
+
+        dispatch = unique_paths * 2
+        random.Random(1234).shuffle(dispatch)
+
+        rm = ResourceManager(pub, show_progress=False)
+        dummy = tmp_path / "dummy"
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            futures = [ex.submit(rm.process_blob, dummy, remote) for remote in dispatch]
+            for fut in as_completed(futures):
+                fut.result()
+
+        assert rm.total_registered == 500
+        assert rm.unique_count == 250
+        assert rm.uploaded == rm.unique_count
+        assert rm.existing == 125
+        assert put_count == 125
+        assert rm.existing + put_count == rm.unique_count
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — Publisher end-to-end (origin mode)
+# ---------------------------------------------------------------------------
+
+
+def _build_shared_blob_generation(root: Path) -> dict[str, str]:
+    """Generation with two resource snapshots sharing one blob + a release APK blob."""
+    snap_store = SnapshotStore(root)
+    gen_store = GenerationStore(root)
+    head_store = ChannelHeadStore(root)
+
+    shared_data = b"shared-resource-bytes"
+    shared_chash = content_hash(shared_data)
+    make_blob(root, "resource://shared.bin", shared_chash, shared_data)
+
+    a_data = b"unique-a-bytes"
+    a_chash = content_hash(a_data)
+    make_blob(root, "resource://a.bin", a_chash, a_data)
+
+    b_data = b"unique-b-bytes"
+    b_chash = content_hash(b_data)
+    make_blob(root, "resource://b.bin", b_chash, b_data)
+
+    apk_data = b"apk-artifact-bytes"
+    apk_chash = content_hash(apk_data)
+    apk_id = "release://1.0.0/android/general"
+    make_blob(root, apk_id, apk_chash, apk_data)
+
+    idx_a = ResourceIndex()
+    idx_a.schema_version = 1
+    for rid, ch, data in (
+        ("resource://shared.bin", shared_chash, shared_data),
+        ("resource://a.bin", a_chash, a_data),
+    ):
+        e = idx_a.entries.add()
+        e.resource_id = rid
+        e.content_hash = ch
+        e.size = len(data)
+
+    idx_b = ResourceIndex()
+    idx_b.schema_version = 1
+    for rid, ch, data in (
+        ("resource://shared.bin", shared_chash, shared_data),
+        ("resource://b.bin", b_chash, b_data),
+    ):
+        e = idx_b.entries.add()
+        e.resource_id = rid
+        e.content_hash = ch
+        e.size = len(data)
+
+    meta = ResourceSnapshotMetadata(
+        serverId="srvA",
+        gameBuild="1.0",
+        gameVersion="Test",
+        resourceCount=2,
+        createdAt="2026-01-01T00:00:00Z",
+    )
+    snap_a = snap_store.create_resource_snapshot(meta, idx_a)
+    meta_b = ResourceSnapshotMetadata(
+        serverId="srvB",
+        gameBuild="1.0",
+        gameVersion="Test",
+        resourceCount=2,
+        createdAt="2026-01-01T00:00:00Z",
+    )
+    snap_b = snap_store.create_resource_snapshot(meta_b, idx_b)
+
+    rel_index = make_release_index(
+        release_id="rel-001",
+        version="1.0.0",
+        android={"general": {"identifier": apk_id, "content_hash": apk_chash}},
+    )
+    rel_meta = ReleaseSnapshotMetadata(
+        releaseCount=1,
+        createdAt="2026-01-01T00:00:00Z",
+    )
+    release_snap = snap_store.create_release_snapshot(rel_meta, rel_index)
+
+    server_index = make_server_index(
+        [
+            ("srvA", {"en": "Server A"}, "1.0", "Test", "", "", ""),
+            ("srvB", {"en": "Server B"}, "1.0", "Test", "", "", ""),
+        ]
+    )
+    resources = make_generation_resources([("srvA", snap_a), ("srvB", snap_b)])
+    release_ptr = make_generation_pointer(release_snap)
+    gen_meta = GenerationMetadata(channel="stable", timestamp="2026-01-01T00:00:00Z")
+    gen_hash = gen_store.create(gen_meta, server_index, resources, release_ptr)
+
+    head_store.ensure_channel("stable")
+    head_store.push("stable", gen_hash)
+
+    return {
+        "snap_a": snap_a,
+        "snap_b": snap_b,
+        "release_snap": release_snap,
+        "gen_hash": gen_hash,
+        "apk_remote": remote_blob_path(apk_id, apk_chash),
+        "shared_remote": remote_blob_path("resource://shared.bin", shared_chash),
+    }
+
+
+def _build_apk_dedup_generation(root: Path) -> dict[str, str]:
+    """Generation where a resource blob is byte-identical to the release APK blob."""
+    snap_store = SnapshotStore(root)
+    gen_store = GenerationStore(root)
+    head_store = ChannelHeadStore(root)
+
+    apk_data = b"apk-and-resource-identical"
+    apk_chash = content_hash(apk_data)
+    apk_id = "release://2.0.0/android/general"
+    make_blob(root, apk_id, apk_chash, apk_data)
+
+    idx = ResourceIndex()
+    idx.schema_version = 1
+    e = idx.entries.add()
+    e.resource_id = apk_id
+    e.content_hash = apk_chash
+    e.size = len(apk_data)
+
+    meta = ResourceSnapshotMetadata(
+        serverId="srvA",
+        gameBuild="1.0",
+        gameVersion="Test",
+        resourceCount=1,
+        createdAt="2026-01-01T00:00:00Z",
+    )
+    snap = snap_store.create_resource_snapshot(meta, idx)
+
+    rel_index = make_release_index(
+        release_id="rel-002",
+        version="2.0.0",
+        android={"general": {"identifier": apk_id, "content_hash": apk_chash}},
+    )
+    rel_meta = ReleaseSnapshotMetadata(releaseCount=1, createdAt="2026-01-01T00:00:00Z")
+    release_snap = snap_store.create_release_snapshot(rel_meta, rel_index)
+
+    server_index = make_server_index([("srvA", {"en": "Server A"}, "1.0", "Test", "", "", "")])
+    resources = make_generation_resources([("srvA", snap)])
+    release_ptr = make_generation_pointer(release_snap)
+    gen_meta = GenerationMetadata(channel="stable", timestamp="2026-01-01T00:00:00Z")
+    gen_hash = gen_store.create(gen_meta, server_index, resources, release_ptr)
+
+    head_store.ensure_channel("stable")
+    head_store.push("stable", gen_hash)
+
+    return {"apk_remote": remote_blob_path(apk_id, apk_chash)}
+
+
+class TestPublisherIntegration:
+    def test_publish_dedups_shared_blob(self, tmp_path: Path) -> None:
+        root = tmp_path / "local"
+        root.mkdir(parents=True, exist_ok=True)
+        origin = make_origin(tmp_path)
+        info = _build_shared_blob_generation(root)
+        pub = Publisher(root, origin_dir=origin)
+
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            pub.publish_all_for_head("stable")
+
+        puts = blob_puts(spy)
+        assert len(puts) == 4
+        assert len(set(puts)) == 4
+        assert puts.count(info["shared_remote"]) == 1
+
+    def test_publish_uploads_dirs_unchanged(self, tmp_path: Path) -> None:
+        root = tmp_path / "local"
+        root.mkdir(parents=True, exist_ok=True)
+        origin = make_origin(tmp_path)
+        info = _build_shared_blob_generation(root)
+        pub = Publisher(root, origin_dir=origin)
+
+        pub.publish_all_for_head("stable")
+
+        base = origin / "efa" / "v2"
+        assert (base / "assets" / "resources" / info["snap_a"] / "metadata.json").is_file()
+        assert (base / "assets" / "resources" / info["snap_b"] / "metadata.json").is_file()
+        assert (base / "assets" / "releases" / info["release_snap"] / "metadata.json").is_file()
+        assert (base / "channels" / "refs" / info["gen_hash"] / "metadata.json").is_file()
+        assert (base / "channels" / "heads" / "stable" / "metadata.json").is_file()
+
+    def test_republish_is_noop(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        root = tmp_path / "local"
+        root.mkdir(parents=True, exist_ok=True)
+        origin = make_origin(tmp_path)
+        _build_shared_blob_generation(root)
+        pub = Publisher(root, origin_dir=origin)
+
+        pub.publish_all_for_head("stable")
+
+        capsys.readouterr()
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            pub.publish_all_for_head("stable")
+        out = capsys.readouterr().out
+
+        assert blob_puts(spy) == []
+        parsed = _parse_summary(out)
+        assert parsed["uploaded"] == 0
+        assert parsed["existing"] == parsed["unique"] == 4
+
+    def test_release_blob_via_rm(self, tmp_path: Path) -> None:
+        root = tmp_path / "local"
+        root.mkdir(parents=True, exist_ok=True)
+        origin = make_origin(tmp_path)
+        info = _build_apk_dedup_generation(root)
+        pub = Publisher(root, origin_dir=origin)
+
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            pub.publish_all_for_head("stable")
+
+        puts = blob_puts(spy)
+        assert puts.count(info["apk_remote"]) == 1
+        assert len(puts) == 1
+        assert (origin / info["apk_remote"]).is_file()
+
+
+# ---------------------------------------------------------------------------
+# Internal
+# ---------------------------------------------------------------------------
+
+
+def _parse_summary(out: str) -> dict[str, int]:
+    """Extract the integer fields from a ``log_summary`` block."""
+    result: dict[str, int] = {}
+    for line in out.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Unique blobs after dedup:"):
+            result["unique"] = int(stripped.rsplit(maxsplit=1)[-1])
+        elif stripped.startswith("Existing on remote:"):
+            result["existing"] = int(stripped.rsplit(maxsplit=1)[-1])
+        elif stripped.startswith("Uploaded:"):
+            result["uploaded"] = int(stripped.rsplit(maxsplit=1)[-1])
+    return result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deduplicating, idempotent publishing workflow that reuses already-uploaded blobs and processes uploads in parallel.
  * Introduced upload progress reporting with a final summary of registered, existing, and newly uploaded content.
* **Bug Fixes**
  * Republishing now reliably skips blobs that already exist on the remote target, reducing unnecessary operations.
* **Tests**
  * Added unit and integration coverage for deduplication across snapshots, remote existence detection, progress/error behavior, parallel safety, and republish no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->