### PR TITLE
feat(ci): implement CI raw data updater and enhance workflow configuration

### DIFF
--- a/.github/workflows/update-raw-data.yml
+++ b/.github/workflows/update-raw-data.yml
@@ -1,0 +1,102 @@
+name: Update Raw EVE Data
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check for updates
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Python dependencies
+        run: nix develop .#python --command bash -c 'uv sync'
+
+      - name: Determine update matrix
+        id: matrix
+        run: |
+          MATRIX=$(nix develop .#python --command bash -c \
+            'uv run x.py ci raw-data check --all --format json')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  update:
+    name: Update raw artifacts
+    needs: check
+    if: ${{ needs.check.outputs.matrix != '[]' }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        server: ${{ fromJSON(needs.check.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Download portable Python 2.7
+        run: |
+          curl.exe -L -o tools/eve-fsd-dumper/py27.zip `
+            https://ci.storage.efa-tech.dev/build-dependencies/py27.zip
+
+      - name: Update raw artifacts
+        run: uv run x.py ci raw-data update --server ${{ matrix.server }} --no-upload
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: raw-artifacts-${{ matrix.server }}
+          path: cache/raw-artifacts/${{ matrix.server }}/
+          retention-days: 1
+
+  upload:
+    name: Upload raw artifacts
+    needs: update
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        server: ${{ fromJSON(needs.check.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: raw-artifacts-${{ matrix.server }}
+          path: raw-artifacts/${{ matrix.server }}/
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Install Python dependencies
+        run: nix develop .#python --command bash -c 'uv sync'
+
+      - name: Upload to CI storage
+        env:
+          CI_ENDPOINT: ${{ secrets.CI_STORAGE_ENDPOINT }}
+          CI_BUCKET: ${{ secrets.CI_STORAGE_BUCKET }}
+          CI_ALIAS: ${{ secrets.CI_STORAGE_ALIAS }}
+          CI_ACCESS_KEY: ${{ secrets.CI_STORAGE_ACCESS_KEY }}
+          CI_SECRET_KEY: ${{ secrets.CI_STORAGE_SECRET_KEY }}
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py \
+              --dev-env ci.storage.endpoint="$CI_ENDPOINT" \
+              --dev-env ci.storage.bucket="$CI_BUCKET" \
+              --dev-env ci.storage.alias="$CI_ALIAS" \
+              --dev-env ci.storage.access_key="$CI_ACCESS_KEY" \
+              --dev-env ci.storage.secret_key="$CI_SECRET_KEY" \
+              --dev-env ci.raw_artifacts.remote_root="data-generator/raw-artifact" \
+              ci raw-data upload --server ${{ matrix.server }} --from-dir raw-artifacts/${{ matrix.server }}/'

--- a/.github/workflows/update-raw-data.yml
+++ b/.github/workflows/update-raw-data.yml
@@ -84,9 +84,7 @@ jobs:
             https://ci.storage.efa-tech.dev/build-dependencies/py27.zip
 
       - name: Update raw artifacts
-        env:
-          SERVER: ${{ matrix.server }}
-        run: uv run x.py ci raw-data update --server "$SERVER" --no-upload
+        run: uv run x.py ci raw-data update --server "${{ matrix.server }}" --no-upload
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/update-raw-data.yml
+++ b/.github/workflows/update-raw-data.yml
@@ -1,44 +1,76 @@
 name: Update Raw EVE Data
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
     name: Check for updates
     runs-on: ubuntu-latest
+    if: |
+      (
+        contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) &&
+        github.ref == 'refs/heads/dev' &&
+        github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
+        github.event.repository.fork == false
+      ) || (
+        github.event_name == 'pull_request' &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'D-Full CI') ||
+          contains(github.event.pull_request.labels.*.name, 'D-CI-Data Update')
+        )
+      )
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Install Python dependencies
         run: nix develop .#python --command bash -c 'uv sync'
 
       - name: Determine update matrix
         id: matrix
+        env:
+          CI_PUBLIC_URL: https://ci.storage.efa-tech.dev
         run: |
           MATRIX=$(nix develop .#python --command bash -c \
-            'uv run x.py ci raw-data check --all --format json')
+            'uv run x.py \
+              --dev-env ci.raw_artifacts.public_url="$CI_PUBLIC_URL" \
+              ci raw-data check --all --format json')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   update:
     name: Update raw artifacts
     needs: check
-    if: ${{ needs.check.outputs.matrix != '[]' }}
+    if: ${{ needs.check.outputs.matrix != '' && needs.check.outputs.matrix != '[]' }}
     runs-on: windows-latest
     strategy:
       fail-fast: true
       matrix:
         server: ${{ fromJSON(needs.check.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -63,15 +95,23 @@ jobs:
 
   upload:
     name: Upload raw artifacts
-    needs: update
+    needs: [check, update]
+    if: |
+      github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/dev' &&
+      github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
+      github.event.repository.fork == false &&
+      needs.check.outputs.matrix != '' &&
+      needs.check.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         server: ${{ fromJSON(needs.check.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+          persist-credentials: false
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/update-raw-data.yml
+++ b/.github/workflows/update-raw-data.yml
@@ -2,7 +2,6 @@ name: Update Raw EVE Data
 
 permissions:
   contents: read
-  actions: write
 
 on:
   schedule:
@@ -85,7 +84,9 @@ jobs:
             https://ci.storage.efa-tech.dev/build-dependencies/py27.zip
 
       - name: Update raw artifacts
-        run: uv run x.py ci raw-data update --server ${{ matrix.server }} --no-upload
+        env:
+          SERVER: ${{ matrix.server }}
+        run: uv run x.py ci raw-data update --server "$SERVER" --no-upload
 
       - uses: actions/upload-artifact@v4
         with:
@@ -125,6 +126,7 @@ jobs:
 
       - name: Upload to CI storage
         env:
+          SERVER: ${{ matrix.server }}
           CI_ENDPOINT: ${{ secrets.CI_STORAGE_ENDPOINT }}
           CI_BUCKET: ${{ secrets.CI_STORAGE_BUCKET }}
           CI_ALIAS: ${{ secrets.CI_STORAGE_ALIAS }}
@@ -139,4 +141,4 @@ jobs:
               --dev-env ci.storage.access_key="$CI_ACCESS_KEY" \
               --dev-env ci.storage.secret_key="$CI_SECRET_KEY" \
               --dev-env ci.raw_artifacts.remote_root="data-generator/raw-artifact" \
-              ci raw-data upload --server ${{ matrix.server }} --from-dir raw-artifacts/${{ matrix.server }}/'
+              ci raw-data upload --server "$SERVER" --from-dir raw-artifacts/"$SERVER"/'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "rust/lib/eve-fit-os"]
 	path = rust/lib/eve-fit-os
 	url = https://github.com/Embers-of-the-Fire/eve-fit-os
+[submodule "tools/eve-fsd-dumper"]
+	path = tools/eve-fsd-dumper
+	url = https://github.com/Embers-of-the-Fire/EVE-FSD-Dumper.git

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -14,8 +14,8 @@ from bootstrap.ci.codegen import run_codegen
 from bootstrap.ci.lint import run_lint
 from bootstrap.ci.suites import SUITE_DEFINITIONS
 from bootstrap.ci.suites import calculate_ci_matrix
+from bootstrap.cli import runtime
 from bootstrap.color import styled
-from bootstrap.utils import execute_command
 from bootstrap.utils import get_command
 
 
@@ -136,18 +136,28 @@ def register_ci_commands(cli_group: click.Group) -> None:
 
         if upload:
             mc = get_command("mc")
-            execute_command(
+            redacted = "<redacted>"
+            runtime.execute_redacted(
                 [
                     mc,
                     "alias",
                     "set",
                     storage.alias,
                     storage.endpoint,
-                    storage.access_key,
-                    storage.secret_key,
+                    storage.access_key.get_secret_value(),
+                    storage.secret_key.get_secret_value(),
+                ],
+                [
+                    mc,
+                    "alias",
+                    "set",
+                    storage.alias,
+                    storage.endpoint,
+                    redacted,
+                    redacted,
                 ],
                 "CI STORAGE ALIAS",
             )
-            execute_command([mc, "cp", str(out_path), remote_path], "CI STORAGE UPLOAD")
+            runtime.execute([mc, "cp", str(out_path), remote_path], "CI STORAGE UPLOAD")
         else:
             click.echo(f"Upload with: mc cp {out_path} {remote_path}")

--- a/bootstrap/cli/__init__.py
+++ b/bootstrap/cli/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from bootstrap.ci import register_ci_commands
 from bootstrap.cli.build import register_build_commands
+from bootstrap.cli.ci.updater import register_raw_data_commands
 from bootstrap.cli.dev import register_dev_commands
 from bootstrap.cli.etc import register_etc_commands
 from bootstrap.cli.generate import register_generate_commands
@@ -30,6 +31,7 @@ def register_all_commands(cli_group: click.Group) -> None:
     register_etc_commands(cli_group)
     register_test_commands(cli_group)
     register_ci_commands(cli_group)
+    register_raw_data_commands(cli_group.commands["ci"])
 
 
 __all__ = ["register_all_commands"]

--- a/bootstrap/cli/ci/updater.py
+++ b/bootstrap/cli/ci/updater.py
@@ -16,20 +16,18 @@ from bootstrap.constant import PROJECT_ROOT
 from bootstrap.data.updater.pipeline import check_server
 from bootstrap.data.updater.pipeline import update_server
 from bootstrap.data.updater.server import SERVER_ALIASES
+from bootstrap.data.updater.server import SERVER_IDS
 from bootstrap.data.updater.uploader import upload_artifacts
-
-
-_ALL_SERVERS = ["tranquility", "serenity", "singularity"]
 
 
 def _resolve_server_input(server: str | None, all_flag: bool) -> list[str]:
     """Return the list of server identifiers to operate on."""
     if all_flag:
-        return list(_ALL_SERVERS)
+        return sorted(SERVER_IDS)
     if server is None:
         raise click.UsageError("Provide --server or --all.")
     normalized = SERVER_ALIASES.get(server.lower(), server.lower())
-    if normalized not in _ALL_SERVERS:
+    if normalized not in SERVER_IDS:
         raise click.UsageError(f"Unknown server: {server}")
     return [normalized]
 
@@ -40,7 +38,7 @@ def register_raw_data_commands(ci: click.Group) -> None:
         """Manage CI raw EVE client artifact updates."""
 
     @raw_data.command("check")
-    @click.option("--server", default=None, help="Server id (tranquility, serenity, singularity).")
+    @click.option("--server", default=None, help=f"Server id ({', '.join(sorted(SERVER_IDS))}).")
     @click.option("--all", "all_flag", is_flag=True, help="Check all servers.")
     @click.option(
         "--format",
@@ -73,7 +71,7 @@ def register_raw_data_commands(ci: click.Group) -> None:
         asyncio.run(run())
 
     @raw_data.command("update")
-    @click.option("--server", default=None, help="Server id (tranquility, serenity, singularity).")
+    @click.option("--server", default=None, help=f"Server id ({', '.join(sorted(SERVER_IDS))}).")
     @click.option("--all", "all_flag", is_flag=True, help="Update all servers.")
     @click.option("--no-upload", is_flag=True, help="Skip uploading to CI storage.")
     @click.option("--keep-temp", is_flag=True, help="Keep temporary working directories.")
@@ -95,7 +93,7 @@ def register_raw_data_commands(ci: click.Group) -> None:
         asyncio.run(run())
 
     @raw_data.command("upload")
-    @click.option("--server", required=True, help="Server id (tranquility, serenity, singularity).")
+    @click.option("--server", required=True, help=f"Server id ({', '.join(sorted(SERVER_IDS))}).")
     @click.option(
         "--from-dir",
         type=click.Path(exists=True, file_okay=False, path_type=Path),
@@ -130,7 +128,7 @@ def register_raw_data_commands(ci: click.Group) -> None:
         click.echo(f"Uploaded {normalized} build {build} from {from_dir}")
 
     @raw_data.command("sync-local")
-    @click.option("--server", required=True, help="Server id (tranquility, serenity, singularity).")
+    @click.option("--server", required=True, help=f"Server id ({', '.join(sorted(SERVER_IDS))}).")
     def raw_data_sync_local(server: str):
         """Upload the local ``data/resources/<server>/`` tree to CI storage as-is."""
         normalized = _resolve_server_input(server, False)[0]

--- a/bootstrap/cli/ci/updater.py
+++ b/bootstrap/cli/ci/updater.py
@@ -1,0 +1,169 @@
+"""CI raw-data updater subcommands."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+
+from pathlib import Path
+
+import click
+
+import bootstrap.config
+
+from bootstrap.constant import PROJECT_ROOT
+from bootstrap.data.updater.pipeline import check_server
+from bootstrap.data.updater.pipeline import update_server
+from bootstrap.data.updater.server import SERVER_ALIASES
+from bootstrap.data.updater.uploader import upload_artifacts
+
+
+_ALL_SERVERS = ["tranquility", "serenity", "singularity"]
+
+
+def _resolve_server_input(server: str | None, all_flag: bool) -> list[str]:
+    """Return the list of server identifiers to operate on."""
+    if all_flag:
+        return list(_ALL_SERVERS)
+    if server is None:
+        raise click.UsageError("Provide --server or --all.")
+    normalized = SERVER_ALIASES.get(server.lower(), server.lower())
+    if normalized not in _ALL_SERVERS:
+        raise click.UsageError(f"Unknown server: {server}")
+    return [normalized]
+
+
+async def _check_all() -> list[str]:
+    """Check all servers and return those needing an update."""
+    results: list[str] = []
+    for server_id in _ALL_SERVERS:
+        result = await check_server(server_id)
+        click.echo(f"{server_id}: remote={result.remote_build}, bucket={result.bucket_build}")
+        if result.needs_update:
+            results.append(server_id)
+    return results
+
+
+def register_raw_data_commands(ci: click.Group) -> None:
+    @ci.group("raw-data")
+    def raw_data():
+        """Manage CI raw EVE client artifact updates."""
+
+    @raw_data.command("check")
+    @click.option("--server", default=None, help="Server id (tranquility, serenity, singularity).")
+    @click.option("--all", "all_flag", is_flag=True, help="Check all servers.")
+    @click.option(
+        "--format",
+        "output_format",
+        type=click.Choice(["text", "json"]),
+        default="text",
+        help="Output format (default: text).",
+    )
+    def raw_data_check(server: str | None, all_flag: bool, output_format: str):
+        """Compare remote EVE builds with the CI bucket."""
+        server_ids = _resolve_server_input(server, all_flag)
+
+        async def run():
+            results: list[str] = []
+            for server_id in server_ids:
+                result = await check_server(server_id)
+                if output_format == "json":
+                    pass
+                else:
+                    click.echo(
+                        f"{server_id}: remote={result.remote_build}, "
+                        f"bucket={result.bucket_build}, "
+                        f"needs_update={result.needs_update}"
+                    )
+                if result.needs_update:
+                    results.append(server_id)
+            if output_format == "json":
+                click.echo(json.dumps(results))
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    @raw_data.command("update")
+    @click.option("--server", default=None, help="Server id (tranquility, serenity, singularity).")
+    @click.option("--all", "all_flag", is_flag=True, help="Update all servers.")
+    @click.option("--no-upload", is_flag=True, help="Skip uploading to CI storage.")
+    @click.option("--keep-temp", is_flag=True, help="Keep temporary working directories.")
+    def raw_data_update(server: str | None, all_flag: bool, no_upload: bool, keep_temp: bool):
+        """Download, convert, and optionally upload raw data."""
+        server_ids = _resolve_server_input(server, all_flag)
+
+        async def run():
+            for server_id in server_ids:
+                result = await update_server(
+                    server_id,
+                    upload=not no_upload,
+                    keep_temp=keep_temp,
+                )
+                click.echo(
+                    f"Updated {result.server_id} to build {result.build}: {result.artifacts_dir}"
+                )
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    @raw_data.command("upload")
+    @click.option("--server", required=True, help="Server id (tranquility, serenity, singularity).")
+    @click.option(
+        "--from-dir",
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+        required=True,
+        help="Local directory containing the artifacts/ tree.",
+    )
+    def raw_data_upload(server: str, from_dir: Path):
+        """Upload a pre-built local artifact tree to CI storage."""
+        normalized = _resolve_server_input(server, False)[0]
+        artifacts_dir = from_dir / "artifacts"
+        if not artifacts_dir.is_dir():
+            raise click.ClickException(f"Artifacts directory not found: {artifacts_dir}")
+
+        build_file = from_dir / "build.txt"
+        if not build_file.is_file():
+            raise click.ClickException(f"Build file not found: {build_file}")
+        build = int(build_file.read_text(encoding="utf-8").strip())
+
+        bootstrap.config.DeveloperConfiguration.ensure_loaded()
+        ci = bootstrap.config.DEV_CONFIGURATION.ci
+        if ci.raw_artifacts is None:
+            ci.raw_artifacts = bootstrap.config.DeveloperCiRawArtifacts()
+        raw_artifacts, storage = ci.require_raw_artifacts()
+
+        async def run():
+            await upload_artifacts(normalized, artifacts_dir, build, raw_artifacts, storage)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        click.echo(f"Uploaded {normalized} build {build} from {from_dir}")
+
+    @raw_data.command("sync-local")
+    @click.option("--server", required=True, help="Server id (tranquility, serenity, singularity).")
+    def raw_data_sync_local(server: str):
+        """Upload the local ``data/resources/<server>/`` tree to CI storage as-is."""
+        normalized = _resolve_server_input(server, False)[0]
+        local_dir = PROJECT_ROOT / "data" / "resources" / normalized
+        if not local_dir.is_dir():
+            raise click.ClickException(f"Local resource directory not found: {local_dir}")
+
+        bootstrap.config.DeveloperConfiguration.ensure_loaded()
+        ci = bootstrap.config.DEV_CONFIGURATION.ci
+        if ci.raw_artifacts is None:
+            ci.raw_artifacts = bootstrap.config.DeveloperCiRawArtifacts()
+        raw_artifacts, storage = ci.require_raw_artifacts()
+
+        base_dir = PROJECT_ROOT / "cache" / "raw-artifacts" / normalized
+        if base_dir.exists():
+            shutil.rmtree(base_dir)
+        artifacts_dir = base_dir / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(local_dir, artifacts_dir, dirs_exist_ok=True)
+
+        build_file = base_dir / "build.txt"
+        build_file.write_text("0", encoding="utf-8")
+
+        async def run():
+            await upload_artifacts(normalized, artifacts_dir, 0, raw_artifacts, storage)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        click.echo(f"Synced local {normalized} resources to CI storage")

--- a/bootstrap/cli/ci/updater.py
+++ b/bootstrap/cli/ci/updater.py
@@ -34,17 +34,6 @@ def _resolve_server_input(server: str | None, all_flag: bool) -> list[str]:
     return [normalized]
 
 
-async def _check_all() -> list[str]:
-    """Check all servers and return those needing an update."""
-    results: list[str] = []
-    for server_id in _ALL_SERVERS:
-        result = await check_server(server_id)
-        click.echo(f"{server_id}: remote={result.remote_build}, bucket={result.bucket_build}")
-        if result.needs_update:
-            results.append(server_id)
-    return results
-
-
 def register_raw_data_commands(ci: click.Group) -> None:
     @ci.group("raw-data")
     def raw_data():
@@ -81,7 +70,7 @@ def register_raw_data_commands(ci: click.Group) -> None:
             if output_format == "json":
                 click.echo(json.dumps(results))
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())
 
     @raw_data.command("update")
     @click.option("--server", default=None, help="Server id (tranquility, serenity, singularity).")
@@ -103,7 +92,7 @@ def register_raw_data_commands(ci: click.Group) -> None:
                     f"Updated {result.server_id} to build {result.build}: {result.artifacts_dir}"
                 )
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())
 
     @raw_data.command("upload")
     @click.option("--server", required=True, help="Server id (tranquility, serenity, singularity).")
@@ -123,18 +112,21 @@ def register_raw_data_commands(ci: click.Group) -> None:
         build_file = from_dir / "build.txt"
         if not build_file.is_file():
             raise click.ClickException(f"Build file not found: {build_file}")
-        build = int(build_file.read_text(encoding="utf-8").strip())
+        try:
+            build = int(build_file.read_text(encoding="utf-8").strip())
+        except ValueError as exc:
+            raise click.ClickException(
+                f"Build file does not contain a valid integer: {build_file}"
+            ) from exc
 
         bootstrap.config.DeveloperConfiguration.ensure_loaded()
         ci = bootstrap.config.DEV_CONFIGURATION.ci
-        if ci.raw_artifacts is None:
-            ci.raw_artifacts = bootstrap.config.DeveloperCiRawArtifacts()
         raw_artifacts, storage = ci.require_raw_artifacts()
 
         async def run():
             await upload_artifacts(normalized, artifacts_dir, build, raw_artifacts, storage)
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())
         click.echo(f"Uploaded {normalized} build {build} from {from_dir}")
 
     @raw_data.command("sync-local")
@@ -148,8 +140,6 @@ def register_raw_data_commands(ci: click.Group) -> None:
 
         bootstrap.config.DeveloperConfiguration.ensure_loaded()
         ci = bootstrap.config.DEV_CONFIGURATION.ci
-        if ci.raw_artifacts is None:
-            ci.raw_artifacts = bootstrap.config.DeveloperCiRawArtifacts()
         raw_artifacts, storage = ci.require_raw_artifacts()
 
         base_dir = PROJECT_ROOT / "cache" / "raw-artifacts" / normalized
@@ -165,5 +155,5 @@ def register_raw_data_commands(ci: click.Group) -> None:
         async def run():
             await upload_artifacts(normalized, artifacts_dir, 0, raw_artifacts, storage)
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())
         click.echo(f"Synced local {normalized} resources to CI storage")

--- a/bootstrap/cli/remote/helpers.py
+++ b/bootstrap/cli/remote/helpers.py
@@ -304,8 +304,12 @@ def resolve_announce_remote_target(
         return (
             endpoint or f"http://{remote_cfg.host}:{minio_cfg.port}",
             bucket or minio_cfg.bucket,
-            access_key or minio_cfg.access_key,
-            secret_key or minio_cfg.secret_key,
+            (access_key or minio_cfg.access_key).get_secret_value()
+            if access_key or minio_cfg.access_key
+            else "",
+            (secret_key or minio_cfg.secret_key).get_secret_value()
+            if secret_key or minio_cfg.secret_key
+            else "",
             alias or minio_cfg.alias,
         )
     elif target == "s3":
@@ -318,8 +322,12 @@ def resolve_announce_remote_target(
         return (
             endpoint or s3_cfg.endpoint,
             bucket or s3_cfg.bucket,
-            access_key or s3_cfg.access_key,
-            secret_key or s3_cfg.secret_key,
+            (access_key or s3_cfg.access_key).get_secret_value()
+            if access_key or s3_cfg.access_key
+            else "",
+            (secret_key or s3_cfg.secret_key).get_secret_value()
+            if secret_key or s3_cfg.secret_key
+            else "",
             alias or s3_cfg.alias,
         )
     else:

--- a/bootstrap/cli/remote/helpers.py
+++ b/bootstrap/cli/remote/helpers.py
@@ -301,15 +301,25 @@ def resolve_announce_remote_target(
                 "[remote.minio] is not configured in efa.dev.toml. "
                 "See efa.dev.example.toml for the expected format."
             )
+        if access_key:
+            resolved_access_key = access_key
+        elif minio_cfg.access_key:
+            resolved_access_key = minio_cfg.access_key.get_secret_value()
+        else:
+            resolved_access_key = ""
+
+        if secret_key:
+            resolved_secret_key = secret_key
+        elif minio_cfg.secret_key:
+            resolved_secret_key = minio_cfg.secret_key.get_secret_value()
+        else:
+            resolved_secret_key = ""
+
         return (
             endpoint or f"http://{remote_cfg.host}:{minio_cfg.port}",
             bucket or minio_cfg.bucket,
-            (access_key or minio_cfg.access_key).get_secret_value()
-            if access_key or minio_cfg.access_key
-            else "",
-            (secret_key or minio_cfg.secret_key).get_secret_value()
-            if secret_key or minio_cfg.secret_key
-            else "",
+            resolved_access_key,
+            resolved_secret_key,
             alias or minio_cfg.alias,
         )
     elif target == "s3":
@@ -319,15 +329,25 @@ def resolve_announce_remote_target(
                 "[remote.s3] is not configured in efa.dev.toml. "
                 "See efa.dev.example.toml for the expected format."
             )
+        if access_key:
+            resolved_access_key = access_key
+        elif s3_cfg.access_key:
+            resolved_access_key = s3_cfg.access_key.get_secret_value()
+        else:
+            resolved_access_key = ""
+
+        if secret_key:
+            resolved_secret_key = secret_key
+        elif s3_cfg.secret_key:
+            resolved_secret_key = s3_cfg.secret_key.get_secret_value()
+        else:
+            resolved_secret_key = ""
+
         return (
             endpoint or s3_cfg.endpoint,
             bucket or s3_cfg.bucket,
-            (access_key or s3_cfg.access_key).get_secret_value()
-            if access_key or s3_cfg.access_key
-            else "",
-            (secret_key or s3_cfg.secret_key).get_secret_value()
-            if secret_key or s3_cfg.secret_key
-            else "",
+            resolved_access_key,
+            resolved_secret_key,
             alias or s3_cfg.alias,
         )
     else:

--- a/bootstrap/cli/remote/lifecycle.py
+++ b/bootstrap/cli/remote/lifecycle.py
@@ -52,16 +52,24 @@ def _resolve_remote_target(target: str, endpoint, bucket, access_key, secret_key
         return (
             endpoint or f"http://{remote_cfg.host}:{minio_cfg.port}",
             bucket or minio_cfg.bucket,
-            access_key or minio_cfg.access_key,
-            secret_key or minio_cfg.secret_key,
+            (access_key or minio_cfg.access_key).get_secret_value()
+            if access_key or minio_cfg.access_key
+            else "",
+            (secret_key or minio_cfg.secret_key).get_secret_value()
+            if secret_key or minio_cfg.secret_key
+            else "",
             alias_name or minio_cfg.alias,
         )
     s3_cfg = remote_cfg.require_s3(op)
     return (
         endpoint or s3_cfg.endpoint,
         bucket or s3_cfg.bucket,
-        access_key or s3_cfg.access_key,
-        secret_key or s3_cfg.secret_key,
+        (access_key or s3_cfg.access_key).get_secret_value()
+        if access_key or s3_cfg.access_key
+        else "",
+        (secret_key or s3_cfg.secret_key).get_secret_value()
+        if secret_key or s3_cfg.secret_key
+        else "",
         alias_name or s3_cfg.alias,
     )
 

--- a/bootstrap/cli/remote/lifecycle.py
+++ b/bootstrap/cli/remote/lifecycle.py
@@ -49,27 +49,47 @@ def _resolve_remote_target(target: str, endpoint, bucket, access_key, secret_key
 
     if target == "minio":
         minio_cfg = remote_cfg.require_minio(op)
+        if access_key:
+            resolved_access_key = access_key
+        elif minio_cfg.access_key:
+            resolved_access_key = minio_cfg.access_key.get_secret_value()
+        else:
+            resolved_access_key = ""
+
+        if secret_key:
+            resolved_secret_key = secret_key
+        elif minio_cfg.secret_key:
+            resolved_secret_key = minio_cfg.secret_key.get_secret_value()
+        else:
+            resolved_secret_key = ""
+
         return (
             endpoint or f"http://{remote_cfg.host}:{minio_cfg.port}",
             bucket or minio_cfg.bucket,
-            (access_key or minio_cfg.access_key).get_secret_value()
-            if access_key or minio_cfg.access_key
-            else "",
-            (secret_key or minio_cfg.secret_key).get_secret_value()
-            if secret_key or minio_cfg.secret_key
-            else "",
+            resolved_access_key,
+            resolved_secret_key,
             alias_name or minio_cfg.alias,
         )
     s3_cfg = remote_cfg.require_s3(op)
+    if access_key:
+        resolved_access_key = access_key
+    elif s3_cfg.access_key:
+        resolved_access_key = s3_cfg.access_key.get_secret_value()
+    else:
+        resolved_access_key = ""
+
+    if secret_key:
+        resolved_secret_key = secret_key
+    elif s3_cfg.secret_key:
+        resolved_secret_key = s3_cfg.secret_key.get_secret_value()
+    else:
+        resolved_secret_key = ""
+
     return (
         endpoint or s3_cfg.endpoint,
         bucket or s3_cfg.bucket,
-        (access_key or s3_cfg.access_key).get_secret_value()
-        if access_key or s3_cfg.access_key
-        else "",
-        (secret_key or s3_cfg.secret_key).get_secret_value()
-        if secret_key or s3_cfg.secret_key
-        else "",
+        resolved_access_key,
+        resolved_secret_key,
         alias_name or s3_cfg.alias,
     )
 

--- a/bootstrap/cli/remote/mock.py
+++ b/bootstrap/cli/remote/mock.py
@@ -207,8 +207,16 @@ def register_remote_mock(remote: click.Group) -> None:
         resolved_port = port or minio.port
         resolved_console_port = console_port or minio.console_port
         resolved_bucket = bucket or minio.bucket
-        resolved_access_key = (access_key or minio.access_key).get_secret_value()
-        resolved_secret_key = (secret_key or minio.secret_key).get_secret_value()
+        resolved_access_key = (
+            access_key
+            if access_key
+            else (minio.access_key.get_secret_value() if minio.access_key else "")
+        )
+        resolved_secret_key = (
+            secret_key
+            if secret_key
+            else (minio.secret_key.get_secret_value() if minio.secret_key else "")
+        )
         resolved_alias = alias_name or minio.alias
         resolved_public_download = (
             public_download if public_download is not None else minio.public_download

--- a/bootstrap/cli/remote/mock.py
+++ b/bootstrap/cli/remote/mock.py
@@ -207,8 +207,8 @@ def register_remote_mock(remote: click.Group) -> None:
         resolved_port = port or minio.port
         resolved_console_port = console_port or minio.console_port
         resolved_bucket = bucket or minio.bucket
-        resolved_access_key = access_key or minio.access_key
-        resolved_secret_key = secret_key or minio.secret_key
+        resolved_access_key = (access_key or minio.access_key).get_secret_value()
+        resolved_secret_key = (secret_key or minio.secret_key).get_secret_value()
         resolved_alias = alias_name or minio.alias
         resolved_public_download = (
             public_download if public_download is not None else minio.public_download

--- a/bootstrap/config.py
+++ b/bootstrap/config.py
@@ -312,6 +312,7 @@ class DeveloperCiRawArtifacts(BaseModel):
     alias: str | None = None
     access_key: SecretStr | None = None
     secret_key: SecretStr | None = None
+    public_url: str | None = None
 
 
 def _fail_remote_sub(toml_key: str, command_group: str) -> None:

--- a/bootstrap/config.py
+++ b/bootstrap/config.py
@@ -366,13 +366,7 @@ class DeveloperCi(BaseModel):
 
     def require_raw_artifacts(self) -> tuple[DeveloperCiRawArtifacts, DeveloperCiStorage]:
         if self.raw_artifacts is None:
-            print(
-                "Error: [ci.raw_artifacts] is not configured in efa.dev.toml.\n"
-                "       Required for `./x ci raw-data` upload commands.\n"
-                "       See efa.dev.example.toml.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+            self.raw_artifacts = DeveloperCiRawArtifacts()
         return self.raw_artifacts, self.require_storage()
 
 

--- a/bootstrap/config.py
+++ b/bootstrap/config.py
@@ -23,6 +23,7 @@ from typing import Any
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import SecretStr
 from pydantic import ValidationError
 from pydantic import model_validator
 
@@ -37,6 +38,62 @@ from bootstrap.validator import ProjectPath  # noqa:TC001
 CONFIGURATION: ProjectConfiguration | None = None
 DEV_CONFIGURATION: DeveloperConfiguration | None = None
 WORKSPACE_CACHE: WorkspaceCache | None = None
+
+_DEV_CONFIG_OVERRIDES: list[tuple[str, str]] = []
+_PROJECT_CONFIG_OVERRIDES: list[tuple[str, str]] = []
+
+
+def _split_key(key: str) -> list[str]:
+    """Split a dotted override key into its path components."""
+    return key.split(".")
+
+
+def _set_nested_value(data: dict, key_path: list[str], value: Any) -> None:
+    """Set ``value`` at ``key_path`` inside ``data``, creating tables as needed.
+
+    Raises ``KeyError`` if an intermediate value is not a dictionary.
+    """
+    *head, tail = key_path
+    node = data
+    for part in head:
+        if part not in node:
+            node[part] = {}
+        node = node[part]
+        if not isinstance(node, dict):
+            raise KeyError(".".join(key_path))
+    node[tail] = value
+
+
+def _apply_overrides(
+    cfg: dict,
+    overrides: list[tuple[str, str]],
+) -> dict:
+    """Apply CLI overrides to a raw TOML dictionary.
+
+    Values are parsed as TOML primitives so numbers, booleans, and arrays work.
+    If a value is not valid bare TOML (e.g. contains special characters), it is
+    treated as a literal string.
+    """
+    for raw_key, raw_value in overrides:
+        key_path = _split_key(raw_key)
+        try:
+            parsed_value = tomllib.loads(f"value = {raw_value}")["value"]
+        except tomllib.TOMLDecodeError:
+            parsed_value = raw_value
+        _set_nested_value(cfg, key_path, parsed_value)
+    return cfg
+
+
+def apply_dev_config_overrides(overrides: list[tuple[str, str]]) -> None:
+    """Register overrides to apply when loading ``efa.dev.toml``."""
+    global _DEV_CONFIG_OVERRIDES
+    _DEV_CONFIG_OVERRIDES = overrides
+
+
+def apply_project_config_overrides(overrides: list[tuple[str, str]]) -> None:
+    """Register overrides to apply when loading ``efa.config.toml``."""
+    global _PROJECT_CONFIG_OVERRIDES
+    _PROJECT_CONFIG_OVERRIDES = overrides
 
 
 class ProjectLocalizations(BaseModel):
@@ -135,6 +192,8 @@ class ProjectConfiguration(BaseModel):
             print(f"Unable to find `eva.config.toml`, expected to be placed at {CONFIG_PATH}")
             raise
 
+        cfg = _apply_overrides(cfg, _PROJECT_CONFIG_OVERRIDES)
+
         try:
             global CONFIGURATION
             CONFIGURATION = ProjectConfiguration.model_validate(cfg)
@@ -211,8 +270,8 @@ class DeveloperRemoteMinio(BaseModel):
     port: int
     console_port: int
     bucket: str
-    access_key: str
-    secret_key: str
+    access_key: SecretStr
+    secret_key: SecretStr
     data_dir: Path
     alias: str
     public_download: bool
@@ -225,12 +284,34 @@ class DeveloperRemoteS3(BaseModel):
 
     endpoint: str
     bucket: str
-    access_key: str
-    secret_key: str
+    access_key: SecretStr
+    secret_key: SecretStr
     alias: str
     public_download: bool
     verify_upload: bool = True
     verify_workers: int = 4
+
+
+class DeveloperCiStorage(BaseModel):
+    """CI data storage configuration (Cloudflare R2). All fields required."""
+
+    endpoint: str
+    bucket: str
+    alias: str
+    access_key: SecretStr
+    secret_key: SecretStr
+    public_url: str
+
+
+class DeveloperCiRawArtifacts(BaseModel):
+    """Raw artifact upload target inside the CI bucket."""
+
+    remote_root: str = Field(default="data-generator/raw-artifact")
+    endpoint: str | None = None
+    bucket: str | None = None
+    alias: str | None = None
+    access_key: SecretStr | None = None
+    secret_key: SecretStr | None = None
 
 
 def _fail_remote_sub(toml_key: str, command_group: str) -> None:
@@ -265,21 +346,11 @@ class DeveloperRemote(BaseModel):
         return self.s3  # type: ignore[return-value]
 
 
-class DeveloperCiStorage(BaseModel):
-    """CI data storage configuration (Cloudflare R2). All fields required."""
-
-    endpoint: str
-    bucket: str
-    alias: str
-    access_key: str
-    secret_key: str
-    public_url: str
-
-
 class DeveloperCi(BaseModel):
     model_config = ConfigDict(validate_default=True)
 
     storage: DeveloperCiStorage | None = None
+    raw_artifacts: DeveloperCiRawArtifacts | None = None
 
     def require_storage(self) -> DeveloperCiStorage:
         if self.storage is None:
@@ -291,6 +362,17 @@ class DeveloperCi(BaseModel):
             )
             sys.exit(1)
         return self.storage
+
+    def require_raw_artifacts(self) -> tuple[DeveloperCiRawArtifacts, DeveloperCiStorage]:
+        if self.raw_artifacts is None:
+            print(
+                "Error: [ci.raw_artifacts] is not configured in efa.dev.toml.\n"
+                "       Required for `./x ci raw-data` upload commands.\n"
+                "       See efa.dev.example.toml.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return self.raw_artifacts, self.require_storage()
 
 
 class DeveloperConfiguration(BaseModel):
@@ -310,6 +392,8 @@ class DeveloperConfiguration(BaseModel):
                 cfg = tomllib.load(cfg_f)
         except FileNotFoundError:
             pass
+
+        cfg = _apply_overrides(cfg, _DEV_CONFIG_OVERRIDES)
 
         try:
             global DEV_CONFIGURATION

--- a/bootstrap/data/updater/__init__.py
+++ b/bootstrap/data/updater/__init__.py
@@ -1,0 +1,16 @@
+"""CI raw-data updater for EVE client builds."""
+
+from __future__ import annotations
+
+from bootstrap.data.updater.server import SERVER_ALIASES
+from bootstrap.data.updater.server import ServerConfig
+from bootstrap.data.updater.server import ServerId
+from bootstrap.data.updater.server import get_server_config
+
+
+__all__ = [
+    "SERVER_ALIASES",
+    "ServerConfig",
+    "ServerId",
+    "get_server_config",
+]

--- a/bootstrap/data/updater/fsd.py
+++ b/bootstrap/data/updater/fsd.py
@@ -109,7 +109,7 @@ async def generate_fsd(
         [sys.executable, str(work_dir / "collect.py"), str(index_file), str(resfileindex_file)],
         "COLLECT FSD BINARIES",
         work_dir,
-        env=env,
+        extra_env=env,
     )
 
     python2 = await _ensure_python2(work_dir / "py27")

--- a/bootstrap/data/updater/fsd.py
+++ b/bootstrap/data/updater/fsd.py
@@ -56,10 +56,19 @@ async def _ensure_python2(extract_dir: Path) -> Path:
     info(f"Extracting portable Python 2.7 from {_PY27_ZIP}")
     extract_dir.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(_PY27_ZIP, "r") as zf:
-        zf.extractall(extract_dir)
+        _safe_extractall(zf, extract_dir)
     if not python_exe.is_file():
         raise FileNotFoundError(f"python.exe not found after extracting {_PY27_ZIP}")
     return python_exe
+
+
+def _safe_extractall(zf: zipfile.ZipFile, dest: Path) -> None:
+    dest_resolved = dest.resolve()
+    for member in zf.namelist():
+        member_path = (dest / member).resolve()
+        if dest_resolved not in member_path.parents and member_path != dest_resolved:
+            raise ValueError(f"Unsafe path in zip archive: {member}")
+    zf.extractall(dest)
 
 
 async def _run_script(
@@ -101,6 +110,11 @@ async def generate_fsd(
     """
     work_dir = temp_root / "fsd-work"
     work_dir.mkdir(parents=True, exist_ok=True)
+
+    if sys.platform != "win32":
+        raise OSError(
+            "FSD binary conversion requires Windows because CCP's loaders are .pyd files."
+        )
 
     await _copy_scripts(work_dir)
 

--- a/bootstrap/data/updater/fsd.py
+++ b/bootstrap/data/updater/fsd.py
@@ -1,0 +1,148 @@
+"""Orchestrate FSD binary collection, conversion, and msgpack compression."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import sys
+import zipfile
+
+from typing import TYPE_CHECKING
+
+from bootstrap.constant import PROJECT_ROOT
+from bootstrap.log import info
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bootstrap.data.updater.server import ServerConfig
+
+
+_DUMPER_DIR = PROJECT_ROOT / "tools" / "eve-fsd-dumper"
+_PY27_ZIP = _DUMPER_DIR / "py27.zip"
+
+
+async def _copy_scripts(work_dir: Path) -> None:
+    """Copy vendored dumper scripts into the temporary work directory."""
+    for name in ("collect.py", "convert.py", "compress.py"):
+        shutil.copy(_DUMPER_DIR / name, work_dir / name)
+
+
+async def _ensure_python2(extract_dir: Path) -> Path:
+    """Return the path to a usable Python 2.7 executable.
+
+    On Windows this extracts the bundled portable interpreter.
+    On other platforms the conversion step cannot succeed because CCP's
+    ``*Loader.pyd`` files are Windows-only, so we fail early.
+    """
+    if sys.platform != "win32":
+        raise OSError(
+            "FSD binary conversion requires Windows because CCP's loaders are .pyd files."
+        )
+
+    if not _PY27_ZIP.is_file():
+        raise FileNotFoundError(
+            f"Portable Python 2.7 archive not found: {_PY27_ZIP}\n"
+            f"       Download it from the CI bucket (build-dependencies/py27.zip) "
+            f"and place it at the path above."
+        )
+
+    python_exe = extract_dir / "python.exe"
+    if python_exe.is_file():
+        return python_exe
+
+    info(f"Extracting portable Python 2.7 from {_PY27_ZIP}")
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(_PY27_ZIP, "r") as zf:
+        zf.extractall(extract_dir)
+    if not python_exe.is_file():
+        raise FileNotFoundError(f"python.exe not found after extracting {_PY27_ZIP}")
+    return python_exe
+
+
+async def _run_script(
+    cmd: list[str],
+    title: str,
+    cwd: Path,
+    extra_env: dict[str, str] | None = None,
+) -> None:
+    """Run a script inside ``cwd`` and stream its output."""
+    info(f"{title}: {' '.join(cmd)}")
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=cwd,
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    assert process.stdout is not None
+    async for line in process.stdout:
+        info(line.decode("utf-8", errors="replace").rstrip())
+    await process.wait()
+    if process.returncode != 0:
+        raise RuntimeError(f"{title} failed with exit code {process.returncode}")
+
+
+async def generate_fsd(
+    index_file: Path,
+    resfileindex_file: Path,
+    server: ServerConfig,
+    out_dir: Path,
+    temp_root: Path,
+) -> Path:
+    """Generate ``*.msgpack`` FSD files from ``*.fsdbinary`` resources.
+
+    Returns the path to the directory containing the generated msgpack files.
+    """
+    work_dir = temp_root / "fsd-work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    await _copy_scripts(work_dir)
+
+    env = {"FSD_DUMPER_SERVER": server.fsd_dumper_server}
+    await _run_script(
+        [sys.executable, str(work_dir / "collect.py"), str(index_file), str(resfileindex_file)],
+        "COLLECT FSD BINARIES",
+        work_dir,
+        env=env,
+    )
+
+    python2 = await _ensure_python2(work_dir / "py27")
+    await _run_script(
+        [
+            str(python2),
+            str(work_dir / "convert.py"),
+            str(work_dir / "data" / "fsdbinary"),
+            str(work_dir / "data" / "loader"),
+        ],
+        "CONVERT FSD BINARIES",
+        work_dir,
+    )
+
+    out_msgpack = work_dir / "out_msgpack"
+    await _run_script(
+        [
+            sys.executable,
+            str(work_dir / "compress.py"),
+            str(work_dir / "out_pickle"),
+            str(out_msgpack),
+        ],
+        "COMPRESS FSD PICKLES",
+        work_dir,
+    )
+
+    fsd_dir = out_dir / "fsd"
+    if fsd_dir.exists():
+        shutil.rmtree(fsd_dir)
+    fsd_dir.mkdir(parents=True, exist_ok=True)
+
+    for msgpack_file in out_msgpack.glob("*.msgpack"):
+        shutil.copy(msgpack_file, fsd_dir / msgpack_file.name)
+
+    info(f"Copied {len(list(fsd_dir.glob('*.msgpack')))} msgpack files to {fsd_dir}")
+    return fsd_dir

--- a/bootstrap/data/updater/index.py
+++ b/bootstrap/data/updater/index.py
@@ -28,12 +28,12 @@ _METADATA_PATHS = {
 async def _download_file(session: aiohttp.ClientSession, url: str, dest: Path) -> None:
     """Download a single file to ``dest``."""
     info(f"Downloading {url} -> {dest}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
     async with session.get(url) as response:
         response.raise_for_status()
-        content = await response.read()
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    async with aiofiles.open(dest, "wb") as f:
-        await f.write(content)
+        async with aiofiles.open(dest, "wb") as f:
+            async for chunk in response.content.iter_chunked(65536):
+                await f.write(chunk)
 
 
 async def download_index(build: int, server: ServerConfig, out_dir: Path) -> Path:
@@ -45,11 +45,11 @@ async def download_index(build: int, server: ServerConfig, out_dir: Path) -> Pat
     return dest
 
 
-def _parse_index_file(index_file: Path) -> dict[str, str]:
+async def _parse_index_file(index_file: Path) -> dict[str, str]:
     """Parse an EVE application index CSV into a ``path -> url`` mapping."""
     entries: dict[str, str] = {}
-    with open(index_file, "r", encoding="utf-8") as f:
-        for line in f:
+    async with aiofiles.open(index_file, "r", encoding="utf-8") as f:
+        async for line in f:
             line = line.strip()
             if not line:
                 continue
@@ -64,7 +64,7 @@ def _parse_index_file(index_file: Path) -> dict[str, str]:
 
 async def download_metadata(index_file: Path, server: ServerConfig, out_dir: Path) -> None:
     """Download metadata files referenced by the application index."""
-    entries = _parse_index_file(index_file)
+    entries = await _parse_index_file(index_file)
     async with aiohttp.ClientSession() as session:
         for resource_id in _METADATA_PATHS:
             resource_url = entries.get(resource_id)
@@ -74,10 +74,6 @@ async def download_metadata(index_file: Path, server: ServerConfig, out_dir: Pat
             file_name = resource_id.replace("app:/", "")
             await _download_file(session, url, out_dir / file_name)
 
-    resfileindex_url = entries.get("app:/resfileindex.txt")
-    if resfileindex_url is None:
-        raise FileNotFoundError(f"Metadata entry 'app:/resfileindex.txt' not found in {index_file}")
-
 
 async def download_resource_index(
     index_file: Path,
@@ -85,7 +81,7 @@ async def download_resource_index(
     out_dir: Path,
 ) -> Path:
     """Download ``resfileindex.txt`` referenced by the application index."""
-    entries = _parse_index_file(index_file)
+    entries = await _parse_index_file(index_file)
     resource_url = entries.get("app:/resfileindex.txt")
     if resource_url is None:
         raise FileNotFoundError(f"Metadata entry 'app:/resfileindex.txt' not found in {index_file}")

--- a/bootstrap/data/updater/index.py
+++ b/bootstrap/data/updater/index.py
@@ -1,0 +1,96 @@
+"""Download and parse EVE application indexes and metadata files."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import aiofiles
+import aiohttp
+
+from bootstrap.log import info
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bootstrap.data.updater.server import ServerConfig
+
+
+_METADATA_PATHS = {
+    "app:/resfileindex.txt",
+    "app:/resfileindex_Windows.txt",
+    "app:/resfileindex_prefetch.txt",
+    "app:/resfiledependencies.yaml",
+    "app:/start.ini",
+}
+
+
+async def _download_file(session: aiohttp.ClientSession, url: str, dest: Path) -> None:
+    """Download a single file to ``dest``."""
+    info(f"Downloading {url} -> {dest}")
+    async with session.get(url) as response:
+        response.raise_for_status()
+        content = await response.read()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    async with aiofiles.open(dest, "wb") as f:
+        await f.write(content)
+
+
+async def download_index(build: int, server: ServerConfig, out_dir: Path) -> Path:
+    """Download the application index for ``build`` to ``out_dir``."""
+    url = server.index_url_template.format(build=build)
+    dest = out_dir / server.index_file_name
+    async with aiohttp.ClientSession() as session:
+        await _download_file(session, url, dest)
+    return dest
+
+
+def _parse_index_file(index_file: Path) -> dict[str, str]:
+    """Parse an EVE application index CSV into a ``path -> url`` mapping."""
+    entries: dict[str, str] = {}
+    with open(index_file, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(",")
+            if len(parts) < 2:
+                continue
+            resource_id = parts[0]
+            resource_url = parts[1]
+            entries[resource_id] = resource_url
+    return entries
+
+
+async def download_metadata(index_file: Path, server: ServerConfig, out_dir: Path) -> None:
+    """Download metadata files referenced by the application index."""
+    entries = _parse_index_file(index_file)
+    async with aiohttp.ClientSession() as session:
+        for resource_id in _METADATA_PATHS:
+            resource_url = entries.get(resource_id)
+            if resource_url is None:
+                raise FileNotFoundError(f"Metadata entry {resource_id!r} not found in {index_file}")
+            url = server.binary_download_url.format(resource_url=resource_url)
+            file_name = resource_id.replace("app:/", "")
+            await _download_file(session, url, out_dir / file_name)
+
+    resfileindex_url = entries.get("app:/resfileindex.txt")
+    if resfileindex_url is None:
+        raise FileNotFoundError(f"Metadata entry 'app:/resfileindex.txt' not found in {index_file}")
+
+
+async def download_resource_index(
+    index_file: Path,
+    server: ServerConfig,
+    out_dir: Path,
+) -> Path:
+    """Download ``resfileindex.txt`` referenced by the application index."""
+    entries = _parse_index_file(index_file)
+    resource_url = entries.get("app:/resfileindex.txt")
+    if resource_url is None:
+        raise FileNotFoundError(f"Metadata entry 'app:/resfileindex.txt' not found in {index_file}")
+    url = server.binary_download_url.format(resource_url=resource_url)
+    dest = out_dir / "resfileindex.txt"
+    async with aiohttp.ClientSession() as session:
+        await _download_file(session, url, dest)
+    return dest

--- a/bootstrap/data/updater/manifest.py
+++ b/bootstrap/data/updater/manifest.py
@@ -1,0 +1,25 @@
+"""Fetch EVE client manifests and parse build numbers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import aiohttp
+
+from bootstrap.log import info
+
+
+if TYPE_CHECKING:
+    from bootstrap.data.updater.server import ServerConfig
+
+
+async def fetch_build(server: ServerConfig) -> int:
+    """Fetch the remote EVE client manifest and return the build number."""
+    info(f"Fetching manifest from {server.manifest_url}")
+    async with aiohttp.ClientSession() as session, session.get(server.manifest_url) as response:
+        response.raise_for_status()
+        data = await response.json()
+    build = data.get("build")
+    if build is None:
+        raise ValueError(f"Manifest missing 'build' field: {server.manifest_url}")
+    return int(str(build).strip())

--- a/bootstrap/data/updater/pipeline.py
+++ b/bootstrap/data/updater/pipeline.py
@@ -89,8 +89,10 @@ async def _read_bucket_build(server_id: ServerId) -> int | None:
             response.raise_for_status()
             text = await response.text()
             return int(text.strip())
-    except (aiohttp.ClientError, ValueError):
-        return None
+    except aiohttp.ClientResponseError as exc:
+        if exc.status == 404:
+            return None
+        raise
 
 
 async def check_server(server_id: str) -> UpdateCheckResult:

--- a/bootstrap/data/updater/pipeline.py
+++ b/bootstrap/data/updater/pipeline.py
@@ -82,6 +82,9 @@ async def _read_bucket_build(server_id: ServerId) -> int | None:
 
     url = f"{public_url}/{raw_artifacts.remote_root}/{server_id}/build.txt"
     info(f"Reading bucket build: {url}")
+    # Only a real 404 should mean "no build". Swallowing aiohttp.ClientError
+    # or a malformed build.txt lets check_server treat outages/corruption as
+    # needs_update=True, which can queue unnecessary update runs.
     try:
         async with aiohttp.ClientSession() as session, session.get(url) as response:
             if response.status == 404:
@@ -135,8 +138,6 @@ async def update_server(
     if upload:
         bootstrap.config.DeveloperConfiguration.ensure_loaded()
         ci = bootstrap.config.DEV_CONFIGURATION.ci
-        if ci.raw_artifacts is None:
-            ci.raw_artifacts = bootstrap.config.DeveloperCiRawArtifacts()
         raw_artifacts, storage = ci.require_raw_artifacts()
         await upload_artifacts(resolved, artifacts_dir, build, raw_artifacts, storage)
         uploaded = True

--- a/bootstrap/data/updater/pipeline.py
+++ b/bootstrap/data/updater/pipeline.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import shutil
-import subprocess
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+import aiohttp
 
 import bootstrap.config
 
@@ -19,7 +20,6 @@ from bootstrap.data.updater.server import SERVER_ALIASES
 from bootstrap.data.updater.server import get_server_config
 from bootstrap.data.updater.uploader import upload_artifacts
 from bootstrap.log import info
-from bootstrap.utils import get_command
 
 
 if TYPE_CHECKING:
@@ -63,38 +63,33 @@ def _get_raw_artifacts_dir(server_id: ServerId) -> Path:
 
 
 async def _read_bucket_build(server_id: ServerId) -> int | None:
-    """Read the current build number stored in the CI bucket, if any."""
+    """Read the current build number stored in the CI bucket, if any.
+
+    This uses the public bucket URL so the check step can run without
+    consuming storage credentials.
+    """
     bootstrap.config.DeveloperConfiguration.ensure_loaded()
     storage = bootstrap.config.DEV_CONFIGURATION.ci.storage
     raw_artifacts = bootstrap.config.DEV_CONFIGURATION.ci.raw_artifacts
-    if storage is None or raw_artifacts is None:
+    if raw_artifacts is None:
         return None
 
-    alias = raw_artifacts.alias or storage.alias
-    bucket = raw_artifacts.bucket or storage.bucket
-    remote_root = raw_artifacts.remote_root
-    build_path = f"{alias}/{bucket}/{remote_root}/{server_id}/build.txt"
+    public_url = raw_artifacts.public_url
+    if public_url is None and storage is not None:
+        public_url = storage.public_url
+    if not public_url:
+        return None
 
-    mc = get_command("mc")
-    cmd = [mc, "cat", build_path]
-    info(f"Reading bucket build: {' '.join(cmd)}")
+    url = f"{public_url}/{raw_artifacts.remote_root}/{server_id}/build.txt"
+    info(f"Reading bucket build: {url}")
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=60,
-            check=False,
-        )
-    except FileNotFoundError:
-        return None
-    if result.returncode != 0:
-        return None
-    try:
-        return int(result.stdout.strip())
-    except ValueError:
+        async with aiohttp.ClientSession() as session, session.get(url) as response:
+            if response.status == 404:
+                return None
+            response.raise_for_status()
+            text = await response.text()
+            return int(text.strip())
+    except (aiohttp.ClientError, ValueError):
         return None
 
 

--- a/bootstrap/data/updater/pipeline.py
+++ b/bootstrap/data/updater/pipeline.py
@@ -1,0 +1,157 @@
+"""End-to-end raw-data update pipeline."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import bootstrap.config
+
+from bootstrap.data.updater.fsd import generate_fsd
+from bootstrap.data.updater.index import download_index
+from bootstrap.data.updater.index import download_metadata
+from bootstrap.data.updater.index import download_resource_index
+from bootstrap.data.updater.manifest import fetch_build
+from bootstrap.data.updater.server import SERVER_ALIASES
+from bootstrap.data.updater.server import get_server_config
+from bootstrap.data.updater.uploader import upload_artifacts
+from bootstrap.log import info
+from bootstrap.utils import get_command
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bootstrap.data.updater.server import ServerId
+
+
+@dataclass(frozen=True)
+class UpdateCheckResult:
+    """Result of comparing the remote build with the bucket build."""
+
+    needs_update: bool
+    remote_build: int
+    bucket_build: int | None
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    """Result of a raw-data update run."""
+
+    server_id: ServerId
+    build: int
+    artifacts_dir: Path
+    uploaded: bool
+
+
+def _resolve_server_id(server_id: str) -> ServerId:
+    """Normalize a server identifier to the canonical form."""
+    normalized = SERVER_ALIASES.get(server_id.lower(), server_id.lower())
+    if normalized in ("tranquility", "serenity", "singularity"):
+        return normalized  # type: ignore[return-value]
+    raise ValueError(f"Unknown server id: {server_id}")
+
+
+def _get_raw_artifacts_dir(server_id: ServerId) -> Path:
+    """Return the local directory where raw artifacts are assembled."""
+    bootstrap.config.DeveloperConfiguration.ensure_loaded()
+    root = bootstrap.config.DEV_CONFIGURATION.paths.root
+    return root / "raw-artifacts" / server_id
+
+
+async def _read_bucket_build(server_id: ServerId) -> int | None:
+    """Read the current build number stored in the CI bucket, if any."""
+    bootstrap.config.DeveloperConfiguration.ensure_loaded()
+    storage = bootstrap.config.DEV_CONFIGURATION.ci.storage
+    raw_artifacts = bootstrap.config.DEV_CONFIGURATION.ci.raw_artifacts
+    if storage is None or raw_artifacts is None:
+        return None
+
+    alias = raw_artifacts.alias or storage.alias
+    bucket = raw_artifacts.bucket or storage.bucket
+    remote_root = raw_artifacts.remote_root
+    build_path = f"{alias}/{bucket}/{remote_root}/{server_id}/build.txt"
+
+    mc = get_command("mc")
+    cmd = [mc, "cat", build_path]
+    info(f"Reading bucket build: {' '.join(cmd)}")
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=60,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip())
+    except ValueError:
+        return None
+
+
+async def check_server(server_id: str) -> UpdateCheckResult:
+    """Check whether the remote EVE build is newer than the one in the CI bucket."""
+    resolved = _resolve_server_id(server_id)
+    server = get_server_config(resolved)
+    remote_build = await fetch_build(server)
+    bucket_build = await _read_bucket_build(resolved)
+    return UpdateCheckResult(
+        needs_update=bucket_build is None or remote_build > bucket_build,
+        remote_build=remote_build,
+        bucket_build=bucket_build,
+    )
+
+
+async def update_server(
+    server_id: str,
+    *,
+    upload: bool = True,
+    keep_temp: bool = False,
+) -> UpdateResult:
+    """Download, convert, and optionally upload raw data for a server."""
+    resolved = _resolve_server_id(server_id)
+    server = get_server_config(resolved)
+
+    build = await fetch_build(server)
+    base_dir = _get_raw_artifacts_dir(resolved)
+    artifacts_dir = base_dir / "artifacts"
+    temp_root = base_dir / "temp"
+
+    if base_dir.exists():
+        shutil.rmtree(base_dir)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    temp_root.mkdir(parents=True, exist_ok=True)
+
+    index_file = await download_index(build, server, artifacts_dir)
+    await download_metadata(index_file, server, artifacts_dir)
+    resfileindex_file = await download_resource_index(index_file, server, artifacts_dir)
+    await generate_fsd(index_file, resfileindex_file, server, artifacts_dir, temp_root)
+
+    uploaded = False
+    if upload:
+        bootstrap.config.DeveloperConfiguration.ensure_loaded()
+        ci = bootstrap.config.DEV_CONFIGURATION.ci
+        if ci.raw_artifacts is None:
+            ci.raw_artifacts = bootstrap.config.DeveloperCiRawArtifacts()
+        raw_artifacts, storage = ci.require_raw_artifacts()
+        await upload_artifacts(resolved, artifacts_dir, build, raw_artifacts, storage)
+        uploaded = True
+
+    if not keep_temp:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+    return UpdateResult(
+        server_id=resolved,
+        build=build,
+        artifacts_dir=artifacts_dir,
+        uploaded=uploaded,
+    )

--- a/bootstrap/data/updater/pipeline.py
+++ b/bootstrap/data/updater/pipeline.py
@@ -16,8 +16,8 @@ from bootstrap.data.updater.index import download_index
 from bootstrap.data.updater.index import download_metadata
 from bootstrap.data.updater.index import download_resource_index
 from bootstrap.data.updater.manifest import fetch_build
-from bootstrap.data.updater.server import SERVER_ALIASES
 from bootstrap.data.updater.server import get_server_config
+from bootstrap.data.updater.server import resolve_server_id
 from bootstrap.data.updater.uploader import upload_artifacts
 from bootstrap.log import info
 
@@ -49,10 +49,7 @@ class UpdateResult:
 
 def _resolve_server_id(server_id: str) -> ServerId:
     """Normalize a server identifier to the canonical form."""
-    normalized = SERVER_ALIASES.get(server_id.lower(), server_id.lower())
-    if normalized in ("tranquility", "serenity", "singularity"):
-        return normalized  # type: ignore[return-value]
-    raise ValueError(f"Unknown server id: {server_id}")
+    return resolve_server_id(server_id)
 
 
 def _get_raw_artifacts_dir(server_id: ServerId) -> Path:

--- a/bootstrap/data/updater/server.py
+++ b/bootstrap/data/updater/server.py
@@ -31,13 +31,14 @@ class ServerConfig:
     fsd_dumper_server: str
 
 
-def _discover_server_ids() -> frozenset[str]:
+def _discover_server_ids(resources_root: Path | None = None) -> frozenset[str]:
     """Return the set of server ids declared under ``data/resources``.
 
     A resource directory is treated as a server when its ``descriptor.toml`` has
     ``metadata.server = true`` and is not ignored.
     """
-    resources_root = PROJECT_ROOT / "data" / "resources"
+    if resources_root is None:
+        resources_root = PROJECT_ROOT / "data" / "resources"
     if not resources_root.is_dir():
         return frozenset()
 
@@ -153,35 +154,7 @@ def list_server_ids() -> list[ServerId]:
 def _reset_for_tests(resources_root: Path | None = None) -> None:
     """Internal hook used by tests to recompute server ids from a fake tree."""
     global SERVER_IDS
-    if resources_root is None:
-        SERVER_IDS = _discover_server_ids()
-    else:
-
-        def discover_from(path: Path) -> frozenset[str]:
-            server_ids: set[str] = set()
-            if not path.is_dir():
-                return frozenset(server_ids)
-            for entry in path.iterdir():
-                if not entry.is_dir():
-                    continue
-                descriptor_path = entry / "descriptor.toml"
-                if not descriptor_path.is_file():
-                    continue
-                try:
-                    with open(descriptor_path, "rb") as f:
-                        data = tomllib.load(f)
-                except Exception:
-                    continue
-                if data.get("ignore", False):
-                    continue
-                metadata = data.get("metadata") or {}
-                if metadata.get("server", False):
-                    identifier = metadata.get("identifier")
-                    if isinstance(identifier, str) and identifier:
-                        server_ids.add(identifier)
-            return frozenset(server_ids)
-
-        SERVER_IDS = discover_from(resources_root)
+    SERVER_IDS = _discover_server_ids(resources_root)
     _validate_server_definitions()
 
 

--- a/bootstrap/data/updater/server.py
+++ b/bootstrap/data/updater/server.py
@@ -46,14 +46,16 @@ def get_server_config(server_id: ServerId) -> ServerConfig:
             fsd_dumper_server="tq",
         )
     if server_id == "serenity":
+        # The Serenity OSS bucket supports HTTPS; use it for the manifest and
+        # index so these files cannot be tampered with in transit.
         return ServerConfig(
             id=server_id,
             manifest_url=(
-                "http://eve-china-version-files.oss-cn-hangzhou.aliyuncs.com/"
+                "https://eve-china-version-files.oss-cn-hangzhou.aliyuncs.com/"
                 "eveclient_SERENITY.json"
             ),
             index_url_template=(
-                "http://eve-china-version-files.oss-cn-hangzhou.aliyuncs.com/eveonline_{build}.txt"
+                "https://eve-china-version-files.oss-cn-hangzhou.aliyuncs.com/eveonline_{build}.txt"
             ),
             binary_download_url="https://ma79.gdl.netease.com/eve/binaries/{resource_url}",
             resource_download_url="https://ma79.gdl.netease.com/eve/resources/{resource_url}",

--- a/bootstrap/data/updater/server.py
+++ b/bootstrap/data/updater/server.py
@@ -1,0 +1,63 @@
+"""Server definitions and URL builders for the CI raw-data updater."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+ServerId = Literal["tranquility", "serenity", "singularity"]
+SERVER_ALIASES = {"tq": "tranquility", "se": "serenity", "sisi": "singularity"}
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    """Configuration for a single EVE server data source."""
+
+    id: ServerId
+    manifest_url: str
+    index_url_template: str
+    binary_download_url: str
+    resource_download_url: str
+    index_file_name: str
+    fsd_dumper_server: Literal["tq", "se"]
+
+
+def get_server_config(server_id: ServerId) -> ServerConfig:
+    """Return the configuration for the given server."""
+    if server_id == "tranquility":
+        return ServerConfig(
+            id=server_id,
+            manifest_url="https://binaries.eveonline.com/eveclient_TQ.json",
+            index_url_template="https://binaries.eveonline.com/eveonline_{build}.txt",
+            binary_download_url="https://binaries.eveonline.com/{resource_url}",
+            resource_download_url="https://resources.eveonline.com/{resource_url}",
+            index_file_name="index_tranquility.txt",
+            fsd_dumper_server="tq",
+        )
+    if server_id == "singularity":
+        return ServerConfig(
+            id=server_id,
+            manifest_url="https://binaries.eveonline.com/eveclient_SISI.json",
+            index_url_template="https://binaries.eveonline.com/eveonline_{build}.txt",
+            binary_download_url="https://binaries.eveonline.com/{resource_url}",
+            resource_download_url="https://resources.eveonline.com/{resource_url}",
+            index_file_name="index_singularity.txt",
+            fsd_dumper_server="tq",
+        )
+    if server_id == "serenity":
+        return ServerConfig(
+            id=server_id,
+            manifest_url=(
+                "http://eve-china-version-files.oss-cn-hangzhou.aliyuncs.com/"
+                "eveclient_SERENITY.json"
+            ),
+            index_url_template=(
+                "http://eve-china-version-files.oss-cn-hangzhou.aliyuncs.com/eveonline_{build}.txt"
+            ),
+            binary_download_url="https://ma79.gdl.netease.com/eve/binaries/{resource_url}",
+            resource_download_url="https://ma79.gdl.netease.com/eve/resources/{resource_url}",
+            index_file_name="index_serenity.txt",
+            fsd_dumper_server="se",
+        )
+    raise ValueError(f"Unknown server id: {server_id}")

--- a/bootstrap/data/updater/server.py
+++ b/bootstrap/data/updater/server.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import tomllib
+
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING
+
+from bootstrap.constant import PROJECT_ROOT
 
 
-ServerId = Literal["tranquility", "serenity", "singularity"]
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+ServerId = str
 SERVER_ALIASES = {"tq": "tranquility", "se": "serenity", "sisi": "singularity"}
 
 
@@ -20,36 +28,64 @@ class ServerConfig:
     binary_download_url: str
     resource_download_url: str
     index_file_name: str
-    fsd_dumper_server: Literal["tq", "se"]
+    fsd_dumper_server: str
 
 
-def get_server_config(server_id: ServerId) -> ServerConfig:
-    """Return the configuration for the given server."""
-    if server_id == "tranquility":
-        return ServerConfig(
-            id=server_id,
+def _discover_server_ids() -> frozenset[str]:
+    """Return the set of server ids declared under ``data/resources``.
+
+    A resource directory is treated as a server when its ``descriptor.toml`` has
+    ``metadata.server = true`` and is not ignored.
+    """
+    resources_root = PROJECT_ROOT / "data" / "resources"
+    if not resources_root.is_dir():
+        return frozenset()
+
+    server_ids: set[str] = set()
+    for entry in resources_root.iterdir():
+        if not entry.is_dir():
+            continue
+        descriptor_path = entry / "descriptor.toml"
+        if not descriptor_path.is_file():
+            continue
+        try:
+            with open(descriptor_path, "rb") as f:
+                data = tomllib.load(f)
+        except Exception:
+            continue
+        if data.get("ignore", False):
+            continue
+        metadata = data.get("metadata") or {}
+        if metadata.get("server", False):
+            identifier = metadata.get("identifier")
+            if isinstance(identifier, str) and identifier:
+                server_ids.add(identifier)
+    return frozenset(server_ids)
+
+
+def _build_server_configs() -> dict[str, ServerConfig]:
+    """Return the static server configuration table keyed by server id."""
+    return {
+        "tranquility": ServerConfig(
+            id="tranquility",
             manifest_url="https://binaries.eveonline.com/eveclient_TQ.json",
             index_url_template="https://binaries.eveonline.com/eveonline_{build}.txt",
             binary_download_url="https://binaries.eveonline.com/{resource_url}",
             resource_download_url="https://resources.eveonline.com/{resource_url}",
             index_file_name="index_tranquility.txt",
             fsd_dumper_server="tq",
-        )
-    if server_id == "singularity":
-        return ServerConfig(
-            id=server_id,
+        ),
+        "singularity": ServerConfig(
+            id="singularity",
             manifest_url="https://binaries.eveonline.com/eveclient_SISI.json",
             index_url_template="https://binaries.eveonline.com/eveonline_{build}.txt",
             binary_download_url="https://binaries.eveonline.com/{resource_url}",
             resource_download_url="https://resources.eveonline.com/{resource_url}",
             index_file_name="index_singularity.txt",
             fsd_dumper_server="tq",
-        )
-    if server_id == "serenity":
-        # The Serenity OSS bucket supports HTTPS; use it for the manifest and
-        # index so these files cannot be tampered with in transit.
-        return ServerConfig(
-            id=server_id,
+        ),
+        "serenity": ServerConfig(
+            id="serenity",
             manifest_url=(
                 "https://eve-china-version-files.oss-cn-hangzhou.aliyuncs.com/"
                 "eveclient_SERENITY.json"
@@ -61,5 +97,100 @@ def get_server_config(server_id: ServerId) -> ServerConfig:
             resource_download_url="https://ma79.gdl.netease.com/eve/resources/{resource_url}",
             index_file_name="index_serenity.txt",
             fsd_dumper_server="se",
+        ),
+    }
+
+
+SERVER_IDS = _discover_server_ids()
+_SERVER_CONFIGS = _build_server_configs()
+
+
+def _validate_server_definitions() -> None:
+    """Fail fast if the code and the resource tree disagree on server ids."""
+    alias_targets = set(SERVER_ALIASES.values())
+    unknown_aliases = alias_targets - SERVER_IDS
+    if unknown_aliases:
+        raise RuntimeError(
+            f"SERVER_ALIASES references unknown server ids: {sorted(unknown_aliases)}"
         )
+
+    configured = set(_SERVER_CONFIGS.keys())
+    missing_configs = SERVER_IDS - configured
+    extra_configs = configured - SERVER_IDS
+    if missing_configs or extra_configs:
+        raise RuntimeError(
+            f"Server config mismatch: missing={sorted(missing_configs)} "
+            f"extra={sorted(extra_configs)}"
+        )
+
+
+_validate_server_definitions()
+
+
+def resolve_server_id(server_id: str) -> ServerId:
+    """Normalize a server identifier to its canonical form."""
+    normalized = SERVER_ALIASES.get(server_id.lower(), server_id.lower())
+    if normalized in SERVER_IDS:
+        return normalized
     raise ValueError(f"Unknown server id: {server_id}")
+
+
+def get_server_config(server_id: ServerId) -> ServerConfig:
+    """Return the configuration for the given server."""
+    if server_id not in SERVER_IDS:
+        raise ValueError(f"Unknown server id: {server_id}")
+    config = _SERVER_CONFIGS.get(server_id)
+    if config is None:
+        raise ValueError(f"Unknown server id: {server_id}")
+    return config
+
+
+def list_server_ids() -> list[ServerId]:
+    """Return all canonical server ids in a stable order."""
+    return sorted(SERVER_IDS)
+
+
+def _reset_for_tests(resources_root: Path | None = None) -> None:
+    """Internal hook used by tests to recompute server ids from a fake tree."""
+    global SERVER_IDS
+    if resources_root is None:
+        SERVER_IDS = _discover_server_ids()
+    else:
+
+        def discover_from(path: Path) -> frozenset[str]:
+            server_ids: set[str] = set()
+            if not path.is_dir():
+                return frozenset(server_ids)
+            for entry in path.iterdir():
+                if not entry.is_dir():
+                    continue
+                descriptor_path = entry / "descriptor.toml"
+                if not descriptor_path.is_file():
+                    continue
+                try:
+                    with open(descriptor_path, "rb") as f:
+                        data = tomllib.load(f)
+                except Exception:
+                    continue
+                if data.get("ignore", False):
+                    continue
+                metadata = data.get("metadata") or {}
+                if metadata.get("server", False):
+                    identifier = metadata.get("identifier")
+                    if isinstance(identifier, str) and identifier:
+                        server_ids.add(identifier)
+            return frozenset(server_ids)
+
+        SERVER_IDS = discover_from(resources_root)
+    _validate_server_definitions()
+
+
+__all__ = [
+    "SERVER_ALIASES",
+    "SERVER_IDS",
+    "ServerConfig",
+    "ServerId",
+    "get_server_config",
+    "list_server_ids",
+    "resolve_server_id",
+]

--- a/bootstrap/data/updater/uploader.py
+++ b/bootstrap/data/updater/uploader.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 from bootstrap.log import info
 from bootstrap.utils import get_command
@@ -87,8 +88,13 @@ async def upload_artifacts(
         ["alias", "set", alias, endpoint, "--api", "s3v4"],
         "CI RAW ARTIFACTS ALIAS",
         env={
+            # ``MC_HOST_<alias>`` is parsed as a URL, so access/secret key characters that
+            # are special in the userinfo segment (``/``, ``+``, ``=``, ``@``, ``:``) must
+            # be percent-encoded. ``mc`` then decodes them before sending to S3.
             f"MC_HOST_{alias}": (
-                f"https://{access_key}:{secret_key}@{endpoint.removeprefix('https://')}"
+                "https://"
+                f"{quote(access_key, safe='')}:{quote(secret_key, safe='')}"
+                f"@{endpoint.removeprefix('https://')}"
             ),
         },
     )

--- a/bootstrap/data/updater/uploader.py
+++ b/bootstrap/data/updater/uploader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 
 from typing import TYPE_CHECKING
 
@@ -21,22 +22,32 @@ if TYPE_CHECKING:
 _REDACTED = "<redacted>"
 
 
-async def _run_mc(cmd: list[str], title: str, *, redacted_indices: set[int] | None = None) -> None:
+async def _run_mc(
+    cmd: list[str],
+    title: str,
+    *,
+    env: dict[str, str] | None = None,
+    secrets: set[str] | None = None,
+) -> None:
     """Run an ``mc`` subcommand and raise on failure.
 
-    Arguments at ``redacted_indices`` are replaced with ``<redacted>`` in logs.
+    Any argument whose value is present in ``secrets`` is replaced with
+    ``<redacted>`` in logs. Value-based redaction is robust against future
+    changes to argument order.
+
+    ``env`` is merged into the subprocess environment; values are not logged.
     """
+
     mc = get_command("mc")
     full_cmd = [mc, *cmd]
-    redacted_cmd = list(full_cmd)
-    for idx in redacted_indices or set():
-        if 0 <= idx < len(redacted_cmd):
-            redacted_cmd[idx] = _REDACTED
+    redacted = {s for s in (secrets or set()) if s != ""}
+    redacted_cmd = [_REDACTED if arg in redacted else arg for arg in full_cmd]
     info(f"{title}: {' '.join(redacted_cmd)}")
     process = await asyncio.create_subprocess_exec(
         *full_cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        env={**os.environ, **(env or {})},
     )
     assert process.stdout is not None
     async for line in process.stdout:
@@ -73,9 +84,13 @@ async def upload_artifacts(
     endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
 
     await _run_mc(
-        ["alias", "set", alias, endpoint, access_key, secret_key, "--api", "s3v4"],
+        ["alias", "set", alias, endpoint, "--api", "s3v4"],
         "CI RAW ARTIFACTS ALIAS",
-        redacted_indices={5, 6},
+        env={
+            f"MC_HOST_{alias}": (
+                f"https://{access_key}:{secret_key}@{endpoint.removeprefix('https://')}"
+            ),
+        },
     )
 
     server_root = f"{alias}/{bucket}/{config.remote_root}/{server_id}"

--- a/bootstrap/data/updater/uploader.py
+++ b/bootstrap/data/updater/uploader.py
@@ -1,0 +1,99 @@
+"""Upload raw artifacts to the CI S3-compatible bucket via ``mc``."""
+
+from __future__ import annotations
+
+import asyncio
+
+from typing import TYPE_CHECKING
+
+from bootstrap.log import info
+from bootstrap.utils import get_command
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bootstrap.config import DeveloperCiRawArtifacts
+    from bootstrap.config import DeveloperCiStorage
+    from bootstrap.data.updater.server import ServerId
+
+
+_REDACTED = "<redacted>"
+
+
+async def _run_mc(cmd: list[str], title: str, *, redacted_indices: set[int] | None = None) -> None:
+    """Run an ``mc`` subcommand and raise on failure.
+
+    Arguments at ``redacted_indices`` are replaced with ``<redacted>`` in logs.
+    """
+    mc = get_command("mc")
+    full_cmd = [mc, *cmd]
+    redacted_cmd = list(full_cmd)
+    for idx in redacted_indices or set():
+        if 0 <= idx < len(redacted_cmd):
+            redacted_cmd[idx] = _REDACTED
+    info(f"{title}: {' '.join(redacted_cmd)}")
+    process = await asyncio.create_subprocess_exec(
+        *full_cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    assert process.stdout is not None
+    async for line in process.stdout:
+        info(line.decode("utf-8", errors="replace").rstrip())
+    await process.wait()
+    if process.returncode != 0:
+        raise RuntimeError(f"{title} failed with exit code {process.returncode}")
+
+
+def _resolve_storage(
+    config: DeveloperCiRawArtifacts,
+    storage: DeveloperCiStorage,
+) -> tuple[str, str, str, str, str]:
+    """Return endpoint, bucket, access_key, secret_key, alias with overrides applied."""
+    resolved_access_key = config.access_key or storage.access_key
+    resolved_secret_key = config.secret_key or storage.secret_key
+    return (
+        config.endpoint or storage.endpoint,
+        config.bucket or storage.bucket,
+        resolved_access_key.get_secret_value() if resolved_access_key else "",
+        resolved_secret_key.get_secret_value() if resolved_secret_key else "",
+        config.alias or storage.alias,
+    )
+
+
+async def upload_artifacts(
+    server_id: ServerId,
+    artifacts_dir: Path,
+    build: int,
+    config: DeveloperCiRawArtifacts,
+    storage: DeveloperCiStorage,
+) -> None:
+    """Upload raw artifacts and ``build.txt`` to the CI bucket."""
+    endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
+
+    await _run_mc(
+        ["alias", "set", alias, endpoint, access_key, secret_key, "--api", "s3v4"],
+        "CI RAW ARTIFACTS ALIAS",
+        redacted_indices={5, 6},
+    )
+
+    server_root = f"{alias}/{bucket}/{config.remote_root}/{server_id}"
+    build_file = artifacts_dir.parent / "build.txt"
+    build_file.write_text(str(build), encoding="utf-8")
+
+    await _run_mc(
+        [
+            "mirror",
+            "--overwrite",
+            "--remove",
+            f"{artifacts_dir}/",
+            f"{server_root}/artifacts/",
+        ],
+        f"UPLOAD {server_id} ARTIFACTS",
+    )
+
+    await _run_mc(
+        ["cp", str(build_file), f"{server_root}/build.txt"],
+        f"UPLOAD {server_id} BUILD.TXT",
+    )

--- a/bootstrap/docs/announcements_remote.py
+++ b/bootstrap/docs/announcements_remote.py
@@ -850,8 +850,11 @@ class AnnouncementRemoteSync:
                 f"Failed to execute [{title}] ({' '.join(redacted_cmd)}): {result.stderr}"
             )
 
-    def _ensure_alias(self) -> None:
-        """Set the S3 alias once, redacting credentials in any error message."""
+    def _ensure_alias(self) -> tuple[str, str]:
+        """Set the S3 alias once, redacting credentials in any error message.
+
+        Returns the resolved ``mc`` binary path and the alias target URL prefix.
+        """
         mc_bin = get_command("mc")
         alias_target = f"{self.alias_name}/{self.bucket}"
         redacted = "<redacted>"
@@ -880,7 +883,7 @@ class AnnouncementRemoteSync:
             ],
             "ANNOUNCE ALIAS",
         )
-        return alias_target
+        return mc_bin, alias_target
 
     def init_remote(self, force: bool = False) -> None:
         """Initialize a new empty announcement workspace on the remote.
@@ -935,11 +938,11 @@ class AnnouncementRemoteSync:
             (self.workspace.remote_dir / "active.json", "announcements/active.json"),
         ]
 
-        alias_target = self._ensure_alias()
+        mc_bin, alias_target = self._ensure_alias()
 
         for local_path, remote_path in uploads:
             target_url = f"{alias_target}/{self.resource_root}/{remote_path}"
-            cmd = ["mc", "cp", str(local_path), target_url]
+            cmd = [mc_bin, "cp", str(local_path), target_url]
             result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to upload {local_path}: {result.stderr}")
@@ -977,7 +980,7 @@ class AnnouncementRemoteSync:
                 print(f"Would upload: {local_path} → {remote_path}")
             return
 
-        alias_target = self._ensure_alias()
+        mc_bin, alias_target = self._ensure_alias()
         seen: set[str] = set()
 
         for local_path, remote_path in files_to_upload:
@@ -988,7 +991,7 @@ class AnnouncementRemoteSync:
                 continue
             seen.add(key)
             target_url = f"{alias_target}/{self.resource_root}/{remote_path}"
-            cmd = ["mc", "cp", str(local_path), target_url]
+            cmd = [mc_bin, "cp", str(local_path), target_url]
             result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to upload {local_path}: {result.stderr}")

--- a/bootstrap/docs/announcements_remote.py
+++ b/bootstrap/docs/announcements_remote.py
@@ -42,6 +42,8 @@ from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import field_validator
 
+from bootstrap.utils import get_command
+
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -840,6 +842,46 @@ class AnnouncementRemoteSync:
                                 f"Failed to download document {body_hash}: {e}"
                             ) from e
 
+    def _run_mc(self, cmd: list[str], redacted_cmd: list[str], title: str) -> None:
+        """Run an ``mc`` command, logging only the redacted version."""
+        result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to execute [{title}] ({' '.join(redacted_cmd)}): {result.stderr}"
+            )
+
+    def _ensure_alias(self) -> None:
+        """Set the S3 alias once, redacting credentials in any error message."""
+        mc_bin = get_command("mc")
+        alias_target = f"{self.alias_name}/{self.bucket}"
+        redacted = "<redacted>"
+        self._run_mc(
+            [
+                mc_bin,
+                "alias",
+                "set",
+                self.alias_name,
+                self.endpoint,
+                self.access_key,
+                self.secret_key,
+                "--api",
+                "s3v4",
+            ],
+            [
+                mc_bin,
+                "alias",
+                "set",
+                self.alias_name,
+                self.endpoint,
+                redacted,
+                redacted,
+                "--api",
+                "s3v4",
+            ],
+            "ANNOUNCE ALIAS",
+        )
+        return alias_target
+
     def init_remote(self, force: bool = False) -> None:
         """Initialize a new empty announcement workspace on the remote.
 
@@ -893,12 +935,11 @@ class AnnouncementRemoteSync:
             (self.workspace.remote_dir / "active.json", "announcements/active.json"),
         ]
 
-        mc_bin = "mc"
-        alias_target = f"{self.alias_name}/{self.bucket}"
+        alias_target = self._ensure_alias()
 
         for local_path, remote_path in uploads:
             target_url = f"{alias_target}/{self.resource_root}/{remote_path}"
-            cmd = [mc_bin, "cp", str(local_path), target_url]
+            cmd = ["mc", "cp", str(local_path), target_url]
             result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to upload {local_path}: {result.stderr}")
@@ -936,8 +977,7 @@ class AnnouncementRemoteSync:
                 print(f"Would upload: {local_path} → {remote_path}")
             return
 
-        mc_bin = "mc"
-        alias_target = f"{self.alias_name}/{self.bucket}"
+        alias_target = self._ensure_alias()
         seen: set[str] = set()
 
         for local_path, remote_path in files_to_upload:
@@ -948,7 +988,7 @@ class AnnouncementRemoteSync:
                 continue
             seen.add(key)
             target_url = f"{alias_target}/{self.resource_root}/{remote_path}"
-            cmd = [mc_bin, "cp", str(local_path), target_url]
+            cmd = ["mc", "cp", str(local_path), target_url]
             result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to upload {local_path}: {result.stderr}")

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -207,7 +207,7 @@ class TestFetchBuild:
 
 
 class TestIndexParsing:
-    def test_parse_index_file(self, tmp_path: Path) -> None:
+    async def test_parse_index_file(self, tmp_path: Path) -> None:
         index_file = tmp_path / "index.txt"
         index_file.write_text(
             "app:/resfileindex.txt,ab/cd1234,hash1,0,0\n"
@@ -215,7 +215,7 @@ class TestIndexParsing:
             "res:/foo/bar.png,ij/kl9012,hash3,0,0\n",
             encoding="utf-8",
         )
-        entries = _parse_index_file(index_file)
+        entries = await _parse_index_file(index_file)
         assert entries["app:/resfileindex.txt"] == "ab/cd1234"
         assert entries["app:/start.ini"] == "ef/gh5678"
         assert entries["res:/foo/bar.png"] == "ij/kl9012"

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -38,6 +38,20 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+class _MockContent:
+    """A minimal aiohttp-compatible content object supporting iter_chunked."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def iter_chunked(self, chunk_size: int):
+        async def _gen():
+            for i in range(0, len(self._body), chunk_size):
+                yield self._body[i : i + chunk_size]
+
+        return _gen()
+
+
 class _MockResponse:
     """A minimal async-context-manager response for aiohttp tests."""
 
@@ -51,6 +65,7 @@ class _MockResponse:
         self._json = json_data
         self._body = body
         self.status = status
+        self.content = _MockContent(body)
 
     async def __aenter__(self) -> _MockResponse:
         return self

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import tomllib
 
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -16,6 +17,7 @@ from bootstrap.config import DeveloperCiRawArtifacts
 from bootstrap.config import DeveloperCiStorage
 from bootstrap.config import DeveloperConfiguration
 from bootstrap.config import _apply_overrides
+from bootstrap.constant import PROJECT_ROOT
 from bootstrap.data.updater.index import _parse_index_file
 from bootstrap.data.updater.index import download_index
 from bootstrap.data.updater.index import download_metadata
@@ -23,7 +25,11 @@ from bootstrap.data.updater.manifest import fetch_build
 from bootstrap.data.updater.pipeline import UpdateCheckResult
 from bootstrap.data.updater.pipeline import _read_bucket_build
 from bootstrap.data.updater.pipeline import check_server
+from bootstrap.data.updater.server import SERVER_ALIASES
+from bootstrap.data.updater.server import SERVER_IDS
 from bootstrap.data.updater.server import get_server_config
+from bootstrap.data.updater.server import list_server_ids
+from bootstrap.data.updater.server import resolve_server_id
 from bootstrap.data.updater.uploader import _resolve_storage
 from bootstrap.data.updater.uploader import _run_mc
 
@@ -124,8 +130,54 @@ class TestServerConfig:
 
     def test_unknown_server_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown server id"):
-            # type: ignore[arg-type]
             get_server_config("invalid")
+
+
+class TestServerDiscovery:
+    def test_server_ids_match_resources_tree(self) -> None:
+        """SERVER_IDS must stay in sync with data/resources descriptor files."""
+        resources_root = PROJECT_ROOT / "data" / "resources"
+        expected: set[str] = set()
+        for entry in resources_root.iterdir():
+            if not entry.is_dir():
+                continue
+            descriptor_path = entry / "descriptor.toml"
+            if not descriptor_path.is_file():
+                continue
+            with open(descriptor_path, "rb") as f:
+                data = tomllib.load(f)
+            if data.get("ignore", False):
+                continue
+            metadata = data.get("metadata") or {}
+            if metadata.get("server", False):
+                identifier = metadata.get("identifier")
+                if isinstance(identifier, str) and identifier:
+                    expected.add(identifier)
+        assert frozenset(expected) == SERVER_IDS
+
+    def test_server_aliases_target_known_servers(self) -> None:
+        for alias, target in SERVER_ALIASES.items():
+            assert target in SERVER_IDS, f"alias {alias!r} targets unknown server {target!r}"
+
+    def test_server_configs_cover_all_servers(self) -> None:
+        for server_id in SERVER_IDS:
+            cfg = get_server_config(server_id)
+            assert cfg.id == server_id
+
+    def test_list_server_ids_is_sorted(self) -> None:
+        server_ids = list_server_ids()
+        assert server_ids == sorted(server_ids)
+        assert set(server_ids) == SERVER_IDS
+
+    def test_resolve_server_id_normalizes_aliases(self) -> None:
+        assert resolve_server_id("tq") == "tranquility"
+        assert resolve_server_id("TQ") == "tranquility"
+        assert resolve_server_id("se") == "serenity"
+        assert resolve_server_id("sisi") == "singularity"
+
+    def test_resolve_server_id_rejects_unknown(self) -> None:
+        with pytest.raises(ValueError, match="Unknown server id"):
+            resolve_server_id("not-a-server")
 
 
 class TestFetchBuild:

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -9,14 +9,17 @@ import pytest
 
 from pydantic import SecretStr
 
+from bootstrap.config import DeveloperCi
 from bootstrap.config import DeveloperCiRawArtifacts
 from bootstrap.config import DeveloperCiStorage
+from bootstrap.config import DeveloperConfiguration
 from bootstrap.config import _apply_overrides
 from bootstrap.data.updater.index import _parse_index_file
 from bootstrap.data.updater.index import download_index
 from bootstrap.data.updater.index import download_metadata
 from bootstrap.data.updater.manifest import fetch_build
 from bootstrap.data.updater.pipeline import UpdateCheckResult
+from bootstrap.data.updater.pipeline import _read_bucket_build
 from bootstrap.data.updater.pipeline import check_server
 from bootstrap.data.updater.server import get_server_config
 from bootstrap.data.updater.uploader import _resolve_storage
@@ -29,9 +32,16 @@ if TYPE_CHECKING:
 class _MockResponse:
     """A minimal async-context-manager response for aiohttp tests."""
 
-    def __init__(self, *, json_data: dict | None = None, body: bytes = b"") -> None:
+    def __init__(
+        self,
+        *,
+        json_data: dict | None = None,
+        body: bytes = b"",
+        status: int = 200,
+    ) -> None:
         self._json = json_data
         self._body = body
+        self.status = status
 
     async def __aenter__(self) -> _MockResponse:
         return self
@@ -47,6 +57,9 @@ class _MockResponse:
 
     async def read(self) -> bytes:
         return self._body
+
+    async def text(self) -> str:
+        return self._body.decode("utf-8", errors="replace")
 
 
 class _MockSession:
@@ -245,6 +258,53 @@ class TestCheckServer:
             result = await check_server("tranquility")
 
         assert result == UpdateCheckResult(needs_update=True, remote_build=100, bucket_build=None)
+
+
+class TestReadBucketBuild:
+    def _dev_config(
+        self, public_url: str | None = "https://public.example.com"
+    ) -> DeveloperConfiguration:
+        raw_artifacts = DeveloperCiRawArtifacts(
+            remote_root="data-generator/raw-artifact",
+            public_url=public_url,
+        )
+        return DeveloperConfiguration(ci=DeveloperCi(raw_artifacts=raw_artifacts))
+
+    async def test_returns_bucket_build_from_public_url(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "bootstrap.data.updater.pipeline.bootstrap.config.DEV_CONFIGURATION",
+            self._dev_config(),
+        )
+        response = _MockResponse(body=b"123456")
+        session = _MockSession(response)
+
+        with patch("bootstrap.data.updater.pipeline.aiohttp.ClientSession", return_value=session):
+            result = await _read_bucket_build("tranquility")
+
+        assert result == 123456
+
+    async def test_returns_none_on_404(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "bootstrap.data.updater.pipeline.bootstrap.config.DEV_CONFIGURATION",
+            self._dev_config(),
+        )
+        response = _MockResponse(body=b"not found", status=404)
+        session = _MockSession(response)
+
+        with patch("bootstrap.data.updater.pipeline.aiohttp.ClientSession", return_value=session):
+            result = await _read_bucket_build("tranquility")
+
+        assert result is None
+
+    async def test_returns_none_when_public_url_missing(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "bootstrap.data.updater.pipeline.bootstrap.config.DEV_CONFIGURATION",
+            self._dev_config(public_url=None),
+        )
+
+        result = await _read_bucket_build("tranquility")
+
+        assert result is None
 
 
 class TestUploader:

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -23,6 +25,7 @@ from bootstrap.data.updater.pipeline import _read_bucket_build
 from bootstrap.data.updater.pipeline import check_server
 from bootstrap.data.updater.server import get_server_config
 from bootstrap.data.updater.uploader import _resolve_storage
+from bootstrap.data.updater.uploader import _run_mc
 
 
 if TYPE_CHECKING:
@@ -307,6 +310,176 @@ class TestReadBucketBuild:
         assert result is None
 
 
+class _MockProcess:
+    """A minimal async process for testing _run_mc."""
+
+    def __init__(self, returncode: int = 0, stdout_lines: list[bytes] | None = None) -> None:
+        self.returncode = returncode
+        self.stdout = _AsyncIterator(stdout_lines or [])
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+class _AsyncIterator:
+    """Async iterator wrapping a list of bytes for mocking stdout."""
+
+    def __init__(self, items: list[bytes]) -> None:
+        self._items = items
+        self._idx = 0
+
+    def __aiter__(self) -> _AsyncIterator:
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._idx >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._idx]
+        self._idx += 1
+        return item
+
+
+class TestRunMc:
+    async def test_redacts_secret_values(self, monkeypatch) -> None:
+        logged: list[str] = []
+        monkeypatch.setattr("bootstrap.data.updater.uploader.info", logged.append)
+
+        async def _fake_subprocess(*args: str, **kwargs) -> _MockProcess:
+            return _MockProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_subprocess)
+
+        await _run_mc(
+            ["alias", "set", "myalias", "https://s3.example.com", "ACCESS", "SECRET"],
+            "TEST",
+            secrets={"ACCESS", "SECRET"},
+        )
+
+        assert len(logged) == 1
+        assert "ACCESS" not in logged[0]
+        assert "SECRET" not in logged[0]
+        assert "<redacted> <redacted>" in logged[0]
+
+    async def test_does_not_redact_unrelated_arguments(self, monkeypatch) -> None:
+        logged: list[str] = []
+        monkeypatch.setattr("bootstrap.data.updater.uploader.info", logged.append)
+
+        async def _fake_subprocess(*args: str, **kwargs) -> _MockProcess:
+            return _MockProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_subprocess)
+
+        await _run_mc(
+            ["alias", "set", "myalias", "https://s3.example.com", "ACCESS", "SECRET"],
+            "TEST",
+            secrets={"OTHER"},
+        )
+
+        assert "ACCESS" in logged[0]
+        assert "SECRET" in logged[0]
+        assert "<redacted>" not in logged[0]
+
+    async def test_empty_secrets_do_not_redact(self, monkeypatch) -> None:
+        logged: list[str] = []
+        monkeypatch.setattr("bootstrap.data.updater.uploader.info", logged.append)
+
+        async def _fake_subprocess(*args: str, **kwargs) -> _MockProcess:
+            return _MockProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_subprocess)
+
+        await _run_mc(
+            ["alias", "set", "myalias", "https://s3.example.com", "ACCESS", ""],
+            "TEST",
+            secrets={""},
+        )
+
+        assert "ACCESS" in logged[0]
+        assert "<redacted>" not in logged[0]
+
+    async def test_env_is_passed_to_subprocess(self, monkeypatch) -> None:
+        logged: list[str] = []
+        monkeypatch.setattr("bootstrap.data.updater.uploader.info", logged.append)
+
+        captured_env: dict[str, str] | None = None
+
+        async def _fake_subprocess(*args: str, **kwargs) -> _MockProcess:
+            nonlocal captured_env
+            captured_env = kwargs.get("env")
+            return _MockProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_subprocess)
+
+        await _run_mc(
+            ["alias", "set", "myalias", "https://s3.example.com"],
+            "TEST",
+            env={"MC_HOST_myalias": "https://key:secret@s3.example.com"},
+        )
+
+        assert captured_env is not None
+        assert captured_env["MC_HOST_myalias"] == "https://key:secret@s3.example.com"
+
+    async def test_env_is_merged_with_os_environ(self, monkeypatch) -> None:
+        monkeypatch.setenv("EXISTING_VAR", "existing_value")
+        monkeypatch.setattr("bootstrap.data.updater.uploader.info", lambda _: None)
+
+        captured_env: dict[str, str] | None = None
+
+        async def _fake_subprocess(*args: str, **kwargs) -> _MockProcess:
+            nonlocal captured_env
+            captured_env = kwargs.get("env")
+            return _MockProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_subprocess)
+
+        await _run_mc(
+            ["cp", "a", "b"],
+            "TEST",
+            env={"NEW_VAR": "new_value"},
+        )
+
+        assert captured_env is not None
+        assert captured_env["EXISTING_VAR"] == "existing_value"
+        assert captured_env["NEW_VAR"] == "new_value"
+
+    async def test_upload_artifacts_uses_mc_host_env(self, monkeypatch, tmp_path: Path) -> None:
+        from bootstrap.data.updater.uploader import upload_artifacts
+
+        captured_env: dict[str, str] | None = None
+        commands: list[list[str]] = []
+
+        async def _fake_subprocess(*args: str, **kwargs) -> _MockProcess:
+            nonlocal captured_env
+            if captured_env is None:
+                captured_env = kwargs.get("env")
+            commands.append(list(args))
+            return _MockProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_subprocess)
+
+        storage = DeveloperCiStorage(
+            endpoint="https://s3.example.com",
+            bucket="bucket",
+            alias="myalias",
+            access_key="ACCESS_KEY",
+            secret_key="SECRET_KEY",  # noqa: S106
+            public_url="https://public.example.com",
+        )
+        config = DeveloperCiRawArtifacts(remote_root="data-generator/raw-artifact")
+
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+
+        await upload_artifacts("tranquility", artifacts_dir, 123456, config, storage)
+
+        assert captured_env is not None
+        assert captured_env["MC_HOST_myalias"] == "https://ACCESS_KEY:SECRET_KEY@s3.example.com"
+
+        alias_cmd = next(cmd for cmd in commands if cmd[1:3] == ["alias", "set"])
+        assert "ACCESS_KEY" not in alias_cmd
+        assert "SECRET_KEY" not in alias_cmd
+
+
 class TestUploader:
     def test_resolve_storage_without_overrides(self) -> None:
         config = DeveloperCiRawArtifacts(remote_root="data-generator/raw-artifact")
@@ -315,7 +488,7 @@ class TestUploader:
             bucket="bucket",
             alias="alias",
             access_key="key",
-            secret_key="secret",
+            secret_key="secret",  # noqa: S106
             public_url="https://public.example.com",
         )
         endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
@@ -323,7 +496,7 @@ class TestUploader:
         assert bucket == "bucket"
         assert alias == "alias"
         assert access_key == "key"
-        assert secret_key == "secret"
+        assert secret_key == "secret"  # noqa: S105
 
     def test_resolve_storage_with_overrides(self) -> None:
         config = DeveloperCiRawArtifacts(
@@ -332,14 +505,14 @@ class TestUploader:
             bucket="override-bucket",
             alias="override-alias",
             access_key="override-key",
-            secret_key="override-secret",
+            secret_key="override-secret",  # noqa: S106
         )
         storage = DeveloperCiStorage(
             endpoint="https://example.com",
             bucket="bucket",
             alias="alias",
             access_key="key",
-            secret_key="secret",
+            secret_key="secret",  # noqa: S106
             public_url="https://public.example.com",
         )
         endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
@@ -347,7 +520,7 @@ class TestUploader:
         assert bucket == "override-bucket"
         assert alias == "override-alias"
         assert access_key == "override-key"
-        assert secret_key == "override-secret"
+        assert secret_key == "override-secret"  # noqa: S105
 
 
 class TestConfigOverrides:
@@ -380,7 +553,7 @@ class TestConfigOverrides:
             {},
             [("ci.storage.secret_key", "abc=def+ghi")],
         )
-        assert cfg["ci"]["storage"]["secret_key"] == "abc=def+ghi"
+        assert cfg["ci"]["storage"]["secret_key"] == "abc=def+ghi"  # noqa: S105
 
 
 class TestSecretStrRedaction:
@@ -390,7 +563,7 @@ class TestSecretStrRedaction:
             bucket="bucket",
             alias="alias",
             access_key="ACCESS_KEY",
-            secret_key="SECRET_KEY",
+            secret_key="SECRET_KEY",  # noqa: S106
             public_url="https://public.example.com",
         )
         dumped = storage.model_dump()
@@ -407,7 +580,7 @@ class TestSecretStrRedaction:
             bucket="bucket",
             alias="alias",
             access_key="ACCESS_KEY",
-            secret_key="SECRET_KEY",
+            secret_key="SECRET_KEY",  # noqa: S106
             public_url="https://public.example.com",
         )
         assert storage.access_key.get_secret_value() == "ACCESS_KEY"
@@ -419,7 +592,7 @@ class TestSecretStrRedaction:
             bucket="bucket",
             alias="alias",
             access_key="ACCESS_KEY",
-            secret_key="SECRET_KEY",
+            secret_key="SECRET_KEY",  # noqa: S106
             public_url="https://public.example.com",
         )
         text = str(storage)

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -1,0 +1,368 @@
+"""Tests for bootstrap.data.updater — CI raw-data updater."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from pydantic import SecretStr
+
+from bootstrap.config import DeveloperCiRawArtifacts
+from bootstrap.config import DeveloperCiStorage
+from bootstrap.config import _apply_overrides
+from bootstrap.data.updater.index import _parse_index_file
+from bootstrap.data.updater.index import download_index
+from bootstrap.data.updater.index import download_metadata
+from bootstrap.data.updater.manifest import fetch_build
+from bootstrap.data.updater.pipeline import UpdateCheckResult
+from bootstrap.data.updater.pipeline import check_server
+from bootstrap.data.updater.server import get_server_config
+from bootstrap.data.updater.uploader import _resolve_storage
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _MockResponse:
+    """A minimal async-context-manager response for aiohttp tests."""
+
+    def __init__(self, *, json_data: dict | None = None, body: bytes = b"") -> None:
+        self._json = json_data
+        self._body = body
+
+    async def __aenter__(self) -> _MockResponse:
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def json(self) -> dict | None:
+        return self._json
+
+    async def read(self) -> bytes:
+        return self._body
+
+
+class _MockSession:
+    """A minimal async-context-manager session for aiohttp tests."""
+
+    def __init__(self, response: _MockResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _MockSession:
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        return None
+
+    def get(self, url: str) -> _MockResponse:
+        return self._response
+
+
+class _MockSessionPerUrl:
+    """A session that returns a response based on the requested URL."""
+
+    def __init__(self, responses: dict[str, _MockResponse]) -> None:
+        self._responses = responses
+
+    async def __aenter__(self) -> _MockSessionPerUrl:
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        return None
+
+    def get(self, url: str) -> _MockResponse:
+        return self._responses[url]
+
+
+class TestServerConfig:
+    def test_tranquility_urls(self) -> None:
+        cfg = get_server_config("tranquility")
+        assert cfg.id == "tranquility"
+        assert cfg.manifest_url == "https://binaries.eveonline.com/eveclient_TQ.json"
+        assert cfg.index_file_name == "index_tranquility.txt"
+        assert cfg.fsd_dumper_server == "tq"
+        assert "{build}" in cfg.index_url_template
+        assert "{resource_url}" in cfg.binary_download_url
+
+    def test_singularity_urls(self) -> None:
+        cfg = get_server_config("singularity")
+        assert cfg.id == "singularity"
+        assert cfg.manifest_url == "https://binaries.eveonline.com/eveclient_SISI.json"
+        assert cfg.index_file_name == "index_singularity.txt"
+        assert cfg.fsd_dumper_server == "tq"
+
+    def test_serenity_urls(self) -> None:
+        cfg = get_server_config("serenity")
+        assert cfg.id == "serenity"
+        assert "eveclient_SERENITY.json" in cfg.manifest_url
+        assert cfg.index_file_name == "index_serenity.txt"
+        assert cfg.fsd_dumper_server == "se"
+        assert "netease" in cfg.binary_download_url
+
+    def test_unknown_server_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown server id"):
+            # type: ignore[arg-type]
+            get_server_config("invalid")
+
+
+class TestFetchBuild:
+    async def test_fetch_build_returns_integer(self) -> None:
+        server = get_server_config("tranquility")
+        response = _MockResponse(json_data={"build": "123456"})
+        session = _MockSession(response)
+
+        with patch("bootstrap.data.updater.manifest.aiohttp.ClientSession", return_value=session):
+            result = await fetch_build(server)
+
+        assert result == 123456
+
+    async def test_fetch_build_missing_build_raises(self) -> None:
+        server = get_server_config("tranquility")
+        response = _MockResponse(json_data={"version": "1.0"})
+        session = _MockSession(response)
+
+        with (
+            patch(
+                "bootstrap.data.updater.manifest.aiohttp.ClientSession",
+                return_value=session,
+            ),
+            pytest.raises(ValueError, match="missing 'build' field"),
+        ):
+            await fetch_build(server)
+
+
+class TestIndexParsing:
+    def test_parse_index_file(self, tmp_path: Path) -> None:
+        index_file = tmp_path / "index.txt"
+        index_file.write_text(
+            "app:/resfileindex.txt,ab/cd1234,hash1,0,0\n"
+            "app:/start.ini,ef/gh5678,hash2,0,0\n"
+            "res:/foo/bar.png,ij/kl9012,hash3,0,0\n",
+            encoding="utf-8",
+        )
+        entries = _parse_index_file(index_file)
+        assert entries["app:/resfileindex.txt"] == "ab/cd1234"
+        assert entries["app:/start.ini"] == "ef/gh5678"
+        assert entries["res:/foo/bar.png"] == "ij/kl9012"
+
+    async def test_download_index(self, tmp_path: Path) -> None:
+        server = get_server_config("tranquility")
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        response = _MockResponse(body=b"app:/resfileindex.txt,ab/cd1234\n")
+        session = _MockSession(response)
+
+        with patch("bootstrap.data.updater.index.aiohttp.ClientSession", return_value=session):
+            result = await download_index(123456, server, out_dir)
+
+        assert result == out_dir / server.index_file_name
+        assert result.read_text(encoding="utf-8") == "app:/resfileindex.txt,ab/cd1234\n"
+
+    async def test_download_metadata(self, tmp_path: Path) -> None:
+        server = get_server_config("tranquility")
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        index_file = tmp_path / "index_tranquility.txt"
+        index_file.write_text(
+            "app:/resfileindex.txt,resfileindex-hash,hash1,0,0\n"
+            "app:/resfileindex_Windows.txt,resfileindex-windows-hash,hash2,0,0\n"
+            "app:/resfileindex_prefetch.txt,resfileindex-prefetch-hash,hash3,0,0\n"
+            "app:/resfiledependencies.yaml,dependencies-hash,hash4,0,0\n"
+            "app:/start.ini,start-hash,hash5,0,0\n",
+            encoding="utf-8",
+        )
+
+        responses: dict[str, _MockResponse] = {
+            "https://binaries.eveonline.com/resfileindex-hash": _MockResponse(
+                body=b"resfileindex content"
+            ),
+            "https://binaries.eveonline.com/resfileindex-windows-hash": _MockResponse(
+                body=b"windows content"
+            ),
+            "https://binaries.eveonline.com/resfileindex-prefetch-hash": _MockResponse(
+                body=b"prefetch content"
+            ),
+            "https://binaries.eveonline.com/dependencies-hash": _MockResponse(
+                body=b"dependencies content"
+            ),
+            "https://binaries.eveonline.com/start-hash": _MockResponse(body=b"start content"),
+        }
+
+        session = _MockSessionPerUrl(responses)
+
+        with patch("bootstrap.data.updater.index.aiohttp.ClientSession", return_value=session):
+            await download_metadata(index_file, server, out_dir)
+
+        assert (out_dir / "resfileindex.txt").read_bytes() == b"resfileindex content"
+        assert (out_dir / "resfileindex_Windows.txt").read_bytes() == b"windows content"
+        assert (out_dir / "resfileindex_prefetch.txt").read_bytes() == b"prefetch content"
+        assert (out_dir / "resfiledependencies.yaml").read_bytes() == b"dependencies content"
+        assert (out_dir / "start.ini").read_bytes() == b"start content"
+
+
+class TestCheckServer:
+    async def test_remote_build_newer_needs_update(self) -> None:
+        with (
+            patch("bootstrap.data.updater.pipeline.fetch_build", return_value=100),
+            patch("bootstrap.data.updater.pipeline._read_bucket_build", return_value=99),
+        ):
+            result = await check_server("tranquility")
+
+        assert result == UpdateCheckResult(needs_update=True, remote_build=100, bucket_build=99)
+
+    async def test_remote_build_equal_no_update(self) -> None:
+        with (
+            patch("bootstrap.data.updater.pipeline.fetch_build", return_value=100),
+            patch("bootstrap.data.updater.pipeline._read_bucket_build", return_value=100),
+        ):
+            result = await check_server("tranquility")
+
+        assert result == UpdateCheckResult(needs_update=False, remote_build=100, bucket_build=100)
+
+    async def test_remote_build_older_no_update(self) -> None:
+        with (
+            patch("bootstrap.data.updater.pipeline.fetch_build", return_value=99),
+            patch("bootstrap.data.updater.pipeline._read_bucket_build", return_value=100),
+        ):
+            result = await check_server("tranquility")
+
+        assert result == UpdateCheckResult(needs_update=False, remote_build=99, bucket_build=100)
+
+    async def test_no_bucket_build_needs_update(self) -> None:
+        with (
+            patch("bootstrap.data.updater.pipeline.fetch_build", return_value=100),
+            patch("bootstrap.data.updater.pipeline._read_bucket_build", return_value=None),
+        ):
+            result = await check_server("tranquility")
+
+        assert result == UpdateCheckResult(needs_update=True, remote_build=100, bucket_build=None)
+
+
+class TestUploader:
+    def test_resolve_storage_without_overrides(self) -> None:
+        config = DeveloperCiRawArtifacts(remote_root="data-generator/raw-artifact")
+        storage = DeveloperCiStorage(
+            endpoint="https://example.com",
+            bucket="bucket",
+            alias="alias",
+            access_key="key",
+            secret_key="secret",
+            public_url="https://public.example.com",
+        )
+        endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
+        assert endpoint == "https://example.com"
+        assert bucket == "bucket"
+        assert alias == "alias"
+        assert access_key == "key"
+        assert secret_key == "secret"
+
+    def test_resolve_storage_with_overrides(self) -> None:
+        config = DeveloperCiRawArtifacts(
+            remote_root="data-generator/raw-artifact",
+            endpoint="https://override.com",
+            bucket="override-bucket",
+            alias="override-alias",
+            access_key="override-key",
+            secret_key="override-secret",
+        )
+        storage = DeveloperCiStorage(
+            endpoint="https://example.com",
+            bucket="bucket",
+            alias="alias",
+            access_key="key",
+            secret_key="secret",
+            public_url="https://public.example.com",
+        )
+        endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
+        assert endpoint == "https://override.com"
+        assert bucket == "override-bucket"
+        assert alias == "override-alias"
+        assert access_key == "override-key"
+        assert secret_key == "override-secret"
+
+
+class TestConfigOverrides:
+    def test_apply_overrides_creates_nested_tables(self) -> None:
+        cfg = _apply_overrides(
+            {},
+            [
+                ("ci.storage.endpoint", "https://test.example.com"),
+                ("ci.storage.bucket", "bucket"),
+            ],
+        )
+        assert cfg["ci"]["storage"]["endpoint"] == "https://test.example.com"
+        assert cfg["ci"]["storage"]["bucket"] == "bucket"
+
+    def test_apply_overrides_parses_toml_primitives(self) -> None:
+        cfg = _apply_overrides(
+            {},
+            [
+                ("version.major", "42"),
+                ("version.pre_label", '"beta"'),
+                ("remote.verify_upload", "true"),
+            ],
+        )
+        assert cfg["version"]["major"] == 42
+        assert cfg["version"]["pre_label"] == "beta"
+        assert cfg["remote"]["verify_upload"] is True
+
+    def test_apply_overrides_falls_back_to_literal_string(self) -> None:
+        cfg = _apply_overrides(
+            {},
+            [("ci.storage.secret_key", "abc=def+ghi")],
+        )
+        assert cfg["ci"]["storage"]["secret_key"] == "abc=def+ghi"
+
+
+class TestSecretStrRedaction:
+    def test_storage_secrets_are_redacted_in_dump(self) -> None:
+        storage = DeveloperCiStorage(
+            endpoint="https://example.com",
+            bucket="bucket",
+            alias="alias",
+            access_key="ACCESS_KEY",
+            secret_key="SECRET_KEY",
+            public_url="https://public.example.com",
+        )
+        dumped = storage.model_dump()
+        assert isinstance(dumped["access_key"], SecretStr)
+        assert dumped["access_key"].get_secret_value() == "ACCESS_KEY"  # SecretStr keeps value
+        assert str(dumped["access_key"]) == "**********"
+        assert isinstance(dumped["secret_key"], SecretStr)
+        assert str(dumped["secret_key"]) == "**********"
+        assert dumped["endpoint"] == "https://example.com"
+
+    def test_storage_secrets_are_available_via_get_secret_value(self) -> None:
+        storage = DeveloperCiStorage(
+            endpoint="https://example.com",
+            bucket="bucket",
+            alias="alias",
+            access_key="ACCESS_KEY",
+            secret_key="SECRET_KEY",
+            public_url="https://public.example.com",
+        )
+        assert storage.access_key.get_secret_value() == "ACCESS_KEY"
+        assert storage.secret_key.get_secret_value() == "SECRET_KEY"
+
+    def test_str_representation_does_not_leak_secret(self) -> None:
+        storage = DeveloperCiStorage(
+            endpoint="https://example.com",
+            bucket="bucket",
+            alias="alias",
+            access_key="ACCESS_KEY",
+            secret_key="SECRET_KEY",
+            public_url="https://public.example.com",
+        )
+        text = str(storage)
+        assert "ACCESS_KEY" not in text
+        assert "SECRET_KEY" not in text
+        assert "**********" in text

--- a/data/resources/example/descriptor.toml
+++ b/data/resources/example/descriptor.toml
@@ -18,6 +18,11 @@ ignore = true
 # This is also used as the output archive file name.
 identifier = "example"
 
+# Whether this resource represents a CI raw-data server that should be tracked
+# by the updater pipeline. Only descriptors with `server = true` are discovered
+# as valid server ids, and they must also have `ignore = false`.
+server = false
+
 # The start configuration file for the resource.
 # See data/README.md for more details.
 start_cfg = "start.ini"

--- a/data/resources/serenity/descriptor.toml
+++ b/data/resources/serenity/descriptor.toml
@@ -2,6 +2,7 @@
 start_cfg = "start.ini"
 name = {en = "Serenity", zh = "晨曦"}
 identifier = "serenity"
+server = true
 
 [resources]
 fsd = "fsd"

--- a/data/resources/singularity/descriptor.toml
+++ b/data/resources/singularity/descriptor.toml
@@ -2,6 +2,7 @@
 start_cfg = "start.ini"
 name = {en = "Singularity", zh = "奇点"}
 identifier = "singularity"
+server = true
 
 [resources]
 fsd = "fsd"

--- a/data/resources/tranquility/descriptor.toml
+++ b/data/resources/tranquility/descriptor.toml
@@ -2,6 +2,7 @@
 start_cfg = "start.ini"
 name = {en = "Tranquility", zh = "宁静"}
 identifier = "tranquility"
+server = true
 
 [resources]
 fsd = "fsd"

--- a/efa.dev.example.toml
+++ b/efa.dev.example.toml
@@ -91,3 +91,7 @@ remote_root = "data-generator/raw-artifact"
 # alias = "efa-ci-raw-artifacts"
 # access_key = "..."
 # secret_key = "..."
+
+# Optional: public URL used to read build.txt without credentials.
+# If omitted, [ci.storage].public_url is used when available.
+# public_url = "https://ci.storage.efa-tech.dev"

--- a/efa.dev.example.toml
+++ b/efa.dev.example.toml
@@ -80,3 +80,14 @@ alias = "efa-ci-storage"
 access_key = "your-r2-access-key"
 secret_key = "your-r2-secret-key"
 public_url = "https://ci.storage.efa-tech.dev"
+
+[ci.raw_artifacts]
+# Prefix inside the CI bucket where raw artifact trees are stored.
+remote_root = "data-generator/raw-artifact"
+
+# Optional: override [ci.storage] values for the raw-artifact target.
+# endpoint = "https://<account_id>.r2.cloudflarestorage.com"
+# bucket = "efa-ci-data"
+# alias = "efa-ci-raw-artifacts"
+# access_key = "..."
+# secret_key = "..."

--- a/flake.nix
+++ b/flake.nix
@@ -122,9 +122,18 @@
         ;
 
       # --- Named package sets ---
-      pythonPackages = with pkgs; [ python3 uv ];
+      pythonPackages = with pkgs; [
+        python3
+        uv
+      ];
 
-      rustPackages = with pkgs; [ rustc cargo rustfmt clippy rust-analyzer ];
+      rustPackages = with pkgs; [
+        rustc
+        cargo
+        rustfmt
+        clippy
+        rust-analyzer
+      ];
 
       nativeBuildPackages = with pkgs; [
         pkg-config
@@ -134,15 +143,30 @@
         llvmPackages.libclang
       ];
 
-      dartPackages = with pkgs; [ flutter jdk17 ];
+      dartPackages = with pkgs; [
+        flutter
+        jdk17
+      ];
 
-      protobufPackages = with pkgs; [ protobuf protoc-gen-dart ];
+      protobufPackages = with pkgs; [
+        protobuf
+        protoc-gen-dart
+      ];
 
       frbPackages = with pkgs; [ flutter_rust_bridge_codegen ];
 
-      jsPackages = with pkgs; [ nodejs_26 pnpm ];
+      jsPackages = with pkgs; [
+        nodejs_26
+        pnpm
+      ];
 
-      releasePackages = with pkgs; [ cargo-expand git-cliff minio minio-client wrangler ];
+      releasePackages = with pkgs; [
+        cargo-expand
+        git-cliff
+        minio
+        minio-client
+        wrangler
+      ];
 
       # --- Shared environment variables ---
       localeEnv = {
@@ -234,7 +258,7 @@
 
         # Minimal Python shell: linting, formatting, and tests
         python = pkgs.mkShell {
-          packages = pythonPackages;
+          packages = pythonPackages ++ [ pkgs.minio-client ];
 
           inherit (localeEnv) LANG LC_ALL;
           UV_PYTHON = "${python3}/bin/python3";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "case-converter>=1.2.0",
     "tqdm>=4.67.0",
     "canonicaljson>=2.0.0",
+    "requests>=2.32.5",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
 testpaths = ["bootstrap/tests"]
 pythonpath = [".", "bootstrap/data/schema"]
 asyncio_mode = "auto"
-addopts = ["--disable-socket"]
+addopts = ["--disable-socket", "--allow-unix-socket"]
 
 [tool.uv.sources]
 convert = { workspace = true }

--- a/ruff.toml
+++ b/ruff.toml
@@ -26,6 +26,8 @@ extend-select = [
     "PIE", # flake8-pie
     "PGH", # pygrep
     "RUF", # ruff checks
+    "S105", # hardcoded-password-string
+    "S106", # hardcoded-password-funcarg
     "SIM", # flake8-simplify
     "T20", # flake8-print
     "TCH", # flake8-type-checking

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,6 +8,7 @@ exclude = [
     "__pycache__",
     "**/*_pb2.py",
     "rust/lib/",
+    "tools/eve-fsd-dumper/",
 ]
 
 [format]

--- a/scripts/ci/raw-data/py2.ps1
+++ b/scripts/ci/raw-data/py2.ps1
@@ -1,0 +1,24 @@
+param(
+    [string]$ZipPath = "tools/eve-fsd-dumper/py27.zip",
+    [string]$ExtractPath = "py27"
+)
+
+if (!(Test-Path $ZipPath)) {
+    Write-Error "Python 2.7 archive not found: $ZipPath"
+    exit 1
+}
+
+if (!(Test-Path $ExtractPath)) {
+    Write-Host "Extracting portable Python 2.7 to $ExtractPath ..."
+    Expand-Archive -Path $ZipPath -DestinationPath $ExtractPath
+} else {
+    Write-Host "Python 2.7 already extracted at $ExtractPath."
+}
+
+$pythonExe = Join-Path $ExtractPath "python.exe"
+if (!(Test-Path $pythonExe)) {
+    Write-Error "python.exe not found in $ExtractPath"
+    exit 1
+}
+
+Write-Host "Python 2.7 executable: $pythonExe"

--- a/scripts/ci/raw-data/py2.ps1
+++ b/scripts/ci/raw-data/py2.ps1
@@ -8,14 +8,14 @@ if (!(Test-Path $ZipPath)) {
     exit 1
 }
 
-if (!(Test-Path $ExtractPath)) {
+$pythonExe = Join-Path $ExtractPath "python.exe"
+if (!(Test-Path $pythonExe)) {
     Write-Host "Extracting portable Python 2.7 to $ExtractPath ..."
     Expand-Archive -Path $ZipPath -DestinationPath $ExtractPath
 } else {
     Write-Host "Python 2.7 already extracted at $ExtractPath."
 }
 
-$pythonExe = Join-Path $ExtractPath "python.exe"
 if (!(Test-Path $pythonExe)) {
     Write-Error "python.exe not found in $ExtractPath"
     exit 1

--- a/uv.lock
+++ b/uv.lock
@@ -168,6 +168,72 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -354,6 +420,7 @@ dependencies = [
     { name = "convert" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "requests" },
     { name = "tenacity" },
     { name = "tqdm" },
     { name = "watchfiles" },
@@ -380,6 +447,7 @@ requires-dist = [
     { name = "convert", editable = "rust/lib/eve-fit-os" },
     { name = "pydantic", specifier = ">=2.13.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "requests", specifier = ">=2.32.5" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "tqdm", specifier = ">=4.67.0" },
     { name = "watchfiles", specifier = ">=1.1.1" },
@@ -1168,6 +1236,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
@@ -1241,6 +1324,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/x.py
+++ b/x.py
@@ -53,6 +53,8 @@ from bootstrap.cli import runtime
 from bootstrap.color import styled
 from bootstrap.config import ProjectConfiguration
 from bootstrap.config import WorkspaceCache
+from bootstrap.config import apply_dev_config_overrides
+from bootstrap.config import apply_project_config_overrides
 
 
 init(autoreset=True)
@@ -64,8 +66,20 @@ if __name__ != "__main__":
     )
     exit(0)
 
-ProjectConfiguration.load_from_global()
-WorkspaceCache.load_from_global()
+
+def _parse_env_option(
+    _ctx: click.Context,
+    _param: click.Parameter,
+    value: tuple[str, ...] | None,
+) -> list[tuple[str, str]]:
+    """Parse repeated ``key=value`` options into a list of overrides."""
+    overrides: list[tuple[str, str]] = []
+    for item in value or ():
+        if "=" not in item:
+            raise click.BadParameter(f"Invalid override {item!r}, expected format: key=value")
+        key, val = item.split("=", 1)
+        overrides.append((key, val))
+    return overrides
 
 
 @click.group(
@@ -75,9 +89,32 @@ WorkspaceCache.load_from_global()
 )
 @click.option("--dry-run", is_flag=True, default=False, help="Show the command without executing.")
 @click.option("--workspace", "--ws", "ws_name", default=None, help="Set current workspace.")
-def cli(dry_run, ws_name):
+@click.option(
+    "--dev-env",
+    "dev_env_overrides",
+    multiple=True,
+    callback=_parse_env_option,
+    default=None,
+    help="Override a value in efa.dev.toml before validation (e.g. --dev-env ci.storage.secret_key=abc).",
+)
+@click.option(
+    "--conf-env",
+    "conf_env_overrides",
+    multiple=True,
+    callback=_parse_env_option,
+    default=None,
+    help="Override a value in efa.config.toml before validation (e.g. --conf-env version.major=1).",
+)
+@click.pass_context
+def cli(ctx, dry_run, ws_name, dev_env_overrides, conf_env_overrides):
     """EFA Workspace Manager."""
     runtime.set_dry_run(dry_run)
+
+    apply_dev_config_overrides(dev_env_overrides)
+    apply_project_config_overrides(conf_env_overrides)
+
+    ProjectConfiguration.load_from_global()
+    WorkspaceCache.load_from_global()
 
     if ws_name:
         WorkspaceCache.select_workspace(ws_name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI **raw-data** command group (check, update, upload, sync-local) for per-server raw artifact refresh.
  * Introduced a GitHub Actions workflow to compute a per-server update matrix and generate/upload raw-artifact caches on schedule and selected events.
  * Added CLI-style TOML override support and new **`ci.raw_artifacts`** configuration for dedicated raw-artifact storage.
  * Implemented an end-to-end raw-data update pipeline (index/metadata download, FSD generation, optional upload).

* **Bug Fixes**
  * Improved credential handling by unwrapping secret values and preventing sensitive data from appearing in logs.

* **Tests**
  * Added comprehensive unit tests for server discovery, pipeline logic, uploader behavior, and config overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->