### PR TITLE
fix(ci): pass MC_HOST credentials to all mc subprocesses

### DIFF
--- a/bootstrap/data/updater/uploader.py
+++ b/bootstrap/data/updater/uploader.py
@@ -84,19 +84,18 @@ async def upload_artifacts(
     """Upload raw artifacts and ``build.txt`` to the CI bucket."""
     endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
 
+    mc_env = {
+        f"MC_HOST_{alias}": (
+            "https://"
+            f"{quote(access_key, safe='')}:{quote(secret_key, safe='')}"
+            f"@{endpoint.removeprefix('https://')}"
+        ),
+    }
+
     await _run_mc(
         ["alias", "set", alias, endpoint, "--api", "s3v4"],
         "CI RAW ARTIFACTS ALIAS",
-        env={
-            # ``MC_HOST_<alias>`` is parsed as a URL, so access/secret key characters that
-            # are special in the userinfo segment (``/``, ``+``, ``=``, ``@``, ``:``) must
-            # be percent-encoded. ``mc`` then decodes them before sending to S3.
-            f"MC_HOST_{alias}": (
-                "https://"
-                f"{quote(access_key, safe='')}:{quote(secret_key, safe='')}"
-                f"@{endpoint.removeprefix('https://')}"
-            ),
-        },
+        env=mc_env,
     )
 
     server_root = f"{alias}/{bucket}/{config.remote_root}/{server_id}"
@@ -110,10 +109,12 @@ async def upload_artifacts(
             f"{server_root}/artifacts/",
         ],
         f"UPLOAD {server_id} ARTIFACTS",
+        env=mc_env,
     )
 
     build_file = artifacts_dir.parent / "build.txt"
     await _run_mc(
         ["cp", str(build_file), f"{server_root}/build.txt"],
         f"UPLOAD {server_id} BUILD.TXT",
+        env=mc_env,
     )

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -512,14 +512,12 @@ class TestRunMc:
     async def test_upload_artifacts_uses_mc_host_env(self, monkeypatch, tmp_path: Path) -> None:
         from bootstrap.data.updater.uploader import upload_artifacts
 
-        captured_env: dict[str, str] | None = None
         commands: list[list[str]] = []
+        envs: list[dict[str, str] | None] = []
 
         async def _fake_subprocess(*args: str, **kwargs) -> _MockProcess:
-            nonlocal captured_env
-            if captured_env is None:
-                captured_env = kwargs.get("env")
             commands.append(list(args))
+            envs.append(kwargs.get("env"))
             return _MockProcess()
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_subprocess)
@@ -541,8 +539,10 @@ class TestRunMc:
 
         await upload_artifacts("tranquility", artifacts_dir, 123456, config, storage)
 
-        assert captured_env is not None
-        assert captured_env["MC_HOST_myalias"] == "https://ACCESS_KEY:SECRET_KEY@s3.example.com"
+        assert len(envs) == 3
+        for env in envs:
+            assert env is not None
+            assert env["MC_HOST_myalias"] == "https://ACCESS_KEY:SECRET_KEY@s3.example.com"
 
         alias_cmd = next(cmd for cmd in commands if cmd[1:3] == ["alias", "set"])
         assert "ACCESS_KEY" not in alias_cmd


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact upload reliability by consistently passing storage access details to all upload steps.
  * Ensured connection details are handled safely with proper encoding for special characters.

* **Tests**
  * Expanded automated coverage to verify the upload process uses the correct environment across multiple command steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->