### PR TITLE
feat(setting): enable developer mode via 5-tap easter egg on version page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,14 +104,20 @@ The `RepoStateNotifier` initializes asynchronously at startup; `SchemaGuard` wat
 
 ## Developer Mode
 
-The `AppSetting` model (`lib/storage/setting/setting.dart`) includes a `developerMode` boolean field (default `false`). A toggle in App Settings → Developer section enables it, with a confirmation dialog on enable.
+The `AppSetting` model (`lib/storage/setting/setting.dart`) includes a `developerMode` boolean field (default `false`). It is not exposed as a normal settings toggle.
+
+**Access:** On **Settings → Version**, tap the **App Version** value in the version info table 5 times within 2 seconds. A confirmation dialog (`developerModeEnableConfirmTitle` / `developerModeEnableConfirmDescription`) is shown; confirming sets `developerMode` to `true` via `appSettingServiceProvider`. Once enabled, a **Developer Settings** card appears on the Version page.
+
+**Entry points after enabled:**
+- Version page → Developer Settings (`/setting/developer-settings`): debug log toggle, remote-content settings visibility, open remote content settings, collect logs, clear cache, and a shortcut to Developer Tools.
+- Developer Settings → Developer Tools (`/setting/developer-tools`): channel overview, restart init, trigger feedback, reset all storage.
 
 **Providers:**
 - `developerModeProvider` — reactive read via `ref.watch(developerModeProvider)` (always up-to-date).
 - `appSettingServiceProvider.select((s) => s.developerMode)` — fine-grained reactive read.
 - `ref.read(appSettingServiceProvider).developerMode` — imperative read within callbacks.
 
-**Localization rule for developer-only widgets:** UI widgets gated behind `developerMode` (i.e., only visible when dev mode is on) **must use hardcoded English**. No ARB entries or `context.l10n` calls for dev-only UI. Only the toggle itself and its confirmation dialog use localization (they are always visible in the settings page).
+**Localization rule for developer-only widgets:** UI widgets gated behind `developerMode` (i.e., only visible when dev mode is on) **must use hardcoded English**. No ARB entries or `context.l10n` calls for dev-only UI. Only the enable-confirmation dialog and the always-visible Version page elements use localization.
 
 ## Style And Generated-Code Gotchas
 

--- a/lib/pages/setting/version/page.dart
+++ b/lib/pages/setting/version/page.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:auto_route/auto_route.dart";
+import "package:eve_fit_assistant/components/dialog/confirm_dialog.dart";
 import "package:eve_fit_assistant/components/layout.dart";
 import "package:eve_fit_assistant/features/announcements/repository/repository.dart"
     show availableUpdateProvider, unreadAnnouncementCountProvider;
@@ -27,11 +28,19 @@ class VersionPage extends ConsumerStatefulWidget {
 
 class _VersionPageState extends ConsumerState<VersionPage> {
   late final Future<PackageInfo> _packageInfoFuture;
+  int _versionTapCount = 0;
+  Timer? _versionTapResetTimer;
 
   @override
   void initState() {
     super.initState();
     _packageInfoFuture = PackageInfo.fromPlatform();
+  }
+
+  @override
+  void dispose() {
+    _versionTapResetTimer?.cancel();
+    super.dispose();
   }
 
   @override
@@ -89,7 +98,7 @@ class _VersionPageState extends ConsumerState<VersionPage> {
                           (
                             label: context.l10n.versionPageAppVersion,
                             value: info?.version,
-                            onTap: null,
+                            onTap: () => _onVersionRowTapped(context),
                           ),
                           (
                             label: context.l10n.versionPageBuildNumber,
@@ -140,7 +149,7 @@ class _VersionPageState extends ConsumerState<VersionPage> {
                         (
                           label: context.l10n.versionPageAppVersion,
                           value: info?.version,
-                          onTap: null,
+                          onTap: () => _onVersionRowTapped(context),
                         ),
                         (
                           label: context.l10n.versionPageBuildNumber,
@@ -197,6 +206,34 @@ class _VersionPageState extends ConsumerState<VersionPage> {
     final localizedName = entry.name[localeName];
     if (localizedName != null && localizedName.isNotEmpty) return localizedName;
     return entry.serverId;
+  }
+
+  void _onVersionRowTapped(BuildContext context) {
+    if (ref.read(appSettingServiceProvider).developerMode) return;
+
+    _versionTapResetTimer?.cancel();
+    _versionTapCount++;
+    _versionTapResetTimer = Timer(const Duration(seconds: 2), () {
+      if (mounted) setState(() => _versionTapCount = 0);
+    });
+
+    if (_versionTapCount >= 5) {
+      _versionTapResetTimer?.cancel();
+      _versionTapCount = 0;
+      unawaited(_showEnableDeveloperModeDialog(context));
+    }
+  }
+
+  Future<void> _showEnableDeveloperModeDialog(BuildContext context) async {
+    final confirmed = await showConfirmDialog(
+      context,
+      title: context.l10n.developerModeEnableConfirmTitle,
+      content: Text(context.l10n.developerModeEnableConfirmDescription),
+    );
+    if (!confirmed || !context.mounted) return;
+    ref
+        .read(appSettingServiceProvider.notifier)
+        .update((setting) => setting.copyWith(developerMode: true));
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hidden way to enable Developer Mode from the App Version screen by tapping the version item multiple times quickly.
  * Added a confirmation prompt before Developer Mode is turned on.
  * Expanded the Version and Developer Tools screens to be the main entry points once Developer Mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->