### PR TITLE
fix(ci): respect --dev-env overrides in raw-data upload and lazy-load logger config

### DIFF
--- a/.github/workflows/update-raw-data.yml
+++ b/.github/workflows/update-raw-data.yml
@@ -138,5 +138,6 @@ jobs:
               --dev-env ci.storage.alias="$CI_ALIAS" \
               --dev-env ci.storage.access_key="$CI_ACCESS_KEY" \
               --dev-env ci.storage.secret_key="$CI_SECRET_KEY" \
+              --dev-env ci.storage.public_url="https://ci.storage.efa-tech.dev" \
               --dev-env ci.raw_artifacts.remote_root="data-generator/raw-artifact" \
               ci raw-data upload --server "$SERVER" --from-dir raw-artifacts/"$SERVER"/'

--- a/bootstrap/cli/release.py
+++ b/bootstrap/cli/release.py
@@ -5,8 +5,9 @@ import click
 from colorama import Fore
 from colorama import Style
 
+import bootstrap.config
+
 from bootstrap.color import styled
-from bootstrap.config import CONFIGURATION
 from bootstrap.config import ProjectVersion
 from bootstrap.release.relnote import create_raw_release_note
 from bootstrap.release.relnote import parse_version_override
@@ -68,7 +69,8 @@ def register_release_commands(cli_group: click.Group) -> None:
         if version_override is not None:
             version = ProjectVersion.model_validate(parse_version_override(version_override))
         else:
-            version = CONFIGURATION.version
+            bootstrap.config.ProjectConfiguration.ensure_loaded()
+            version = bootstrap.config.CONFIGURATION.version
 
         channels_list = split_csv(channels)
         platforms_list = split_csv(platforms)

--- a/bootstrap/cli/remote/announce.py
+++ b/bootstrap/cli/remote/announce.py
@@ -15,7 +15,6 @@ import bootstrap.config
 from bootstrap.cli.remote.helpers import get_announce_workspace
 from bootstrap.cli.remote.helpers import resolve_announce_remote_target
 from bootstrap.color import styled
-from bootstrap.config import CONFIGURATION
 from bootstrap.config import ProjectVersion
 from bootstrap.docs.announcements_remote import ACTIVE_KEY
 from bootstrap.docs.announcements_remote import DOCUMENT_ID_PATTERN
@@ -816,7 +815,7 @@ def register_remote_announce(remote: click.Group) -> None:
             version = ProjectVersion.model_validate(parse_version_override(version_override))
         else:
             bootstrap.config.ProjectConfiguration.ensure_loaded()
-            version = CONFIGURATION.version
+            version = bootstrap.config.CONFIGURATION.version
 
         app_version = version.render_semver()
         dir_name = normalize_version_dir(app_version)

--- a/bootstrap/config.py
+++ b/bootstrap/config.py
@@ -293,14 +293,14 @@ class DeveloperRemoteS3(BaseModel):
 
 
 class DeveloperCiStorage(BaseModel):
-    """CI data storage configuration (Cloudflare R2). All fields required."""
+    """CI data storage configuration (Cloudflare R2)."""
 
     endpoint: str
     bucket: str
     alias: str
     access_key: SecretStr
     secret_key: SecretStr
-    public_url: str
+    public_url: str | None = None
 
 
 class DeveloperCiRawArtifacts(BaseModel):
@@ -357,7 +357,8 @@ class DeveloperCi(BaseModel):
         if self.storage is None:
             print(
                 "Error: [ci.storage] is not configured in efa.dev.toml.\n"
-                "       Required for `./x ci pack-data`.\n"
+                "       Required for CI storage commands (e.g. ``./x ci pack-data`` "
+                "and ``./x ci raw-data upload``).\n"
                 "       See efa.dev.example.toml.",
                 file=sys.stderr,
             )

--- a/bootstrap/log.py
+++ b/bootstrap/log.py
@@ -39,7 +39,18 @@ class ColoredTerminalFormatter(logging.Formatter):
 
 LOGGER = logging.getLogger("EFA")
 
-if len(LOGGER.handlers) == 0:
+
+def _ensure_handlers() -> None:
+    """Initialize logging handlers lazily on first use.
+
+    Import-time config loading caused ``--dev-env`` overrides to be ignored,
+    because the CLI registers those overrides only after the command modules
+    have been imported. Lazy initialization ensures the first log call triggers
+    config load after overrides are in place.
+    """
+    if LOGGER.handlers:
+        return
+
     bootstrap.config.ProjectConfiguration.ensure_loaded()
     bootstrap.config.DeveloperConfiguration.ensure_loaded()
     log_path = bootstrap.config.DEV_CONFIGURATION.paths.log_path
@@ -62,8 +73,27 @@ if len(LOGGER.handlers) == 0:
     LOGGER.addHandler(file_handler)
     LOGGER.addHandler(console_handler)
 
-info = LOGGER.info
-warning = LOGGER.warning
-error = LOGGER.error
-debug = LOGGER.debug
-critical = LOGGER.critical
+
+def info(msg: object, *args, **kwargs) -> None:
+    _ensure_handlers()
+    LOGGER.info(msg, *args, **kwargs)
+
+
+def warning(msg: object, *args, **kwargs) -> None:
+    _ensure_handlers()
+    LOGGER.warning(msg, *args, **kwargs)
+
+
+def error(msg: object, *args, **kwargs) -> None:
+    _ensure_handlers()
+    LOGGER.error(msg, *args, **kwargs)
+
+
+def debug(msg: object, *args, **kwargs) -> None:
+    _ensure_handlers()
+    LOGGER.debug(msg, *args, **kwargs)
+
+
+def critical(msg: object, *args, **kwargs) -> None:
+    _ensure_handlers()
+    LOGGER.critical(msg, *args, **kwargs)

--- a/bootstrap/log.py
+++ b/bootstrap/log.py
@@ -51,49 +51,77 @@ def _ensure_handlers() -> None:
     if LOGGER.handlers:
         return
 
-    bootstrap.config.ProjectConfiguration.ensure_loaded()
-    bootstrap.config.DeveloperConfiguration.ensure_loaded()
-    log_path = bootstrap.config.DEV_CONFIGURATION.paths.log_path
-    if not log_path.exists():
-        log_path.mkdir(parents=True, exist_ok=True)
+    try:
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
+        bootstrap.config.DeveloperConfiguration.ensure_loaded()
+        log_path = bootstrap.config.DEV_CONFIGURATION.paths.log_path
+        if not log_path.exists():
+            log_path.mkdir(parents=True, exist_ok=True)
 
-    LOGGER.setLevel(logging.DEBUG)
-    log_filename = f"{time.strftime('%Y%m%d-%H%M%S')}.log"
-    file_handler = logging.FileHandler(log_path / log_filename, mode="w", encoding="utf-8")
-    file_handler.setLevel(logging.DEBUG)
+        LOGGER.setLevel(logging.DEBUG)
+        log_filename = f"{time.strftime('%Y%m%d-%H%M%S')}.log"
+        file_handler = logging.FileHandler(log_path / log_filename, mode="w", encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)
 
-    console_handler = logging.StreamHandler(sys.stderr)
-    console_handler.setLevel(logging.INFO)
+        console_handler = logging.StreamHandler(sys.stderr)
+        console_handler.setLevel(logging.INFO)
 
-    file_formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] [%(pathname)s]: %(message)s")
-    file_handler.setFormatter(file_formatter)
+        file_formatter = logging.Formatter(
+            "[%(asctime)s] [%(levelname)s] [%(pathname)s]: %(message)s"
+        )
+        file_handler.setFormatter(file_formatter)
 
-    console_handler.setFormatter(ColoredTerminalFormatter())
+        console_handler.setFormatter(ColoredTerminalFormatter())
 
-    LOGGER.addHandler(file_handler)
-    LOGGER.addHandler(console_handler)
+        LOGGER.addHandler(file_handler)
+        LOGGER.addHandler(console_handler)
+    except Exception as exc:
+        # Config or filesystem setup failed. Install a minimal stderr fallback
+        # so the message being logged (often from an ``except`` block) is not
+        # swallowed by this secondary failure.
+        fallback = logging.StreamHandler(sys.stderr)
+        fallback.setLevel(logging.NOTSET)
+        fallback.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+        LOGGER.setLevel(logging.DEBUG)
+        LOGGER.addHandler(fallback)
+        fallback.emit(
+            logging.LogRecord(
+                name=LOGGER.name,
+                level=logging.WARNING,
+                pathname=__file__,
+                lineno=0,
+                msg="Logging setup failed, using stderr fallback: %s",
+                args=(exc,),
+                exc_info=None,
+            )
+        )
 
 
 def info(msg: object, *args, **kwargs) -> None:
     _ensure_handlers()
+    kwargs.setdefault("stacklevel", 2)
     LOGGER.info(msg, *args, **kwargs)
 
 
 def warning(msg: object, *args, **kwargs) -> None:
     _ensure_handlers()
+    kwargs.setdefault("stacklevel", 2)
     LOGGER.warning(msg, *args, **kwargs)
 
 
 def error(msg: object, *args, **kwargs) -> None:
     _ensure_handlers()
+    kwargs.setdefault("stacklevel", 2)
     LOGGER.error(msg, *args, **kwargs)
 
 
 def debug(msg: object, *args, **kwargs) -> None:
     _ensure_handlers()
+    kwargs.setdefault("stacklevel", 2)
     LOGGER.debug(msg, *args, **kwargs)
 
 
 def critical(msg: object, *args, **kwargs) -> None:
     _ensure_handlers()
+    kwargs.setdefault("stacklevel", 2)
     LOGGER.critical(msg, *args, **kwargs)

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -684,6 +684,26 @@ class TestConfigOverrides:
         )
         assert cfg["ci"]["storage"]["secret_key"] == "abc=def+ghi"  # noqa: S105
 
+    def test_dev_env_overrides_create_ci_storage_without_dev_toml(self) -> None:
+        cfg = _apply_overrides(
+            {},
+            [
+                ("ci.storage.endpoint", "https://test.example.com"),
+                ("ci.storage.bucket", "bucket"),
+                ("ci.storage.alias", "alias"),
+                ("ci.storage.access_key", "key"),
+                ("ci.storage.secret_key", "secret"),
+            ],
+        )
+        dev = DeveloperConfiguration.model_validate(cfg)
+        assert dev.ci.storage is not None
+        assert dev.ci.storage.endpoint == "https://test.example.com"
+        assert dev.ci.storage.bucket == "bucket"
+        assert dev.ci.storage.alias == "alias"
+        assert dev.ci.storage.access_key.get_secret_value() == "key"
+        assert dev.ci.storage.secret_key.get_secret_value() == "secret"
+        assert dev.ci.storage.public_url is None
+
 
 class TestSecretStrRedaction:
     def test_storage_secrets_are_redacted_in_dump(self) -> None:

--- a/bootstrap/tests/test_remote_announce_relnote.py
+++ b/bootstrap/tests/test_remote_announce_relnote.py
@@ -144,12 +144,56 @@ class TestHelpers:
 
 
 class TestAddReleaseNote:
-    def test_stages_release_note_entry(self, tmp_path: Path) -> None:
+    @pytest.fixture
+    def register_remote_announce(self):
         import bootstrap.config
 
         bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
+        return register_remote_announce
+
+    @pytest.fixture
+    def announce_workspace(self, tmp_path: Path) -> AnnouncementWorkspace:
+        workspace = _build_workspace(tmp_path)
+        _write_empty_remote_state(workspace)
+        return workspace
+
+    @pytest.fixture
+    def invoke_add_release_note(
+        self,
+        tmp_path: Path,
+        register_remote_announce,
+        announce_workspace: AnnouncementWorkspace,
+    ):
+        def _invoke(
+            directory: Path,
+            version: ProjectVersion,
+            *,
+            args: list[str] | None = None,
+        ) -> click.testing.Result:
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr(
+                    "bootstrap.cli.remote.announce.get_announce_workspace",
+                    lambda: tmp_path / "announce-workspace",
+                )
+                mp.setattr("bootstrap.config.CONFIGURATION.version", version)
+                group = click.Group()
+                register_remote_announce(group)
+                cmd = group.commands["announce"].commands["add-release-note"]
+                all_args = [f"--directory={directory}"]
+                if args:
+                    all_args.extend(args)
+                return CliRunner().invoke(cmd, all_args)
+
+        return _invoke
+
+    def test_stages_release_note_entry(
+        self,
+        tmp_path: Path,
+        announce_workspace: AnnouncementWorkspace,
+        invoke_add_release_note,
+    ) -> None:
         directory = _make_release_note_dir(
             tmp_path,
             "0-1-0-beta-7",
@@ -158,30 +202,12 @@ class TestAddReleaseNote:
             en_body="# v0.1.0-beta.7 Release Notes\n\nThis release includes the changes below.\n\n- Feature A\n",
             changelog="## [v0.1.0-beta.7] - 2026-07-04\n\n### Added\n\n- Feature A\n",
         )
-        workspace = _build_workspace(tmp_path)
-        _write_empty_remote_state(workspace)
-
         version = ProjectVersion(major=0, minor=1, patch=0, pre_label="beta", pre_num=7)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "bootstrap.cli.remote.announce.get_announce_workspace",
-                lambda: tmp_path / "announce-workspace",
-            )
-            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
+        result = invoke_add_release_note(directory, version)
+        assert result.exit_code == 0
 
-            group = click.Group()
-            register_remote_announce(group)
-            cmd = group.commands["announce"].commands["add-release-note"]
-            result = CliRunner().invoke(
-                cmd,
-                [
-                    f"--directory={directory}",
-                ],
-            )
-            assert result.exit_code == 0
-
-        overlay = workspace.read_overlay()
+        overlay = announce_workspace.read_overlay()
         assert ACTIVE_KEY in overlay.pages
         entry = overlay.pages[ACTIVE_KEY]["version-0-1-0-beta-7"]
         assert entry is not None
@@ -195,15 +221,15 @@ class TestAddReleaseNote:
         en = entry.localizations["en"]
         assert zh.title == "v0.1.0-beta.7 发布说明"
         assert en.title == "v0.1.0-beta.7 Release Notes"
-        assert "Feature A" in workspace.get_document(en.body_hash)
-        assert "---" in workspace.get_document(en.body_hash)
+        assert "Feature A" in announce_workspace.get_document(en.body_hash)
+        assert "---" in announce_workspace.get_document(en.body_hash)
 
-    def test_uses_spec_channels_and_platforms(self, tmp_path: Path) -> None:
-        import bootstrap.config
-
-        bootstrap.config.ProjectConfiguration.ensure_loaded()
-        from bootstrap.cli.remote.announce import register_remote_announce
-
+    def test_uses_spec_channels_and_platforms(
+        self,
+        tmp_path: Path,
+        announce_workspace: AnnouncementWorkspace,
+        invoke_add_release_note,
+    ) -> None:
         directory = _make_release_note_dir(
             tmp_path,
             "1-0-0",
@@ -213,35 +239,22 @@ class TestAddReleaseNote:
             changelog="- Fix\n",
             extra_spec="channels:\n- stable\nplatforms:\n- ios\n",
         )
-        workspace = _build_workspace(tmp_path)
-        _write_empty_remote_state(workspace)
-
         version = ProjectVersion(major=1, minor=0, patch=0)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "bootstrap.cli.remote.announce.get_announce_workspace",
-                lambda: tmp_path / "announce-workspace",
-            )
-            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
+        result = invoke_add_release_note(directory, version)
+        assert result.exit_code == 0
 
-            group = click.Group()
-            register_remote_announce(group)
-            cmd = group.commands["announce"].commands["add-release-note"]
-            result = CliRunner().invoke(cmd, [f"--directory={directory}"])
-            assert result.exit_code == 0
-
-        overlay = workspace.read_overlay()
+        overlay = announce_workspace.read_overlay()
         entry = overlay.pages[ACTIVE_KEY]["version-1-0-0"]
         assert entry.channels == ["stable"]
         assert entry.platforms == ["ios"]
 
-    def test_uses_spec_tags(self, tmp_path: Path) -> None:
-        import bootstrap.config
-
-        bootstrap.config.ProjectConfiguration.ensure_loaded()
-        from bootstrap.cli.remote.announce import register_remote_announce
-
+    def test_uses_spec_tags(
+        self,
+        tmp_path: Path,
+        announce_workspace: AnnouncementWorkspace,
+        invoke_add_release_note,
+    ) -> None:
         directory = _make_release_note_dir(
             tmp_path,
             "1-0-0",
@@ -251,34 +264,21 @@ class TestAddReleaseNote:
             changelog="- Fix\n",
             extra_spec="tags:\n- custom-tag\n",
         )
-        workspace = _build_workspace(tmp_path)
-        _write_empty_remote_state(workspace)
-
         version = ProjectVersion(major=1, minor=0, patch=0)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "bootstrap.cli.remote.announce.get_announce_workspace",
-                lambda: tmp_path / "announce-workspace",
-            )
-            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
+        result = invoke_add_release_note(directory, version)
+        assert result.exit_code == 0
 
-            group = click.Group()
-            register_remote_announce(group)
-            cmd = group.commands["announce"].commands["add-release-note"]
-            result = CliRunner().invoke(cmd, [f"--directory={directory}"])
-            assert result.exit_code == 0
-
-        overlay = workspace.read_overlay()
+        overlay = announce_workspace.read_overlay()
         entry = overlay.pages[ACTIVE_KEY]["version-1-0-0"]
         assert entry.tags == ["custom-tag"]
 
-    def test_cli_overrides_take_precedence(self, tmp_path: Path) -> None:
-        import bootstrap.config
-
-        bootstrap.config.ProjectConfiguration.ensure_loaded()
-        from bootstrap.cli.remote.announce import register_remote_announce
-
+    def test_cli_overrides_take_precedence(
+        self,
+        tmp_path: Path,
+        announce_workspace: AnnouncementWorkspace,
+        invoke_add_release_note,
+    ) -> None:
         directory = _make_release_note_dir(
             tmp_path,
             "1-0-0",
@@ -288,46 +288,33 @@ class TestAddReleaseNote:
             changelog="- Fix\n",
             extra_spec="channels:\n- stable\n",
         )
-        workspace = _build_workspace(tmp_path)
-        _write_empty_remote_state(workspace)
-
         version = ProjectVersion(major=1, minor=0, patch=0)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "bootstrap.cli.remote.announce.get_announce_workspace",
-                lambda: tmp_path / "announce-workspace",
-            )
-            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
+        result = invoke_add_release_note(
+            directory,
+            version,
+            args=[
+                "--channels=testing,stable",
+                "--platforms=ios",
+                "--published-at=2026-01-01T00:00:00Z",
+                "--tags=version",
+            ],
+        )
+        assert result.exit_code == 0
 
-            group = click.Group()
-            register_remote_announce(group)
-            cmd = group.commands["announce"].commands["add-release-note"]
-            result = CliRunner().invoke(
-                cmd,
-                [
-                    f"--directory={directory}",
-                    "--channels=testing,stable",
-                    "--platforms=ios",
-                    "--published-at=2026-01-01T00:00:00Z",
-                    "--tags=version",
-                ],
-            )
-            assert result.exit_code == 0
-
-        overlay = workspace.read_overlay()
+        overlay = announce_workspace.read_overlay()
         entry = overlay.pages[ACTIVE_KEY]["version-1-0-0"]
         assert entry.channels == ["testing", "stable"]
         assert entry.platforms == ["ios"]
         assert entry.published_at == "2026-01-01T00:00:00Z"
         assert entry.tags == ["version"]
 
-    def test_missing_changelog_fails(self, tmp_path: Path) -> None:
-        import bootstrap.config
-
-        bootstrap.config.ProjectConfiguration.ensure_loaded()
-        from bootstrap.cli.remote.announce import register_remote_announce
-
+    def test_missing_changelog_fails(
+        self,
+        tmp_path: Path,
+        announce_workspace: AnnouncementWorkspace,
+        invoke_add_release_note,
+    ) -> None:
         directory = _make_release_note_dir(
             tmp_path,
             "1-0-0",
@@ -337,31 +324,18 @@ class TestAddReleaseNote:
             changelog="- Fix\n",
         )
         (directory / "changelog.md").unlink()
-        workspace = _build_workspace(tmp_path)
-        _write_empty_remote_state(workspace)
-
         version = ProjectVersion(major=1, minor=0, patch=0)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "bootstrap.cli.remote.announce.get_announce_workspace",
-                lambda: tmp_path / "announce-workspace",
-            )
-            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
+        result = invoke_add_release_note(directory, version)
+        assert result.exit_code != 0
+        assert "release relnote" in result.output
 
-            group = click.Group()
-            register_remote_announce(group)
-            cmd = group.commands["announce"].commands["add-release-note"]
-            result = CliRunner().invoke(cmd, [f"--directory={directory}"])
-            assert result.exit_code != 0
-            assert "release relnote" in result.output
-
-    def test_missing_content_locale_fails(self, tmp_path: Path) -> None:
-        import bootstrap.config
-
-        bootstrap.config.ProjectConfiguration.ensure_loaded()
-        from bootstrap.cli.remote.announce import register_remote_announce
-
+    def test_missing_content_locale_fails(
+        self,
+        tmp_path: Path,
+        announce_workspace: AnnouncementWorkspace,
+        invoke_add_release_note,
+    ) -> None:
         directory = _make_release_note_dir(
             tmp_path,
             "1-0-0",
@@ -371,31 +345,18 @@ class TestAddReleaseNote:
             changelog="- Fix\n",
         )
         (directory / "content.zh.md").unlink()
-        workspace = _build_workspace(tmp_path)
-        _write_empty_remote_state(workspace)
-
         version = ProjectVersion(major=1, minor=0, patch=0)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "bootstrap.cli.remote.announce.get_announce_workspace",
-                lambda: tmp_path / "announce-workspace",
-            )
-            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
+        result = invoke_add_release_note(directory, version)
+        assert result.exit_code != 0
+        assert "Missing required locale file" in result.output
 
-            group = click.Group()
-            register_remote_announce(group)
-            cmd = group.commands["announce"].commands["add-release-note"]
-            result = CliRunner().invoke(cmd, [f"--directory={directory}"])
-            assert result.exit_code != 0
-            assert "Missing required locale file" in result.output
-
-    def test_duplicate_entry_fails(self, tmp_path: Path) -> None:
-        import bootstrap.config
-
-        bootstrap.config.ProjectConfiguration.ensure_loaded()
-        from bootstrap.cli.remote.announce import register_remote_announce
-
+    def test_duplicate_entry_fails(
+        self,
+        tmp_path: Path,
+        announce_workspace: AnnouncementWorkspace,
+        invoke_add_release_note,
+    ) -> None:
         directory = _make_release_note_dir(
             tmp_path,
             "1-0-0",
@@ -404,34 +365,21 @@ class TestAddReleaseNote:
             en_body="# Title\n\nSummary.\n",
             changelog="- Fix\n",
         )
-        workspace = _build_workspace(tmp_path)
-        _write_empty_remote_state(workspace)
-
         version = ProjectVersion(major=1, minor=0, patch=0)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "bootstrap.cli.remote.announce.get_announce_workspace",
-                lambda: tmp_path / "announce-workspace",
-            )
-            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
+        result = invoke_add_release_note(directory, version)
+        assert result.exit_code == 0
 
-            group = click.Group()
-            register_remote_announce(group)
-            cmd = group.commands["announce"].commands["add-release-note"]
-            result = CliRunner().invoke(cmd, [f"--directory={directory}"])
-            assert result.exit_code == 0
+        result = invoke_add_release_note(directory, version)
+        assert result.exit_code != 0
+        assert "already exists" in result.output
 
-            result = CliRunner().invoke(cmd, [f"--directory={directory}"])
-            assert result.exit_code != 0
-            assert "already exists" in result.output
-
-    def test_spec_id_mismatch_fails(self, tmp_path: Path) -> None:
-        import bootstrap.config
-
-        bootstrap.config.ProjectConfiguration.ensure_loaded()
-        from bootstrap.cli.remote.announce import register_remote_announce
-
+    def test_spec_id_mismatch_fails(
+        self,
+        tmp_path: Path,
+        announce_workspace: AnnouncementWorkspace,
+        invoke_add_release_note,
+    ) -> None:
         directory = _make_release_note_dir(
             tmp_path,
             "1-0-0",
@@ -441,24 +389,11 @@ class TestAddReleaseNote:
             changelog="- Fix\n",
             extra_spec="id: version-wrong\n",
         )
-        workspace = _build_workspace(tmp_path)
-        _write_empty_remote_state(workspace)
-
         version = ProjectVersion(major=1, minor=0, patch=0)
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "bootstrap.cli.remote.announce.get_announce_workspace",
-                lambda: tmp_path / "announce-workspace",
-            )
-            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
-
-            group = click.Group()
-            register_remote_announce(group)
-            cmd = group.commands["announce"].commands["add-release-note"]
-            result = CliRunner().invoke(cmd, [f"--directory={directory}"])
-            assert result.exit_code != 0
-            assert "does not match expected id" in result.output
+        result = invoke_add_release_note(directory, version)
+        assert result.exit_code != 0
+        assert "does not match expected id" in result.output
 
 
 class TestDocumentParser:

--- a/bootstrap/tests/test_remote_announce_relnote.py
+++ b/bootstrap/tests/test_remote_announce_relnote.py
@@ -145,6 +145,9 @@ class TestHelpers:
 
 class TestAddReleaseNote:
     def test_stages_release_note_entry(self, tmp_path: Path) -> None:
+        import bootstrap.config
+
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
         directory = _make_release_note_dir(
@@ -165,7 +168,7 @@ class TestAddReleaseNote:
                 "bootstrap.cli.remote.announce.get_announce_workspace",
                 lambda: tmp_path / "announce-workspace",
             )
-            mp.setattr("bootstrap.cli.remote.announce.CONFIGURATION.version", version)
+            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
 
             group = click.Group()
             register_remote_announce(group)
@@ -196,6 +199,9 @@ class TestAddReleaseNote:
         assert "---" in workspace.get_document(en.body_hash)
 
     def test_uses_spec_channels_and_platforms(self, tmp_path: Path) -> None:
+        import bootstrap.config
+
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
         directory = _make_release_note_dir(
@@ -217,7 +223,7 @@ class TestAddReleaseNote:
                 "bootstrap.cli.remote.announce.get_announce_workspace",
                 lambda: tmp_path / "announce-workspace",
             )
-            mp.setattr("bootstrap.cli.remote.announce.CONFIGURATION.version", version)
+            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
 
             group = click.Group()
             register_remote_announce(group)
@@ -231,6 +237,9 @@ class TestAddReleaseNote:
         assert entry.platforms == ["ios"]
 
     def test_uses_spec_tags(self, tmp_path: Path) -> None:
+        import bootstrap.config
+
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
         directory = _make_release_note_dir(
@@ -252,7 +261,7 @@ class TestAddReleaseNote:
                 "bootstrap.cli.remote.announce.get_announce_workspace",
                 lambda: tmp_path / "announce-workspace",
             )
-            mp.setattr("bootstrap.cli.remote.announce.CONFIGURATION.version", version)
+            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
 
             group = click.Group()
             register_remote_announce(group)
@@ -265,6 +274,9 @@ class TestAddReleaseNote:
         assert entry.tags == ["custom-tag"]
 
     def test_cli_overrides_take_precedence(self, tmp_path: Path) -> None:
+        import bootstrap.config
+
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
         directory = _make_release_note_dir(
@@ -286,7 +298,7 @@ class TestAddReleaseNote:
                 "bootstrap.cli.remote.announce.get_announce_workspace",
                 lambda: tmp_path / "announce-workspace",
             )
-            mp.setattr("bootstrap.cli.remote.announce.CONFIGURATION.version", version)
+            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
 
             group = click.Group()
             register_remote_announce(group)
@@ -311,6 +323,9 @@ class TestAddReleaseNote:
         assert entry.tags == ["version"]
 
     def test_missing_changelog_fails(self, tmp_path: Path) -> None:
+        import bootstrap.config
+
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
         directory = _make_release_note_dir(
@@ -332,7 +347,7 @@ class TestAddReleaseNote:
                 "bootstrap.cli.remote.announce.get_announce_workspace",
                 lambda: tmp_path / "announce-workspace",
             )
-            mp.setattr("bootstrap.cli.remote.announce.CONFIGURATION.version", version)
+            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
 
             group = click.Group()
             register_remote_announce(group)
@@ -342,6 +357,9 @@ class TestAddReleaseNote:
             assert "release relnote" in result.output
 
     def test_missing_content_locale_fails(self, tmp_path: Path) -> None:
+        import bootstrap.config
+
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
         directory = _make_release_note_dir(
@@ -363,7 +381,7 @@ class TestAddReleaseNote:
                 "bootstrap.cli.remote.announce.get_announce_workspace",
                 lambda: tmp_path / "announce-workspace",
             )
-            mp.setattr("bootstrap.cli.remote.announce.CONFIGURATION.version", version)
+            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
 
             group = click.Group()
             register_remote_announce(group)
@@ -373,6 +391,9 @@ class TestAddReleaseNote:
             assert "Missing required locale file" in result.output
 
     def test_duplicate_entry_fails(self, tmp_path: Path) -> None:
+        import bootstrap.config
+
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
         directory = _make_release_note_dir(
@@ -393,7 +414,7 @@ class TestAddReleaseNote:
                 "bootstrap.cli.remote.announce.get_announce_workspace",
                 lambda: tmp_path / "announce-workspace",
             )
-            mp.setattr("bootstrap.cli.remote.announce.CONFIGURATION.version", version)
+            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
 
             group = click.Group()
             register_remote_announce(group)
@@ -406,6 +427,9 @@ class TestAddReleaseNote:
             assert "already exists" in result.output
 
     def test_spec_id_mismatch_fails(self, tmp_path: Path) -> None:
+        import bootstrap.config
+
+        bootstrap.config.ProjectConfiguration.ensure_loaded()
         from bootstrap.cli.remote.announce import register_remote_announce
 
         directory = _make_release_note_dir(
@@ -427,7 +451,7 @@ class TestAddReleaseNote:
                 "bootstrap.cli.remote.announce.get_announce_workspace",
                 lambda: tmp_path / "announce-workspace",
             )
-            mp.setattr("bootstrap.cli.remote.announce.CONFIGURATION.version", version)
+            mp.setattr("bootstrap.config.CONFIGURATION.version", version)
 
             group = click.Group()
             register_remote_announce(group)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-note and remote announcement commands so they read version information more reliably.
  * CI storage uploads now support a public URL setting even when it isn’t always provided, reducing configuration errors.
  * Logging now initializes more safely on first use, helping ensure messages are written consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->