### PR TITLE
feat: refactor developer tools into dedicated sub-page and update settings

### DIFF
--- a/lib/pages/router.dart
+++ b/lib/pages/router.dart
@@ -10,6 +10,7 @@ import "package:eve_fit_assistant/pages/setting/channel_overview/page.dart";
 import "package:eve_fit_assistant/pages/setting/data/channel_metadata.dart";
 import "package:eve_fit_assistant/pages/setting/data/checkout_management.dart";
 import "package:eve_fit_assistant/pages/setting/data/storage.dart";
+import "package:eve_fit_assistant/pages/setting/developer-tools/page.dart";
 import "package:eve_fit_assistant/pages/view.dart";
 import "package:eve_fit_assistant/pages/workspace/create-fit/page.dart";
 import "package:flutter/material.dart";
@@ -31,6 +32,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(path: "/setting/data/storage", page: StorageManagement.page),
     AutoRoute(path: "/setting/data/channel-metadata", page: ChannelMetadataRoute.page),
     AutoRoute(path: "/setting/data/checkouts", page: CheckoutManagementRoute.page),
+    AutoRoute(path: "/setting/developer-tools", page: DeveloperToolsRoute.page),
     AutoRoute(path: "/setting/channel-overview", page: ChannelOverviewRoute.page),
     AutoRoute(path: "/setting/report-feedback", page: ReportFeedbackRoute.page),
     AutoRoute(path: "/setting/report-feedback/external", page: ReportExternalLinksRoute.page),

--- a/lib/pages/setting/app-settings/page.dart
+++ b/lib/pages/setting/app-settings/page.dart
@@ -8,8 +8,6 @@ import "package:eve_fit_assistant/components/list/config_list.dart";
 import "package:eve_fit_assistant/components/list/dropdown_list_tile.dart";
 import "package:eve_fit_assistant/config/locale.dart" show Locale;
 import "package:eve_fit_assistant/config/type_list.dart";
-import "package:eve_fit_assistant/features/feedback/feedback_dialog.dart";
-import "package:eve_fit_assistant/features/feedback/feedback_state_store.dart";
 import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
 import "package:eve_fit_assistant/pages/router.dart";
 import "package:eve_fit_assistant/storage/setting/setting.dart";
@@ -25,9 +23,7 @@ part "developer_remote_content.dart";
 part "font_scale.dart";
 part "impact_warning.dart";
 part "locale.dart";
-part "restart_init.dart";
 part "select_list.dart";
-part "trigger_feedback.dart";
 
 @RoutePage()
 class AppSettingsPage extends ConsumerWidget {
@@ -68,8 +64,6 @@ class AppSettingsPage extends ConsumerWidget {
           subtitle: context.l10n.appSettingsPageClearCacheDescription,
           onTap: () => unawaited(_clearCache(context)),
         ),
-        if (ref.watch(developerModeProvider)) const ConfigListTile.custom(RestartInitTile()),
-        if (ref.watch(developerModeProvider)) const ConfigListTile.custom(TriggerFeedbackTile()),
       ],
     ),
   );

--- a/lib/pages/setting/app-settings/restart_init.dart
+++ b/lib/pages/setting/app-settings/restart_init.dart
@@ -1,4 +1,8 @@
-part of "page.dart";
+import "dart:async";
+
+import "package:eve_fit_assistant/storage/setting/setting.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
 
 class RestartInitTile extends ConsumerWidget {
   const RestartInitTile({super.key});

--- a/lib/pages/setting/app-settings/trigger_feedback.dart
+++ b/lib/pages/setting/app-settings/trigger_feedback.dart
@@ -1,4 +1,10 @@
-part of "page.dart";
+import "dart:async";
+
+import "package:auto_route/auto_route.dart";
+import "package:eve_fit_assistant/features/feedback/feedback_dialog.dart";
+import "package:eve_fit_assistant/features/feedback/feedback_state_store.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
 
 class TriggerFeedbackTile extends ConsumerWidget {
   const TriggerFeedbackTile({super.key});

--- a/lib/pages/setting/developer-tools/page.dart
+++ b/lib/pages/setting/developer-tools/page.dart
@@ -1,0 +1,37 @@
+// THIS FILE DOES NOT USE LOCALIZATION.
+// All strings are hardcoded English — this is a developer-facing page,
+// not an end-user screen.
+
+import "dart:async";
+
+import "package:auto_route/auto_route.dart";
+import "package:eve_fit_assistant/components/layout.dart";
+import "package:eve_fit_assistant/components/list/config_list.dart";
+import "package:eve_fit_assistant/pages/router.dart";
+import "package:eve_fit_assistant/pages/setting/app-settings/restart_init.dart";
+import "package:eve_fit_assistant/pages/setting/app-settings/trigger_feedback.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+@RoutePage()
+class DeveloperToolsPage extends ConsumerWidget {
+  const DeveloperToolsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) => Layout(
+    title: "Developer Tools",
+    child: ConfigListView(
+      children: [
+        const ConfigListTile.space(20),
+        ConfigListTile.item(
+          icon: const Icon(Icons.info_outline),
+          title: "Channel Overview",
+          subtitle: "Remote channel metadata and sync status",
+          onTap: () => unawaited(context.router.push(const ChannelOverviewRoute())),
+        ),
+        const ConfigListTile.custom(RestartInitTile()),
+        const ConfigListTile.custom(TriggerFeedbackTile()),
+      ],
+    ),
+  );
+}

--- a/lib/pages/setting/developer-tools/page.dart
+++ b/lib/pages/setting/developer-tools/page.dart
@@ -10,6 +10,7 @@ import "package:eve_fit_assistant/components/list/config_list.dart";
 import "package:eve_fit_assistant/pages/router.dart";
 import "package:eve_fit_assistant/pages/setting/app-settings/restart_init.dart";
 import "package:eve_fit_assistant/pages/setting/app-settings/trigger_feedback.dart";
+import "package:eve_fit_assistant/storage/setting/setting.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
@@ -18,20 +19,29 @@ class DeveloperToolsPage extends ConsumerWidget {
   const DeveloperToolsPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) => Layout(
-    title: "Developer Tools",
-    child: ConfigListView(
-      children: [
-        const ConfigListTile.space(20),
-        ConfigListTile.item(
-          icon: const Icon(Icons.info_outline),
-          title: "Channel Overview",
-          subtitle: "Remote channel metadata and sync status",
-          onTap: () => unawaited(context.router.push(const ChannelOverviewRoute())),
-        ),
-        const ConfigListTile.custom(RestartInitTile()),
-        const ConfigListTile.custom(TriggerFeedbackTile()),
-      ],
-    ),
-  );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final developerMode = ref.watch(developerModeProvider);
+    if (!developerMode) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(context.router.replace(const FrontRoute()));
+      });
+      return const SizedBox.shrink();
+    }
+    return Layout(
+      title: "Developer Tools",
+      child: ConfigListView(
+        children: [
+          const ConfigListTile.space(20),
+          ConfigListTile.item(
+            icon: const Icon(Icons.info_outline),
+            title: "Channel Overview",
+            subtitle: "Remote channel metadata and sync status",
+            onTap: () => unawaited(context.router.push(const ChannelOverviewRoute())),
+          ),
+          const ConfigListTile.custom(RestartInitTile()),
+          const ConfigListTile.custom(TriggerFeedbackTile()),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/pages/setting/page.dart
+++ b/lib/pages/setting/page.dart
@@ -39,10 +39,10 @@ class SettingPage extends ConsumerWidget {
         ),
         if (developerMode)
           ConfigListTile.item(
-            icon: const Icon(Icons.info_outline),
-            title: "Channel Overview",
-            subtitle: "Remote channel metadata and sync status",
-            onTap: () => unawaited(context.router.push(const ChannelOverviewRoute())),
+            icon: const Icon(Icons.developer_mode),
+            title: "Developer Tools",
+            subtitle: "Channel overview, restart init, trigger feedback",
+            onTap: () => unawaited(context.router.push(const DeveloperToolsRoute())),
           ),
         ConfigListTile.item(
           icon: const Icon(Icons.feedback_outlined),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Developer Tools** page in Settings.
  * Moved developer-only actions into a dedicated screen, including channel overview, restart init, and feedback trigger options.
* **UI Changes**
  * Replaced the old developer-mode settings entry with a **Developer Tools** tile and updated its description.
  * Simplified the main settings list by removing those developer options from the inline list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->