### PR TITLE
feat(ci): add EFA Data CI release snapshot workflow

### DIFF
--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -61,64 +61,19 @@ jobs:
           CI_SECRET_KEY: ${{ secrets.CI_STORAGE_SECRET_KEY }}
         run: |
           nix develop .#python --command bash -c \
-            'python3 - <<PY
-          import os
-          import subprocess
-          import urllib.parse
-
-          alias = os.environ["CI_ALIAS"]
-          endpoint = os.environ["CI_ENDPOINT"]
-          access_key = os.environ["CI_ACCESS_KEY"]
-          secret_key = os.environ["CI_SECRET_KEY"]
-          host = (
-              "https://"
-              + urllib.parse.quote(access_key, safe="")
-              + ":"
-              + urllib.parse.quote(secret_key, safe="")
-              + "@"
-              + endpoint.removeprefix("https://").removeprefix("http://")
-          )
-          os.environ[f"MC_HOST_{alias}"] = host
-          bucket = os.environ["CI_BUCKET"]
-          for server in ("tranquility", "serenity", "singularity"):
-              os.makedirs(f"data/resources/{server}", exist_ok=True)
-              subprocess.run(
-                  [
-                      "mc", "mirror", "--overwrite",
-                      f"{alias}/{bucket}/data-generator/raw-artifact/{server}/artifacts/",
-                      f"data/resources/{server}/",
-                  ],
-                  check=True,
-              )
-          PY'
+            'uv run x.py \
+              --dev-env ci.storage.endpoint="$CI_ENDPOINT" \
+              --dev-env ci.storage.bucket="$CI_BUCKET" \
+              --dev-env ci.storage.alias="$CI_ALIAS" \
+              --dev-env ci.storage.access_key="$CI_ACCESS_KEY" \
+              --dev-env ci.storage.secret_key="$CI_SECRET_KEY" \
+              --dev-env ci.raw_artifacts.remote_root="data-generator/raw-artifact" \
+              ci raw-data download --all'
 
       - name: Build resource snapshots
         run: |
-          set -euo pipefail
-          mkdir -p cache/snapshot-hashes
-          nix develop .#python --command bash -c '
-            set -euo pipefail
-            for server in tranquility serenity singularity; do
-              uv run x.py --ws "${server}" build data \
-                --schema-root cache/remote \
-                --output-snapshot-hash "cache/snapshot-hashes/${server}.txt"
-            done
-          '
-
-      - name: Create snapshot-hashes.json
-        run: |
           nix develop .#python --command bash -c \
-            'python3 - <<PY
-          import json
-          from pathlib import Path
-
-          hashes = {}
-          for server in ("tranquility", "serenity", "singularity"):
-              hashes[server] = Path(f"cache/snapshot-hashes/{server}.txt").read_text().strip()
-          Path("snapshot-hashes.json").write_text(
-              json.dumps(hashes, indent=2, sort_keys=True) + "\n"
-          )
-          PY'
+            'uv run x.py ci release-data build --output cache/remote --hashes snapshot-hashes.json'
 
       - uses: actions/upload-artifact@v4
         with:
@@ -144,9 +99,6 @@ jobs:
       - name: Install Python dependencies
         run: nix develop .#python --command bash -c 'uv sync'
 
-      - name: Generate protobuf
-        run: nix develop .#codegen --command bash -c 'uv run x.py generate protobuf'
-
       - name: Determine mode
         id: mode
         run: |
@@ -161,99 +113,28 @@ jobs:
           name: v2-snapshots
           path: .
 
-      - name: Initialize session and stage snapshots
-        run: |
-          nix develop .#python --command bash -c \
-            'set -euo pipefail
-          uv run x.py remote session init testing --schema-root cache/remote
-          python3 - <<PY
-          import json
-          import subprocess
-          from pathlib import Path
-
-          hashes = json.loads(Path("snapshot-hashes.json").read_text())
-          for server in ("tranquility", "serenity", "singularity"):
-              hash_value = hashes[server]
-              subprocess.run(
-                  [
-                      "uv", "run", "x.py", "remote", "session", "add",
-                      "--resource", "--hash", hash_value,
-                      "--schema-root", "cache/remote",
-                  ],
-                  check=True,
-              )
-          PY'
-
-      - name: Diff staged snapshots
-        run: |
-          nix develop .#python --command bash -c \
-            'uv run x.py remote session diff --json --schema-root cache/remote'
-
-      - name: Verify staged snapshots
-        run: |
-          nix develop .#python --command bash -c \
-            'uv run x.py remote session verify --schema-root cache/remote'
-
-      - name: Commit generation
-        id: commit
+      - name: Publish to testing channel
         env:
           IS_TEST_MODE: ${{ steps.mode.outputs.is_test_mode }}
+          REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
+          REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
+          REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
+          REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
         run: |
           if [ "${IS_TEST_MODE}" = "true" ]; then
-            nix develop .#python --command bash -c \
-              'uv run x.py remote session commit --no-push --schema-root cache/remote'
+            TEST_MODE_FLAG="--test-mode"
           else
-            nix develop .#python --command bash -c \
-              'uv run x.py remote session commit --schema-root cache/remote'
-            G=$(nix develop .#python --command bash -c \
-              'python3 -c "import json; print(json.load(open(\"cache/remote/channels/heads/testing/metadata.json\"))[\"generationHash\"])"')
-            echo "generation_hash=${G}" >> "$GITHUB_OUTPUT"
+            TEST_MODE_FLAG=""
           fi
-
-      - name: Publish to remote
-        if: steps.mode.outputs.is_test_mode != 'true'
-        env:
-          REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
-          REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
-          REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
-          REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
-        run: |
+          export TEST_MODE_FLAG
           nix develop .#python --command bash -c \
-            'uv run x.py remote publish testing --target s3 \
+            'uv run x.py ci release-data publish testing \
+              --hashes snapshot-hashes.json \
+              --schema-root cache/remote \
+              --target s3 \
               --endpoint "${REMOTE_ENDPOINT}" \
               --bucket "${REMOTE_BUCKET}" \
               --access-key "${REMOTE_ACCESS_KEY}" \
               --secret-key "${REMOTE_SECRET_KEY}" \
               --alias efa-remote-publish \
-              --schema-root cache/remote'
-
-      - name: Sync remote metadata
-        if: steps.mode.outputs.is_test_mode != 'true'
-        env:
-          REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
-          REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
-          REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
-          REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
-        run: |
-          nix develop .#python --command bash -c \
-            'uv run x.py remote sync --target s3 --channel testing --depth 1 \
-              --endpoint "${REMOTE_ENDPOINT}" \
-              --bucket "${REMOTE_BUCKET}" \
-              --access-key "${REMOTE_ACCESS_KEY}" \
-              --secret-key "${REMOTE_SECRET_KEY}" \
-              --alias efa-remote-publish \
-              --schema-root cache/remote'
-
-      - name: Verify remote head
-        if: steps.mode.outputs.is_test_mode != 'true'
-        env:
-          GENERATION_HASH: ${{ steps.commit.outputs.generation_hash }}
-        run: |
-          COMMITTED="${GENERATION_HASH}"
-          SYNCED=$(nix develop .#python --command bash -c \
-            'python3 -c "import json; print(json.load(open(\"cache/remote/channels/heads/testing/metadata.json\"))[\"generationHash\"])"')
-          if [ "${COMMITTED}" != "${SYNCED}" ]; then
-            echo "Remote head verification failed: committed=${COMMITTED}, synced=${SYNCED}" >&2
-            exit 1
-          fi
-          echo "Remote head verified: ${SYNCED}"
+              ${TEST_MODE_FLAG}'

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -196,8 +196,10 @@ jobs:
 
       - name: Commit generation
         id: commit
+        env:
+          IS_TEST_MODE: ${{ steps.mode.outputs.is_test_mode }}
         run: |
-          if [ "${{ steps.mode.outputs.is_test_mode }}" = "true" ]; then
+          if [ "${IS_TEST_MODE}" = "true" ]; then
             nix develop .#python --command bash -c \
               'uv run x.py remote session commit --no-push --schema-root cache/remote'
           else
@@ -244,8 +246,10 @@ jobs:
 
       - name: Verify remote head
         if: steps.mode.outputs.is_test_mode != 'true'
+        env:
+          GENERATION_HASH: ${{ steps.commit.outputs.generation_hash }}
         run: |
-          COMMITTED="${{ steps.commit.outputs.generation_hash }}"
+          COMMITTED="${GENERATION_HASH}"
           SYNCED=$(nix develop .#python --command bash -c \
             'python3 -c "import json; print(json.load(open(\"cache/remote/channels/heads/testing/metadata.json\"))[\"generationHash\"])"')
           if [ "${COMMITTED}" != "${SYNCED}" ]; then

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install Python dependencies
         run: nix develop .#python --command bash -c 'uv sync'
 
+      - name: Generate protobuf
+        run: nix develop .#codegen --command bash -c 'uv run x.py generate protobuf'
+
       - name: Download raw artifacts
         env:
           CI_ENDPOINT: ${{ secrets.CI_STORAGE_ENDPOINT }}
@@ -140,6 +143,9 @@ jobs:
 
       - name: Install Python dependencies
         run: nix develop .#python --command bash -c 'uv sync'
+
+      - name: Generate protobuf
+        run: nix develop .#codegen --command bash -c 'uv run x.py generate protobuf'
 
       - name: Determine mode
         id: mode

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -1,0 +1,249 @@
+name: Release Data Snapshot
+
+permissions:
+  contents: read
+
+on:
+  workflow_run:
+    workflows: [Update Raw EVE Data]
+    types: [completed]
+    branches: [dev]
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [dev]
+
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('release-data-test-{0}', github.ref) || 'release-data' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build resource snapshots
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'pull_request' &&
+        github.ref == 'refs/heads/dev' &&
+        github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
+        github.event.repository.fork == false
+      ) || (
+        github.event_name == 'pull_request' &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'D-CI-Data Release') ||
+          contains(github.event.pull_request.labels.*.name, 'D-Full CI')
+        ) &&
+        github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
+        github.event.repository.fork == false
+      )
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Install Python dependencies
+        run: nix develop .#python --command bash -c 'uv sync'
+
+      - name: Download raw artifacts
+        env:
+          CI_ENDPOINT: ${{ secrets.CI_STORAGE_ENDPOINT }}
+          CI_BUCKET: ${{ secrets.CI_STORAGE_BUCKET }}
+          CI_ALIAS: ${{ secrets.CI_STORAGE_ALIAS }}
+          CI_ACCESS_KEY: ${{ secrets.CI_STORAGE_ACCESS_KEY }}
+          CI_SECRET_KEY: ${{ secrets.CI_STORAGE_SECRET_KEY }}
+        run: |
+          nix develop .#python --command bash -c \
+            'python3 - <<PY
+          import os
+          import subprocess
+          import urllib.parse
+
+          alias = os.environ["CI_ALIAS"]
+          endpoint = os.environ["CI_ENDPOINT"]
+          access_key = os.environ["CI_ACCESS_KEY"]
+          secret_key = os.environ["CI_SECRET_KEY"]
+          host = (
+              "https://"
+              + urllib.parse.quote(access_key, safe="")
+              + ":"
+              + urllib.parse.quote(secret_key, safe="")
+              + "@"
+              + endpoint.removeprefix("https://").removeprefix("http://")
+          )
+          os.environ[f"MC_HOST_{alias}"] = host
+          bucket = os.environ["CI_BUCKET"]
+          for server in ("tranquility", "serenity", "singularity"):
+              os.makedirs(f"data/resources/{server}", exist_ok=True)
+              subprocess.run(
+                  [
+                      "mc", "mirror", "--overwrite",
+                      f"{alias}/{bucket}/data-generator/raw-artifact/{server}/artifacts/",
+                      f"data/resources/{server}/",
+                  ],
+                  check=True,
+              )
+          PY'
+
+      - name: Build resource snapshots
+        run: |
+          set -euo pipefail
+          mkdir -p cache/snapshot-hashes
+          nix develop .#python --command bash -c '
+            set -euo pipefail
+            for server in tranquility serenity singularity; do
+              uv run x.py --ws "${server}" build data \
+                --schema-root cache/remote \
+                --output-snapshot-hash "cache/snapshot-hashes/${server}.txt"
+            done
+          '
+
+      - name: Create snapshot-hashes.json
+        run: |
+          nix develop .#python --command bash -c \
+            'python3 - <<PY
+          import json
+          from pathlib import Path
+
+          hashes = {}
+          for server in ("tranquility", "serenity", "singularity"):
+              hashes[server] = Path(f"cache/snapshot-hashes/{server}.txt").read_text().strip()
+          Path("snapshot-hashes.json").write_text(
+              json.dumps(hashes, indent=2, sort_keys=True) + "\n"
+          )
+          PY'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: v2-snapshots
+          path: |
+            cache/remote/assets/
+            snapshot-hashes.json
+          retention-days: 1
+
+  publish:
+    name: Publish to testing channel
+    needs: build
+    runs-on: ubuntu-latest
+    if: needs.build.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Install Python dependencies
+        run: nix develop .#python --command bash -c 'uv sync'
+
+      - name: Determine mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "is_test_mode=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_test_mode=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: v2-snapshots
+          path: .
+
+      - name: Initialize session and stage snapshots
+        run: |
+          nix develop .#python --command bash -c \
+            'set -euo pipefail
+          uv run x.py remote session init testing --schema-root cache/remote
+          python3 - <<PY
+          import json
+          import subprocess
+          from pathlib import Path
+
+          hashes = json.loads(Path("snapshot-hashes.json").read_text())
+          for server in ("tranquility", "serenity", "singularity"):
+              hash_value = hashes[server]
+              subprocess.run(
+                  [
+                      "uv", "run", "x.py", "remote", "session", "add",
+                      "--resource", "--hash", hash_value,
+                      "--schema-root", "cache/remote",
+                  ],
+                  check=True,
+              )
+          PY'
+
+      - name: Diff staged snapshots
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote session diff --json --schema-root cache/remote'
+
+      - name: Verify staged snapshots
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote session verify --schema-root cache/remote'
+
+      - name: Commit generation
+        id: commit
+        run: |
+          if [ "${{ steps.mode.outputs.is_test_mode }}" = "true" ]; then
+            nix develop .#python --command bash -c \
+              'uv run x.py remote session commit --no-push --schema-root cache/remote'
+          else
+            nix develop .#python --command bash -c \
+              'uv run x.py remote session commit --schema-root cache/remote'
+            G=$(nix develop .#python --command bash -c \
+              'python3 -c "import json; print(json.load(open(\"cache/remote/channels/heads/testing/metadata.json\"))[\"generationHash\"])"')
+            echo "generation_hash=${G}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to remote
+        if: steps.mode.outputs.is_test_mode != 'true'
+        env:
+          REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
+          REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
+          REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
+          REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote publish testing --target s3 \
+              --endpoint "${REMOTE_ENDPOINT}" \
+              --bucket "${REMOTE_BUCKET}" \
+              --access-key "${REMOTE_ACCESS_KEY}" \
+              --secret-key "${REMOTE_SECRET_KEY}" \
+              --alias efa-remote-publish \
+              --schema-root cache/remote'
+
+      - name: Sync remote metadata
+        if: steps.mode.outputs.is_test_mode != 'true'
+        env:
+          REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
+          REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
+          REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
+          REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote sync --target s3 --channel testing --depth 1 \
+              --endpoint "${REMOTE_ENDPOINT}" \
+              --bucket "${REMOTE_BUCKET}" \
+              --access-key "${REMOTE_ACCESS_KEY}" \
+              --secret-key "${REMOTE_SECRET_KEY}" \
+              --alias efa-remote-publish \
+              --schema-root cache/remote'
+
+      - name: Verify remote head
+        if: steps.mode.outputs.is_test_mode != 'true'
+        run: |
+          COMMITTED="${{ steps.commit.outputs.generation_hash }}"
+          SYNCED=$(nix develop .#python --command bash -c \
+            'python3 -c "import json; print(json.load(open(\"cache/remote/channels/heads/testing/metadata.json\"))[\"generationHash\"])"')
+          if [ "${COMMITTED}" != "${SYNCED}" ]; then
+            echo "Remote head verification failed: committed=${COMMITTED}, synced=${SYNCED}" >&2
+            exit 1
+          fi
+          echo "Remote head verified: ${SYNCED}"

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -113,6 +113,9 @@ jobs:
           name: v2-snapshots
           path: .
 
+      - name: Generate protobuf
+        run: nix develop .#codegen --command bash -c 'uv run x.py generate protobuf'
+
       - name: Publish to testing channel
         env:
           IS_TEST_MODE: ${{ steps.mode.outputs.is_test_mode }}

--- a/.github/workflows/update-raw-data.yml
+++ b/.github/workflows/update-raw-data.yml
@@ -79,9 +79,7 @@ jobs:
         run: uv sync
 
       - name: Download portable Python 2.7
-        run: |
-          curl.exe -L -o tools/eve-fsd-dumper/py27.zip `
-            https://ci.storage.efa-tech.dev/build-dependencies/py27.zip
+        run: uv run x.py ci raw-data setup-py27
 
       - name: Update raw artifacts
         run: uv run x.py ci raw-data update --server "${{ matrix.server }}" --no-upload

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -22,8 +22,6 @@ from bootstrap.color import styled
 from bootstrap.constant import PROJECT_ROOT
 from bootstrap.data.updater.server import SERVER_IDS
 from bootstrap.data.workspace.config import WorkspaceConfig
-from bootstrap.data.workspace.generate import run_generator
-from bootstrap.remote import SessionManager
 from bootstrap.utils import get_command
 
 
@@ -206,6 +204,8 @@ def register_ci_commands(cli_group: click.Group) -> None:
     )
     def release_data_build(output: Path, hashes: Path, server: tuple[str, ...]):
         """Build resource snapshots for all servers and emit snapshot-hashes.json."""
+        from bootstrap.data.workspace.generate import run_generator
+
         schema_root = (PROJECT_ROOT / output).resolve()
         servers = list(server) if server else sorted(SERVER_IDS)
         if not servers:
@@ -290,6 +290,8 @@ def register_ci_commands(cli_group: click.Group) -> None:
         sync_depth: int,
     ):
         """Publish resource snapshots to a remote channel."""
+        from bootstrap.remote import SessionManager
+
         resolved_root = (PROJECT_ROOT / schema_root).resolve()
 
         hashes_path = (PROJECT_ROOT / hashes).resolve()

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -16,7 +16,6 @@ from bootstrap.ci.lint import run_lint
 from bootstrap.ci.suites import SUITE_DEFINITIONS
 from bootstrap.ci.suites import calculate_ci_matrix
 from bootstrap.cli import runtime
-from bootstrap.cli.generate import _run_protobuf
 from bootstrap.cli.remote.helpers import validate_remote_channel
 from bootstrap.color import styled
 from bootstrap.constant import PROJECT_ROOT
@@ -300,8 +299,6 @@ def register_ci_commands(cli_group: click.Group) -> None:
             raise click.ClickException(f"Invalid hashes file: {hashes_path}")
 
         resolved_channel = validate_remote_channel(channel).value
-
-        _run_protobuf()
 
         init_cmd = _lookup_command(ctx, "remote", "session", "init")
         add_cmd = _lookup_command(ctx, "remote", "session", "add")

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import tarfile
 
@@ -15,7 +16,14 @@ from bootstrap.ci.lint import run_lint
 from bootstrap.ci.suites import SUITE_DEFINITIONS
 from bootstrap.ci.suites import calculate_ci_matrix
 from bootstrap.cli import runtime
+from bootstrap.cli.generate import _run_protobuf
+from bootstrap.cli.remote.helpers import validate_remote_channel
 from bootstrap.color import styled
+from bootstrap.constant import PROJECT_ROOT
+from bootstrap.data.updater.server import SERVER_IDS
+from bootstrap.data.workspace.config import WorkspaceConfig
+from bootstrap.data.workspace.generate import run_generator
+from bootstrap.remote import SessionManager
 from bootstrap.utils import get_command
 
 
@@ -161,3 +169,227 @@ def register_ci_commands(cli_group: click.Group) -> None:
             runtime.execute([mc, "cp", str(out_path), remote_path], "CI STORAGE UPLOAD")
         else:
             click.echo(f"Upload with: mc cp {out_path} {remote_path}")
+
+    def _lookup_command(ctx: click.Context, *path: str) -> click.Command:
+        """Walk from the root CLI group to a nested command by name."""
+        root_ctx = ctx
+        while root_ctx.parent is not None:
+            root_ctx = root_ctx.parent
+        cmd = root_ctx.command
+        for name in path:
+            cmd = cmd.commands[name]
+        return cmd
+
+    @ci.group("release-data")
+    def release_data():
+        """Manage CI release data snapshots."""
+
+    @release_data.command("build")
+    @click.option(
+        "--output",
+        "-o",
+        type=click.Path(file_okay=False, path_type=Path),
+        default="cache/remote",
+        help="Schema V2 root for the generated snapshots (default: cache/remote).",
+    )
+    @click.option(
+        "--hashes",
+        type=click.Path(file_okay=True, path_type=Path),
+        default="snapshot-hashes.json",
+        help="Output path for the snapshot hashes JSON file.",
+    )
+    @click.option(
+        "--server",
+        multiple=True,
+        default=None,
+        help="Server to build (default: all configured servers).",
+    )
+    def release_data_build(output: Path, hashes: Path, server: tuple[str, ...]):
+        """Build resource snapshots for all servers and emit snapshot-hashes.json."""
+        schema_root = (PROJECT_ROOT / output).resolve()
+        servers = list(server) if server else sorted(SERVER_IDS)
+        if not servers:
+            raise click.ClickException("No servers configured.")
+
+        hashes_data: dict[str, str] = {}
+        for server_id in servers:
+            if server_id not in SERVER_IDS:
+                raise click.ClickException(f"Unknown server: {server_id}")
+            ws_descriptor = runtime.get_workspace(server_id)
+            ws_config = WorkspaceConfig.load_from_descriptor(ws_descriptor)
+            snapshot_hash = asyncio.run(run_generator(ws_config, set(), schema_root=schema_root))
+            if snapshot_hash is None:
+                raise click.ClickException(f"No snapshot produced for {server_id}")
+            hashes_data[server_id] = snapshot_hash
+            click.echo(f"Built {server_id} snapshot: {snapshot_hash[:16]}...")
+
+        hashes_path = (PROJECT_ROOT / hashes).resolve()
+        hashes_path.parent.mkdir(parents=True, exist_ok=True)
+        hashes_path.write_text(
+            json.dumps(hashes_data, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        click.echo(styled([Style.BRIGHT, Fore.GREEN], f"Wrote snapshot hashes to {hashes_path}"))
+
+    @release_data.command("publish")
+    @click.argument("channel")
+    @click.option(
+        "--hashes",
+        type=click.Path(exists=True, file_okay=True, path_type=Path),
+        default="snapshot-hashes.json",
+        help="Path to the snapshot hashes JSON file.",
+    )
+    @click.option(
+        "--schema-root",
+        type=click.Path(file_okay=False, path_type=Path),
+        default="cache/remote",
+        help="Schema V2 root containing the snapshots (default: cache/remote).",
+    )
+    @click.option(
+        "--test-mode",
+        is_flag=True,
+        help="Commit with --no-push and skip publish/sync/verify.",
+    )
+    @click.option(
+        "--target",
+        type=click.Choice(["minio", "s3"]),
+        default="s3",
+        help="Remote target type (default: s3).",
+    )
+    @click.option("--endpoint", default=None, help="Override remote endpoint URL.")
+    @click.option("--bucket", default=None, help="Override remote bucket name.")
+    @click.option("--access-key", default=None, help="Override remote access key.")
+    @click.option("--secret-key", default=None, help="Override remote secret key.")
+    @click.option("--alias", "alias_name", default=None, help="Override mc alias name.")
+    @click.option(
+        "--workers",
+        type=click.IntRange(min=1),
+        default=8,
+        help="Number of parallel upload/download workers.",
+    )
+    @click.option(
+        "--sync-depth",
+        type=click.IntRange(min=-1),
+        default=1,
+        help="Max generations to sync after publish (default: 1).",
+    )
+    @click.pass_context
+    def release_data_publish(
+        ctx: click.Context,
+        channel: str,
+        hashes: Path,
+        schema_root: Path,
+        test_mode: bool,
+        target: str,
+        endpoint: str | None,
+        bucket: str | None,
+        access_key: str | None,
+        secret_key: str | None,
+        alias_name: str | None,
+        workers: int,
+        sync_depth: int,
+    ):
+        """Publish resource snapshots to a remote channel."""
+        resolved_root = (PROJECT_ROOT / schema_root).resolve()
+
+        hashes_path = (PROJECT_ROOT / hashes).resolve()
+        hashes_data = json.loads(hashes_path.read_text(encoding="utf-8"))
+        if not isinstance(hashes_data, dict):
+            raise click.ClickException(f"Invalid hashes file: {hashes_path}")
+
+        resolved_channel = validate_remote_channel(channel).value
+
+        _run_protobuf()
+
+        init_cmd = _lookup_command(ctx, "remote", "session", "init")
+        add_cmd = _lookup_command(ctx, "remote", "session", "add")
+        diff_cmd = _lookup_command(ctx, "remote", "session", "diff")
+        verify_cmd = _lookup_command(ctx, "remote", "session", "verify")
+        commit_cmd = _lookup_command(ctx, "remote", "session", "commit")
+
+        ctx.invoke(
+            init_cmd,
+            channel=resolved_channel,
+            schema_root=resolved_root,
+            force_overwrite=False,
+        )
+
+        for server_id, hash_value in hashes_data.items():
+            ctx.invoke(
+                add_cmd,
+                resource_flag=True,
+                release_flag=False,
+                source_hash=hash_value,
+                source_file=None,
+                force=False,
+                replace_hash=None,
+                schema_root=resolved_root,
+            )
+            click.echo(f"Staged {server_id} snapshot: {hash_value[:16]}...")
+
+        ctx.invoke(diff_cmd, as_json=True, schema_root=resolved_root)
+        ctx.invoke(verify_cmd, repair=False, schema_root=resolved_root)
+        ctx.invoke(
+            commit_cmd,
+            no_push=test_mode,
+            force=False,
+            schema_root=resolved_root,
+        )
+
+        mgr = SessionManager(resolved_root)
+        committed_hash = mgr.get_head(resolved_channel).generation_hash
+        click.echo(
+            styled(
+                [Style.BRIGHT, Fore.GREEN],
+                f"Committed generation: {committed_hash[:16]}...",
+            )
+        )
+
+        if test_mode:
+            click.echo(
+                styled([Style.BRIGHT, Fore.YELLOW], "Test mode: skipped publish/sync/verify.")
+            )
+            return
+
+        publish_cmd = _lookup_command(ctx, "remote", "publish")
+        sync_cmd = _lookup_command(ctx, "remote", "sync")
+
+        ctx.invoke(
+            publish_cmd,
+            channel=resolved_channel,
+            target=target,
+            endpoint=endpoint,
+            bucket=bucket,
+            access_key=access_key,
+            secret_key=secret_key,
+            alias_name=alias_name,
+            workers=workers,
+            schema_root=resolved_root,
+        )
+
+        ctx.invoke(
+            sync_cmd,
+            target=target,
+            endpoint=endpoint,
+            bucket=bucket,
+            access_key=access_key,
+            secret_key=secret_key,
+            alias_name=alias_name,
+            depth=sync_depth,
+            workers=workers,
+            schema_root=resolved_root,
+            channel=resolved_channel,
+        )
+
+        synced_hash = mgr.get_head(resolved_channel).generation_hash
+        if committed_hash != synced_hash:
+            raise click.ClickException(
+                f"Remote head verification failed: "
+                f"committed={committed_hash[:16]}..., synced={synced_hash[:16]}..."
+            )
+        click.echo(
+            styled(
+                [Style.BRIGHT, Fore.GREEN],
+                f"Remote head verified: {synced_hash[:16]}...",
+            )
+        )

--- a/bootstrap/ci/lint.py
+++ b/bootstrap/ci/lint.py
@@ -46,6 +46,17 @@ def run_lint(
             execute_command([uv, "run", "ruff", "format"], "RUFF FORMAT OUTPUT", dry_run)
 
     if lang in ("all", "dart"):
+        from bootstrap.docs import build_bundled_docs
+
+        _echo("build bundled docs")
+        if dry_run:
+            click.echo(styled([Style.BRIGHT, Fore.YELLOW], "[Dry-Run] Skipping build bundled docs"))
+        else:
+            try:
+                build_bundled_docs()
+            except ValueError as exception:
+                raise click.ClickException(str(exception)) from exception
+
         dart = get_command("dart")
 
         if not no_check or check_only:

--- a/bootstrap/cli/build.py
+++ b/bootstrap/cli/build.py
@@ -196,7 +196,25 @@ def register_build_commands(cli_group: click.Group) -> None:
     )
     @click.option("--author", default=None, help="Author identifier for the snapshot.")
     @click.option("--description", default=None, help="Description for the snapshot.")
-    def data_cmd(skip: list[str], author: str | None, description: str | None):
+    @click.option(
+        "--schema-root",
+        type=click.Path(file_okay=False, path_type=Path),
+        default=None,
+        help="Schema V2 storage root for the generated snapshot (default from dev config).",
+    )
+    @click.option(
+        "--output-snapshot-hash",
+        type=click.Path(file_okay=True, path_type=Path),
+        default=None,
+        help="Write the generated snapshot hash to this file.",
+    )
+    def data_cmd(
+        skip: list[str],
+        author: str | None,
+        description: str | None,
+        schema_root: Path | None,
+        output_snapshot_hash: Path | None,
+    ):
         """Build data files."""
         from bootstrap.data.workspace.generate import run_generator
 
@@ -212,14 +230,25 @@ def register_build_commands(cli_group: click.Group) -> None:
             click.echo("Valid types are: " + ", ".join(_GENERATOR_TYPES))
             exit(1)
 
-        asyncio.run(
+        snapshot_hash = asyncio.run(
             run_generator(
                 runtime.current_workspace_descriptor(),
                 to_skip,
                 author=author,
                 description=description,
+                schema_root=schema_root,
             )
         )
+
+        if output_snapshot_hash is not None:
+            if snapshot_hash is None:
+                raise click.ClickException(
+                    f"No snapshot was produced; cannot write {output_snapshot_hash}"
+                )
+            output_snapshot_hash.parent.mkdir(parents=True, exist_ok=True)
+            output_snapshot_hash.write_text(snapshot_hash, encoding="utf-8")
+
+        return snapshot_hash
 
     @build.command("docs")
     def build_docs_cmd():

--- a/bootstrap/cli/ci/updater.py
+++ b/bootstrap/cli/ci/updater.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+import urllib.request
 
 from pathlib import Path
 
@@ -17,6 +18,7 @@ from bootstrap.data.updater.pipeline import check_server
 from bootstrap.data.updater.pipeline import update_server
 from bootstrap.data.updater.server import SERVER_ALIASES
 from bootstrap.data.updater.server import SERVER_IDS
+from bootstrap.data.updater.uploader import download_artifacts
 from bootstrap.data.updater.uploader import upload_artifacts
 
 
@@ -126,6 +128,51 @@ def register_raw_data_commands(ci: click.Group) -> None:
 
         asyncio.run(run())
         click.echo(f"Uploaded {normalized} build {build} from {from_dir}")
+
+    @raw_data.command("download")
+    @click.option("--server", default=None, help=f"Server id ({', '.join(sorted(SERVER_IDS))}).")
+    @click.option("--all", "all_flag", is_flag=True, help="Download all servers.")
+    @click.option(
+        "--output-dir",
+        type=click.Path(file_okay=False, path_type=Path),
+        default=None,
+        help="Output directory (default: data/resources).",
+    )
+    def raw_data_download(server: str | None, all_flag: bool, output_dir: Path | None):
+        """Download raw artifacts from CI storage to the local data/resources tree."""
+        server_ids = _resolve_server_input(server, all_flag)
+        if output_dir is None:
+            output_dir = PROJECT_ROOT / "data" / "resources"
+
+        bootstrap.config.DeveloperConfiguration.ensure_loaded()
+        ci = bootstrap.config.DEV_CONFIGURATION.ci
+        raw_artifacts, storage = ci.require_raw_artifacts()
+
+        async def run():
+            for server_id in server_ids:
+                await download_artifacts(server_id, output_dir, raw_artifacts, storage)
+                click.echo(f"Downloaded {server_id} artifacts to {output_dir / server_id}")
+
+        asyncio.run(run())
+
+    @raw_data.command("setup-py27")
+    @click.option(
+        "--output",
+        "-o",
+        type=click.Path(file_okay=True, path_type=Path),
+        default="tools/eve-fsd-dumper/py27.zip",
+        help="Output path for py27.zip.",
+    )
+    @click.option(
+        "--url",
+        default="https://ci.storage.efa-tech.dev/build-dependencies/py27.zip",
+        help="Download URL for portable Python 2.7.",
+    )
+    def raw_data_setup_py27(output: Path, url: str):
+        """Download portable Python 2.7 for the FSD dumper."""
+        output.parent.mkdir(parents=True, exist_ok=True)
+        urllib.request.urlretrieve(url, output)
+        click.echo(f"Downloaded Python 2.7 to {output}")
 
     @raw_data.command("sync-local")
     @click.option("--server", required=True, help=f"Server id ({', '.join(sorted(SERVER_IDS))}).")

--- a/bootstrap/data/updater/uploader.py
+++ b/bootstrap/data/updater/uploader.py
@@ -74,16 +74,13 @@ def _resolve_storage(
     )
 
 
-async def upload_artifacts(
-    server_id: ServerId,
-    artifacts_dir: Path,
-    build: int,
-    config: DeveloperCiRawArtifacts,
-    storage: DeveloperCiStorage,
-) -> None:
-    """Upload raw artifacts and ``build.txt`` to the CI bucket."""
-    endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
-
+async def _setup_mc(
+    endpoint: str,
+    access_key: str,
+    secret_key: str,
+    alias: str,
+) -> dict[str, str]:
+    """Configure the MinIO client environment and alias for subsequent calls."""
     mc_env = {
         f"MC_HOST_{alias}": (
             "https://"
@@ -97,6 +94,20 @@ async def upload_artifacts(
         "CI RAW ARTIFACTS ALIAS",
         env=mc_env,
     )
+    return mc_env
+
+
+async def upload_artifacts(
+    server_id: ServerId,
+    artifacts_dir: Path,
+    build: int,
+    config: DeveloperCiRawArtifacts,
+    storage: DeveloperCiStorage,
+) -> None:
+    """Upload raw artifacts and ``build.txt`` to the CI bucket."""
+    endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
+
+    mc_env = await _setup_mc(endpoint, access_key, secret_key, alias)
 
     server_root = f"{alias}/{bucket}/{config.remote_root}/{server_id}"
 
@@ -129,19 +140,7 @@ async def download_artifacts(
     """Download raw artifacts from the CI bucket to a local directory."""
     endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
 
-    mc_env = {
-        f"MC_HOST_{alias}": (
-            "https://"
-            f"{quote(access_key, safe='')}:{quote(secret_key, safe='')}"
-            f"@{endpoint.removeprefix('https://')}"
-        ),
-    }
-
-    await _run_mc(
-        ["alias", "set", alias, endpoint, "--api", "s3v4"],
-        "CI RAW ARTIFACTS ALIAS",
-        env=mc_env,
-    )
+    mc_env = await _setup_mc(endpoint, access_key, secret_key, alias)
 
     server_root = f"{alias}/{bucket}/{config.remote_root}/{server_id}"
     target_dir = output_dir / server_id

--- a/bootstrap/data/updater/uploader.py
+++ b/bootstrap/data/updater/uploader.py
@@ -118,3 +118,42 @@ async def upload_artifacts(
         f"UPLOAD {server_id} BUILD.TXT",
         env=mc_env,
     )
+
+
+async def download_artifacts(
+    server_id: ServerId,
+    output_dir: Path,
+    config: DeveloperCiRawArtifacts,
+    storage: DeveloperCiStorage,
+) -> None:
+    """Download raw artifacts from the CI bucket to a local directory."""
+    endpoint, bucket, access_key, secret_key, alias = _resolve_storage(config, storage)
+
+    mc_env = {
+        f"MC_HOST_{alias}": (
+            "https://"
+            f"{quote(access_key, safe='')}:{quote(secret_key, safe='')}"
+            f"@{endpoint.removeprefix('https://')}"
+        ),
+    }
+
+    await _run_mc(
+        ["alias", "set", alias, endpoint, "--api", "s3v4"],
+        "CI RAW ARTIFACTS ALIAS",
+        env=mc_env,
+    )
+
+    server_root = f"{alias}/{bucket}/{config.remote_root}/{server_id}"
+    target_dir = output_dir / server_id
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    await _run_mc(
+        [
+            "mirror",
+            "--overwrite",
+            f"{server_root}/artifacts/",
+            f"{target_dir}/",
+        ],
+        f"DOWNLOAD {server_id} ARTIFACTS",
+        env=mc_env,
+    )

--- a/bootstrap/data/workspace/generate/__init__.py
+++ b/bootstrap/data/workspace/generate/__init__.py
@@ -17,6 +17,8 @@ from .data import GeneratorDatasource
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from bootstrap.data.workspace.config import WorkspaceConfig
 
 
@@ -25,7 +27,8 @@ async def run_generator(
     skip: set[str],
     author: str | None = None,
     description: str | None = None,
-):
+    schema_root: Path | None = None,
+) -> str | None:
     info("Running data generator...")
     datasource = GeneratorDatasource(config)
     try:
@@ -47,10 +50,10 @@ async def run_generator(
 
             await images.generate(datasource, collection_cache)
 
-        schema_generator.generate_schema_checkout(
+        snapshot_hash = schema_generator.generate_schema_checkout(
             config,
             build_dir=datasource.paths.full_generate_out_path,
-            schema_root=DEV_CONFIGURATION.paths.schema_dir,
+            schema_root=schema_root or DEV_CONFIGURATION.paths.schema_dir,
             author=author,
             description=description,
         )
@@ -58,3 +61,4 @@ async def run_generator(
         info("Data generator finished.")
     finally:
         await datasource.aclose()
+    return snapshot_hash

--- a/bootstrap/data/workspace/generate/images/graphics.py
+++ b/bootstrap/data/workspace/generate/images/graphics.py
@@ -19,8 +19,6 @@ from bootstrap.utils import try_get_attr
 if TYPE_CHECKING:
     from bootstrap.data.workspace.generate import GeneratorDatasource
 
-_graphic_semaphore = asyncio.Semaphore(32)
-
 
 class GraphicIconInfo(BaseModel):
     folder: str | None = Field(default=None)
@@ -53,8 +51,10 @@ async def generate(data: GeneratorDatasource, tree_shake_graphics: set[int]):
         )
     )
 
+    graphic_semaphore = asyncio.Semaphore(32)
+
     tasks = (
-        __download_graphic(graphic_id, graphic_folder, data)
+        __download_graphic(graphic_id, graphic_folder, data, graphic_semaphore)
         for graphic_id, graphic_folder in filtered_graphics
     )
     await asyncio.gather(*tasks)
@@ -62,7 +62,12 @@ async def generate(data: GeneratorDatasource, tree_shake_graphics: set[int]):
     info(f"Generated {len(filtered_graphics)} graphics.")
 
 
-async def __download_graphic(graphic_id: int, graphic_folder: str, data: GeneratorDatasource):
+async def __download_graphic(
+    graphic_id: int,
+    graphic_folder: str,
+    data: GeneratorDatasource,
+    graphic_semaphore: asyncio.Semaphore,
+):
     maybe_graphic_files = [
         (f"{graphic_folder}/{graphic_id}_64.png", GraphicVariantType.NONE),
         (f"{graphic_folder}/{graphic_id}_64_bp.png", GraphicVariantType.BP),
@@ -83,7 +88,7 @@ async def __download_graphic(graphic_id: int, graphic_folder: str, data: Generat
             continue
 
         async with (
-            _graphic_semaphore,
+            graphic_semaphore,
             graphic_file.open() as f_input,
             aiofiles.open(target_dir, "wb+") as f_output,
         ):

--- a/bootstrap/data/workspace/generate/images/icons.py
+++ b/bootstrap/data/workspace/generate/images/icons.py
@@ -16,8 +16,6 @@ from bootstrap.log import warning
 if TYPE_CHECKING:
     from bootstrap.data.workspace.generate import GeneratorDatasource
 
-_icon_semaphore = asyncio.Semaphore(32)
-
 
 class IconDef(BaseModel):
     iconFile: str
@@ -30,8 +28,10 @@ async def generate(data: GeneratorDatasource, tree_shake_icons: set[int]):
 
     info(f"Tree shaken {len(set(icons.keys()).difference(tree_shake_icons))} icons.")
 
+    icon_semaphore = asyncio.Semaphore(32)
+
     tasks = (
-        __download_icon(icon_id, IconDef.model_validate(icon), data)
+        __download_icon(icon_id, IconDef.model_validate(icon), data, icon_semaphore)
         for icon_id, icon in icons.items()
         if icon_id in tree_shake_icons
     )
@@ -40,7 +40,9 @@ async def generate(data: GeneratorDatasource, tree_shake_icons: set[int]):
     info(f"Generated {len(icons)} icons.")
 
 
-async def __download_icon(icon_id: int, icon: IconDef, data: GeneratorDatasource):
+async def __download_icon(
+    icon_id: int, icon: IconDef, data: GeneratorDatasource, icon_semaphore: asyncio.Semaphore
+):
     icon_file = data.resources.res.get_resource(icon.iconFile)
     if icon_file is None:
         warning(f"Icon file {icon.iconFile} for icon ID {icon_id} not found.")
@@ -52,7 +54,7 @@ async def __download_icon(icon_id: int, icon: IconDef, data: GeneratorDatasource
         return
 
     async with (
-        _icon_semaphore,
+        icon_semaphore,
         icon_file.open("rb") as f_input,
         aiofiles.open(out_path, "wb") as f_output,
     ):

--- a/bootstrap/tests/test_raw_updater.py
+++ b/bootstrap/tests/test_raw_updater.py
@@ -548,6 +548,46 @@ class TestRunMc:
         assert "ACCESS_KEY" not in alias_cmd
         assert "SECRET_KEY" not in alias_cmd
 
+    async def test_download_artifacts_uses_mc_host_env(self, monkeypatch, tmp_path: Path) -> None:
+        from bootstrap.data.updater.uploader import download_artifacts
+
+        commands: list[list[str]] = []
+        envs: list[dict[str, str] | None] = []
+
+        async def _fake_subprocess(*args: str, **kwargs) -> _MockProcess:
+            commands.append(list(args))
+            envs.append(kwargs.get("env"))
+            return _MockProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_subprocess)
+
+        storage = DeveloperCiStorage(
+            endpoint="https://s3.example.com",
+            bucket="bucket",
+            alias="myalias",
+            access_key="ACCESS_KEY",
+            secret_key="SECRET_KEY",  # noqa: S106
+            public_url="https://public.example.com",
+        )
+        config = DeveloperCiRawArtifacts(remote_root="data-generator/raw-artifact")
+
+        output_dir = tmp_path / "out"
+
+        await download_artifacts("tranquility", output_dir, config, storage)
+
+        assert len(envs) == 2
+        for env in envs:
+            assert env is not None
+            assert env["MC_HOST_myalias"] == "https://ACCESS_KEY:SECRET_KEY@s3.example.com"
+
+        mirror_cmd = next(cmd for cmd in commands if cmd[1:2] == ["mirror"])
+        assert mirror_cmd[-2] == "myalias/bucket/data-generator/raw-artifact/tranquility/artifacts/"
+        assert mirror_cmd[-1] == f"{output_dir / 'tranquility'}/"
+
+        alias_cmd = next(cmd for cmd in commands if cmd[1:3] == ["alias", "set"])
+        assert "ACCESS_KEY" not in alias_cmd
+        assert "SECRET_KEY" not in alias_cmd
+
 
 class TestUpdateServer:
     async def test_writes_build_txt_when_upload_disabled(self, monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Release Data Snapshot” workflow to build and publish resource snapshots, including a testing publish mode.
  * Enhanced `build data` with `--schema-root` and `--output-snapshot-hash`; `release-data` CI commands now support snapshot build + publish.
  * Added CI commands to download raw artifacts and set up portable Python 2.7.
* **Bug Fixes**
  * Improved safety checks by validating remote targets and verifying committed vs synced generation hashes before finishing.
* **Tests**
  * Added coverage for artifact download command/environment construction and secret redaction.
* **Refactor**
  * Scoped icon/graphic download concurrency semaphores per run; improved CI uploader logic reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->