### PR TITLE
refactor(ci): split data release workflows into cron and test variants

### DIFF
--- a/.github/workflows/_release-data.yml
+++ b/.github/workflows/_release-data.yml
@@ -7,6 +7,10 @@ on:
         description: "Run in test mode (skip publish)"
         type: boolean
         default: false
+      servers:
+        description: "JSON array of server IDs to rebuild (default: all)"
+        type: string
+        default: "[]"
 
 permissions:
   contents: read
@@ -31,26 +35,37 @@ jobs:
 
       - name: Download raw artifacts
         env:
+          SERVERS_JSON: ${{ inputs.servers }}
           CI_ENDPOINT: ${{ secrets.CI_STORAGE_ENDPOINT }}
           CI_BUCKET: ${{ secrets.CI_STORAGE_BUCKET }}
           CI_ACCESS_KEY: ${{ secrets.CI_STORAGE_ACCESS_KEY }}
           CI_SECRET_KEY: ${{ secrets.CI_STORAGE_SECRET_KEY }}
         run: |
-          # shellcheck disable=SC2016
           nix develop .#python --command bash -c \
-            'uv run x.py \
-              --dev-env ci.storage.endpoint="$CI_ENDPOINT" \
-              --dev-env ci.storage.bucket="$CI_BUCKET" \
-              --dev-env ci.storage.alias="efa-ci-storage" \
-              --dev-env ci.storage.access_key="$CI_ACCESS_KEY" \
-              --dev-env ci.storage.secret_key="$CI_SECRET_KEY" \
-              --dev-env ci.raw_artifacts.remote_root="data-generator/raw-artifact" \
-              ci raw-data download --all'
+            'uv run python -c "
+              import json, os, subprocess
+              servers = json.loads(os.environ.get(\"SERVERS_JSON\") or \"[]\")
+              if not servers:
+                  subprocess.run([\"uv\", \"run\", \"x.py\", \"ci\", \"raw-data\", \"download\", \"--all\"])
+              else:
+                  for s in servers:
+                      subprocess.run([\"uv\", \"run\", \"x.py\", \"ci\", \"raw-data\", \"download\", \"--server\", s])
+            "'
 
       - name: Build resource snapshots
+        env:
+          SERVERS_JSON: ${{ inputs.servers }}
         run: |
           nix develop .#python --command bash -c \
-            'uv run x.py ci release-data build --output cache/remote --hashes snapshot-hashes.json'
+            'uv run python -c "
+              import json, os, subprocess
+              servers = json.loads(os.environ.get(\"SERVERS_JSON\") or \"[]\")
+              cmd = [\"uv\", \"run\", \"x.py\", \"ci\", \"release-data\", \"build\"]
+              for s in servers:
+                  cmd.extend([\"--server\", s])
+              cmd.extend([\"--output\", \"cache/remote\", \"--hashes\", \"snapshot-hashes.json\"])
+              subprocess.run(cmd)
+            "'
 
       - uses: actions/upload-artifact@v4
         with:
@@ -84,6 +99,31 @@ jobs:
       - name: Generate protobuf
         run: nix develop .#codegen --command bash -c 'uv run x.py generate protobuf'
 
+      - name: Sync remote channel head
+        env:
+          REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
+          REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
+          REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
+          REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
+        run: |
+          # shellcheck disable=SC2016
+          nix develop .#python --command bash -c \
+            'uv run x.py \
+              --dev-env remote.s3.endpoint="${REMOTE_ENDPOINT}" \
+              --dev-env remote.s3.bucket="${REMOTE_BUCKET}" \
+              --dev-env remote.s3.access_key="${REMOTE_ACCESS_KEY}" \
+              --dev-env remote.s3.secret_key="${REMOTE_SECRET_KEY}" \
+              --dev-env remote.s3.alias=efa-remote-publish \
+              --dev-env remote.s3.public_download=true \
+              remote sync \
+              --target s3 \
+              --endpoint "${REMOTE_ENDPOINT}" \
+              --bucket "${REMOTE_BUCKET}" \
+              --access-key "${REMOTE_ACCESS_KEY}" \
+              --secret-key "${REMOTE_SECRET_KEY}" \
+              --alias efa-remote-publish \
+              --channel testing'
+
       - name: Publish to testing channel
         env:
           REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
@@ -108,4 +148,5 @@ jobs:
               --bucket "${REMOTE_BUCKET}" \
               --access-key "${REMOTE_ACCESS_KEY}" \
               --secret-key "${REMOTE_SECRET_KEY}" \
-              --alias efa-remote-publish'
+              --alias efa-remote-publish \
+              --merge'

--- a/.github/workflows/_release-data.yml
+++ b/.github/workflows/_release-data.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Generate protobuf
         run: nix develop .#codegen --command bash -c 'uv run x.py generate protobuf'
 
-      - name: Download raw artifacts
+      - name: Download raw artifacts and build snapshots
         env:
           SERVERS_JSON: ${{ inputs.servers }}
           CI_ENDPOINT: ${{ secrets.CI_STORAGE_ENDPOINT }}
@@ -41,15 +41,21 @@ jobs:
           CI_ACCESS_KEY: ${{ secrets.CI_STORAGE_ACCESS_KEY }}
           CI_SECRET_KEY: ${{ secrets.CI_STORAGE_SECRET_KEY }}
         run: |
+          # shellcheck disable=SC2016
           nix develop .#python --command bash -c \
-            'uv run python -c "import json, os, subprocess; servers = json.loads(os.environ.get(\"SERVERS_JSON\") or \"[]\"); subprocess.run([\"uv\", \"run\", \"x.py\", \"ci\", \"raw-data\", \"download\", \"--all\"]) if not servers else [subprocess.run([\"uv\", \"run\", \"x.py\", \"ci\", \"raw-data\", \"download\", \"--server\", s]) for s in servers]"'
-
-      - name: Build resource snapshots
-        env:
-          SERVERS_JSON: ${{ inputs.servers }}
-        run: |
-          nix develop .#python --command bash -c \
-            'uv run python -c "import json, os, subprocess; servers = json.loads(os.environ.get(\"SERVERS_JSON\") or \"[]\"); cmd = [\"uv\", \"run\", \"x.py\", \"ci\", \"release-data\", \"build\"]; [cmd.extend([\"--server\", s]) for s in servers]; cmd.extend([\"--output\", \"cache/remote\", \"--hashes\", \"snapshot-hashes.json\"]); subprocess.run(cmd)"'
+            'uv run x.py \
+              --dev-env ci.storage.endpoint="${CI_ENDPOINT}" \
+              --dev-env ci.storage.bucket="${CI_BUCKET}" \
+              --dev-env ci.storage.alias="efa-ci-storage" \
+              --dev-env ci.storage.access_key="${CI_ACCESS_KEY}" \
+              --dev-env ci.storage.secret_key="${CI_SECRET_KEY}" \
+              --dev-env ci.storage.public_url="https://ci.storage.efa-tech.dev" \
+              --dev-env ci.raw_artifacts.remote_root="data-generator/raw-artifact" \
+              ci release-data build \
+                --download \
+                --servers "${SERVERS_JSON}" \
+                --output cache/remote \
+                --hashes snapshot-hashes.json'
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_release-data.yml
+++ b/.github/workflows/_release-data.yml
@@ -1,43 +1,20 @@
-name: Release Data Snapshot
+name: Release Data Snapshot (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      test_mode:
+        description: "Run in test mode (skip publish)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
-
-on:
-  workflow_run:
-    workflows: [Update Raw EVE Data]
-    types: [completed]
-    branches: [dev]
-  workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    branches: [dev]
-
-concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('release-data-test-{0}', github.ref) || 'release-data' }}
-  cancel-in-progress: true
 
 jobs:
   build:
     name: Build resource snapshots
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' || (
-        github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event != 'pull_request' &&
-        github.ref == 'refs/heads/dev' &&
-        github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
-        github.event.repository.fork == false
-      ) || (
-        github.event_name == 'pull_request' &&
-        (
-          contains(github.event.pull_request.labels.*.name, 'D-CI-Data Release') ||
-          contains(github.event.pull_request.labels.*.name, 'D-Full CI')
-        ) &&
-        github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
-        github.event.repository.fork == false
-      )
     steps:
       - uses: actions/checkout@v6
         with:
@@ -59,6 +36,7 @@ jobs:
           CI_ACCESS_KEY: ${{ secrets.CI_STORAGE_ACCESS_KEY }}
           CI_SECRET_KEY: ${{ secrets.CI_STORAGE_SECRET_KEY }}
         run: |
+          # shellcheck disable=SC2016
           nix develop .#python --command bash -c \
             'uv run x.py \
               --dev-env ci.storage.endpoint="$CI_ENDPOINT" \
@@ -86,7 +64,7 @@ jobs:
     name: Publish to testing channel
     needs: build
     runs-on: ubuntu-latest
-    if: needs.build.result == 'success'
+    if: inputs.test_mode == false
     steps:
       - uses: actions/checkout@v6
         with:
@@ -98,15 +76,6 @@ jobs:
       - name: Install Python dependencies
         run: nix develop .#python --command bash -c 'uv sync'
 
-      - name: Determine mode
-        id: mode
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "flag=--test-mode" >> "$GITHUB_OUTPUT"
-          else
-            echo "flag=" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/download-artifact@v4
         with:
           name: v2-snapshots
@@ -117,12 +86,12 @@ jobs:
 
       - name: Publish to testing channel
         env:
-          TEST_MODE_FLAG: ${{ steps.mode.outputs.flag }}
           REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
           REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
           REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
           REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
         run: |
+          # shellcheck disable=SC2016
           nix develop .#python --command bash -c \
             'uv run x.py \
               --dev-env remote.s3.endpoint="${REMOTE_ENDPOINT}" \
@@ -134,4 +103,9 @@ jobs:
               ci release-data publish testing \
               --hashes snapshot-hashes.json \
               --schema-root cache/remote \
-              ${TEST_MODE_FLAG}'
+              --target s3 \
+              --endpoint "${REMOTE_ENDPOINT}" \
+              --bucket "${REMOTE_BUCKET}" \
+              --access-key "${REMOTE_ACCESS_KEY}" \
+              --secret-key "${REMOTE_SECRET_KEY}" \
+              --alias efa-remote-publish'

--- a/.github/workflows/_release-data.yml
+++ b/.github/workflows/_release-data.yml
@@ -42,30 +42,14 @@ jobs:
           CI_SECRET_KEY: ${{ secrets.CI_STORAGE_SECRET_KEY }}
         run: |
           nix develop .#python --command bash -c \
-            'uv run python -c "
-              import json, os, subprocess
-              servers = json.loads(os.environ.get(\"SERVERS_JSON\") or \"[]\")
-              if not servers:
-                  subprocess.run([\"uv\", \"run\", \"x.py\", \"ci\", \"raw-data\", \"download\", \"--all\"])
-              else:
-                  for s in servers:
-                      subprocess.run([\"uv\", \"run\", \"x.py\", \"ci\", \"raw-data\", \"download\", \"--server\", s])
-            "'
+            'uv run python -c "import json, os, subprocess; servers = json.loads(os.environ.get(\"SERVERS_JSON\") or \"[]\"); subprocess.run([\"uv\", \"run\", \"x.py\", \"ci\", \"raw-data\", \"download\", \"--all\"]) if not servers else [subprocess.run([\"uv\", \"run\", \"x.py\", \"ci\", \"raw-data\", \"download\", \"--server\", s]) for s in servers]"'
 
       - name: Build resource snapshots
         env:
           SERVERS_JSON: ${{ inputs.servers }}
         run: |
           nix develop .#python --command bash -c \
-            'uv run python -c "
-              import json, os, subprocess
-              servers = json.loads(os.environ.get(\"SERVERS_JSON\") or \"[]\")
-              cmd = [\"uv\", \"run\", \"x.py\", \"ci\", \"release-data\", \"build\"]
-              for s in servers:
-                  cmd.extend([\"--server\", s])
-              cmd.extend([\"--output\", \"cache/remote\", \"--hashes\", \"snapshot-hashes.json\"])
-              subprocess.run(cmd)
-            "'
+            'uv run python -c "import json, os, subprocess; servers = json.loads(os.environ.get(\"SERVERS_JSON\") or \"[]\"); cmd = [\"uv\", \"run\", \"x.py\", \"ci\", \"release-data\", \"build\"]; [cmd.extend([\"--server\", s]) for s in servers]; cmd.extend([\"--output\", \"cache/remote\", \"--hashes\", \"snapshot-hashes.json\"]); subprocess.run(cmd)"'
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_update-raw-data.yml
+++ b/.github/workflows/_update-raw-data.yml
@@ -1,39 +1,32 @@
-name: Update Raw EVE Data
+name: Update Raw EVE Data (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      all:
+        description: "Check/update all servers"
+        type: boolean
+        default: true
+      no_upload:
+        description: "Skip uploading to CI storage"
+        type: boolean
+        default: false
+    outputs:
+      matrix:
+        value: ${{ jobs.check.outputs.matrix }}
+      has_updates:
+        value: ${{ jobs.check.outputs.has_updates }}
 
 permissions:
   contents: read
-
-on:
-  schedule:
-    - cron: "0 0 * * *"
-  workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    branches: [dev]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   check:
     name: Check for updates
     runs-on: ubuntu-latest
-    if: |
-      (
-        contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) &&
-        github.ref == 'refs/heads/dev' &&
-        github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
-        github.event.repository.fork == false
-      ) || (
-        github.event_name == 'pull_request' &&
-        (
-          contains(github.event.pull_request.labels.*.name, 'D-Full CI') ||
-          contains(github.event.pull_request.labels.*.name, 'D-CI-Data Update')
-        )
-      )
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      has_updates: ${{ steps.matrix.outputs.has_updates }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -50,11 +43,17 @@ jobs:
         env:
           CI_PUBLIC_URL: https://ci.storage.efa-tech.dev
         run: |
+          # shellcheck disable=SC2016
           MATRIX=$(nix develop .#python --command bash -c \
             'uv run x.py \
               --dev-env ci.raw_artifacts.public_url="$CI_PUBLIC_URL" \
               ci raw-data check --all --format json')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          if [ "$MATRIX" = "[]" ] || [ -z "$MATRIX" ]; then
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_updates=true" >> "$GITHUB_OUTPUT"
+          fi
 
   update:
     name: Update raw artifacts
@@ -94,10 +93,7 @@ jobs:
     name: Upload raw artifacts
     needs: [check, update]
     if: |
-      github.event_name != 'pull_request' &&
-      github.ref == 'refs/heads/dev' &&
-      github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
-      github.event.repository.fork == false &&
+      inputs.no_upload == false &&
       needs.check.outputs.matrix != '' &&
       needs.check.outputs.matrix != '[]'
     runs-on: ubuntu-latest
@@ -128,6 +124,7 @@ jobs:
           CI_ACCESS_KEY: ${{ secrets.CI_STORAGE_ACCESS_KEY }}
           CI_SECRET_KEY: ${{ secrets.CI_STORAGE_SECRET_KEY }}
         run: |
+          # shellcheck disable=SC2016
           nix develop .#python --command bash -c \
             'uv run x.py \
               --dev-env ci.storage.endpoint="$CI_ENDPOINT" \

--- a/.github/workflows/_update-raw-data.yml
+++ b/.github/workflows/_update-raw-data.yml
@@ -42,12 +42,13 @@ jobs:
         id: matrix
         env:
           CI_PUBLIC_URL: https://ci.storage.efa-tech.dev
+          CHECK_ALL: ${{ inputs.all && '--all' || '' }}
         run: |
           # shellcheck disable=SC2016
           MATRIX=$(nix develop .#python --command bash -c \
             'uv run x.py \
               --dev-env ci.raw_artifacts.public_url="$CI_PUBLIC_URL" \
-              ci raw-data check --all --format json')
+              ci raw-data check ${CHECK_ALL:+"$CHECK_ALL"} --format json')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           if [ "$MATRIX" = "[]" ] || [ -z "$MATRIX" ]; then
             echo "has_updates=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_update-raw-data.yml
+++ b/.github/workflows/_update-raw-data.yml
@@ -91,7 +91,7 @@ jobs:
         run: uv sync
 
       - name: Download portable Python 2.7
-        run: uv run x.py ci raw-data setup-py27
+        run: uv run x.py --dev-env ci.raw_artifacts.public_url="https://ci.storage.efa-tech.dev" ci raw-data setup-py27
 
       - name: Update raw artifacts
         run: uv run x.py ci raw-data update --server "${{ matrix.server }}" --no-upload

--- a/.github/workflows/_update-raw-data.yml
+++ b/.github/workflows/_update-raw-data.yml
@@ -7,6 +7,10 @@ on:
         description: "Check/update all servers"
         type: boolean
         default: true
+      server:
+        description: "Check/update a single server (takes precedence over all)"
+        type: string
+        default: ""
       no_upload:
         description: "Skip uploading to CI storage"
         type: boolean
@@ -43,12 +47,20 @@ jobs:
         env:
           CI_PUBLIC_URL: https://ci.storage.efa-tech.dev
           CHECK_ALL: ${{ inputs.all && '--all' || '' }}
+          SERVER: ${{ inputs.server }}
         run: |
           # shellcheck disable=SC2016
-          MATRIX=$(nix develop .#python --command bash -c \
-            'uv run x.py \
-              --dev-env ci.raw_artifacts.public_url="$CI_PUBLIC_URL" \
-              ci raw-data check ${CHECK_ALL:+"$CHECK_ALL"} --format json')
+          if [ -n "$SERVER" ]; then
+            MATRIX=$(nix develop .#python --command bash -c \
+              'uv run x.py \
+                --dev-env ci.raw_artifacts.public_url="$CI_PUBLIC_URL" \
+                ci raw-data check --server "$SERVER" --format json')
+          else
+            MATRIX=$(nix develop .#python --command bash -c \
+              'uv run x.py \
+                --dev-env ci.raw_artifacts.public_url="$CI_PUBLIC_URL" \
+                ci raw-data check ${CHECK_ALL:+"$CHECK_ALL"} --format json')
+          fi
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           if [ "$MATRIX" = "[]" ] || [ -z "$MATRIX" ]; then
             echo "has_updates=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-data-cron.yml
+++ b/.github/workflows/release-data-cron.yml
@@ -1,0 +1,30 @@
+name: Release Data Snapshot (cron)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      test_mode:
+        description: "Run in test mode (skip publish)"
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      test_mode:
+        description: "Run in test mode (skip publish)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: Build and publish
+    uses: ./.github/workflows/_release-data.yml
+    secrets: inherit
+    with:
+      test_mode: ${{ inputs.test_mode }}

--- a/.github/workflows/release-data-cron.yml
+++ b/.github/workflows/release-data-cron.yml
@@ -10,12 +10,20 @@ on:
         description: "Run in test mode (skip publish)"
         type: boolean
         default: false
+      servers:
+        description: "JSON array of server IDs to rebuild (default: all)"
+        type: string
+        default: "[]"
   workflow_dispatch:
     inputs:
       test_mode:
         description: "Run in test mode (skip publish)"
         type: boolean
         default: false
+      servers:
+        description: "JSON array of server IDs to rebuild (default: all)"
+        type: string
+        default: "[]"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -28,3 +36,4 @@ jobs:
     secrets: inherit
     with:
       test_mode: ${{ inputs.test_mode }}
+      servers: ${{ inputs.servers }}

--- a/.github/workflows/release-data-test.yml
+++ b/.github/workflows/release-data-test.yml
@@ -1,0 +1,28 @@
+name: Release Data Snapshot (test)
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: Build and test publish
+    if: |
+      (
+        contains(github.event.pull_request.labels.*.name, 'D-CI-Data Release') ||
+        contains(github.event.pull_request.labels.*.name, 'D-Full CI')
+      ) &&
+      github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
+      github.event.repository.fork == false
+    uses: ./.github/workflows/_release-data.yml
+    secrets: inherit
+    with:
+      test_mode: true

--- a/.github/workflows/update-raw-data-cron.yml
+++ b/.github/workflows/update-raw-data-cron.yml
@@ -1,0 +1,35 @@
+name: Update Raw EVE Data (cron)
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Check and update raw data
+    if: |
+      github.ref == 'refs/heads/dev' &&
+      github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
+      github.event.repository.fork == false
+    uses: ./.github/workflows/_update-raw-data.yml
+    secrets: inherit
+    with:
+      all: true
+      no_upload: false
+
+  release:
+    name: Release data snapshot
+    needs: update
+    if: needs.update.outputs.has_updates == 'true'
+    uses: ./.github/workflows/release-data-cron.yml
+    secrets: inherit
+    with:
+      test_mode: false

--- a/.github/workflows/update-raw-data-cron.yml
+++ b/.github/workflows/update-raw-data-cron.yml
@@ -33,3 +33,4 @@ jobs:
     secrets: inherit
     with:
       test_mode: false
+      servers: ${{ needs.update.outputs.matrix }}

--- a/.github/workflows/update-raw-data-test.yml
+++ b/.github/workflows/update-raw-data-test.yml
@@ -1,0 +1,29 @@
+name: Update Raw EVE Data (test)
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Check and update raw data
+    if: |
+      (
+        contains(github.event.pull_request.labels.*.name, 'D-Full CI') ||
+        contains(github.event.pull_request.labels.*.name, 'D-CI-Data Update')
+      ) &&
+      github.repository == 'Embers-of-the-Fire/eve-fit-assistant' &&
+      github.event.repository.fork == false
+    uses: ./.github/workflows/_update-raw-data.yml
+    secrets: inherit
+    with:
+      all: true
+      no_upload: true

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -201,34 +201,105 @@ def register_ci_commands(cli_group: click.Group) -> None:
         default=None,
         help="Server to build (default: all configured servers).",
     )
-    def release_data_build(output: Path, hashes: Path, server: tuple[str, ...]):
+    @click.option(
+        "--servers",
+        default=None,
+        help="JSON array of server IDs to build (default: all configured servers).",
+    )
+    @click.option(
+        "--download",
+        is_flag=True,
+        help="Download raw artifacts from CI storage before building.",
+    )
+    @click.option(
+        "--resources-dir",
+        type=click.Path(file_okay=False, path_type=Path),
+        default="data/resources",
+        help="Directory to download raw artifacts into (default: data/resources).",
+    )
+    def release_data_build(
+        output: Path,
+        hashes: Path,
+        server: tuple[str, ...],
+        servers: str | None,
+        download: bool,
+        resources_dir: Path,
+    ):
         """Build resource snapshots for all servers and emit snapshot-hashes.json."""
         from bootstrap.data.workspace.generate import run_generator
 
-        schema_root = (PROJECT_ROOT / output).resolve()
-        servers = list(server) if server else sorted(SERVER_IDS)
-        if not servers:
+        if servers is not None:
+            if servers.strip() == "":
+                servers_to_build = sorted(SERVER_IDS)
+            else:
+                try:
+                    parsed_servers = json.loads(servers)
+                except json.JSONDecodeError as exc:
+                    raise click.BadParameter(f"Invalid JSON in --servers: {exc}") from exc
+                if not isinstance(parsed_servers, list):
+                    raise click.BadParameter("--servers must be a JSON array")
+                servers_to_build = parsed_servers
+        elif server:
+            servers_to_build = list(server)
+        else:
+            servers_to_build = sorted(SERVER_IDS)
+
+        if not servers_to_build:
+            servers_to_build = sorted(SERVER_IDS)
+        if not servers_to_build:
             raise click.ClickException("No servers configured.")
 
-        hashes_data: dict[str, str] = {}
-        for server_id in servers:
+        for server_id in servers_to_build:
             if server_id not in SERVER_IDS:
                 raise click.ClickException(f"Unknown server: {server_id}")
-            ws_descriptor = runtime.get_workspace(server_id)
-            ws_config = WorkspaceConfig.load_from_descriptor(ws_descriptor)
-            snapshot_hash = asyncio.run(run_generator(ws_config, set(), schema_root=schema_root))
-            if snapshot_hash is None:
-                raise click.ClickException(f"No snapshot produced for {server_id}")
-            hashes_data[server_id] = snapshot_hash
-            click.echo(f"Built {server_id} snapshot: {snapshot_hash[:16]}...")
 
-        hashes_path = (PROJECT_ROOT / hashes).resolve()
-        hashes_path.parent.mkdir(parents=True, exist_ok=True)
-        hashes_path.write_text(
-            json.dumps(hashes_data, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        click.echo(styled([Style.BRIGHT, Fore.GREEN], f"Wrote snapshot hashes to {hashes_path}"))
+        schema_root = (PROJECT_ROOT / output).resolve()
+        resolved_resources_dir = (PROJECT_ROOT / resources_dir).resolve()
+
+        raw_artifacts = None
+        storage = None
+        if download:
+            import bootstrap.config
+
+            from bootstrap.data.updater.uploader import download_artifacts
+
+            bootstrap.config.DeveloperConfiguration.ensure_loaded()
+            ci = bootstrap.config.DEV_CONFIGURATION.ci
+            raw_artifacts, storage = ci.require_raw_artifacts()
+
+        async def run_pipeline():
+            if download:
+                assert raw_artifacts is not None
+                assert storage is not None
+                for server_id in servers_to_build:
+                    await download_artifacts(
+                        server_id, resolved_resources_dir, raw_artifacts, storage
+                    )
+                    click.echo(
+                        f"Downloaded {server_id} artifacts to {resolved_resources_dir / server_id}"
+                    )
+
+            hashes_data: dict[str, str] = {}
+            for server_id in servers_to_build:
+                ws_descriptor = runtime.get_workspace(server_id)
+                ws_config = WorkspaceConfig.load_from_descriptor(ws_descriptor)
+                snapshot_hash = await run_generator(ws_config, set(), schema_root=schema_root)
+                if snapshot_hash is None:
+                    raise click.ClickException(f"No snapshot produced for {server_id}")
+                hashes_data[server_id] = snapshot_hash
+                click.echo(f"Built {server_id} snapshot: {snapshot_hash[:16]}...")
+
+            hashes_path = (PROJECT_ROOT / hashes).resolve()
+            hashes_path.parent.mkdir(parents=True, exist_ok=True)
+            hashes_path.write_text(
+                json.dumps(hashes_data, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            click.echo(
+                styled([Style.BRIGHT, Fore.GREEN], f"Wrote snapshot hashes to {hashes_path}")
+            )
+
+        asyncio.run(run_pipeline())
 
     @release_data.command("publish")
     @click.argument("channel")

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -272,6 +272,12 @@ def register_ci_commands(cli_group: click.Group) -> None:
         default=1,
         help="Max generations to sync after publish (default: 1).",
     )
+    @click.option(
+        "--merge",
+        is_flag=True,
+        default=False,
+        help="Include unchanged server snapshots from the current channel head.",
+    )
     @click.pass_context
     def release_data_publish(
         ctx: click.Context,
@@ -287,6 +293,7 @@ def register_ci_commands(cli_group: click.Group) -> None:
         alias_name: str | None,
         workers: int,
         sync_depth: int,
+        merge: bool,
     ):
         """Publish resource snapshots to a remote channel."""
         from bootstrap.remote import SessionManager
@@ -299,6 +306,24 @@ def register_ci_commands(cli_group: click.Group) -> None:
             raise click.ClickException(f"Invalid hashes file: {hashes_path}")
 
         resolved_channel = validate_remote_channel(channel).value
+
+        mgr = SessionManager(resolved_root)
+        if merge:
+            from bootstrap.remote.generation import GenerationStore
+
+            try:
+                head = mgr.get_head(resolved_channel)
+            except FileNotFoundError:
+                head = None
+            if head and head.generation_hash:
+                prev_gen = GenerationStore(resolved_root).load(head.generation_hash)
+                for entry in prev_gen.resources.entries:
+                    if entry.server_id not in hashes_data:
+                        hashes_data[entry.server_id] = entry.snapshot_hash
+                        click.echo(
+                            f"Carried forward {entry.server_id} snapshot: "
+                            f"{entry.snapshot_hash[:16]}..."
+                        )
 
         init_cmd = _lookup_command(ctx, "remote", "session", "init")
         add_cmd = _lookup_command(ctx, "remote", "session", "add")
@@ -335,7 +360,6 @@ def register_ci_commands(cli_group: click.Group) -> None:
             schema_root=resolved_root,
         )
 
-        mgr = SessionManager(resolved_root)
         committed_hash = mgr.get_head(resolved_channel).generation_hash
         click.echo(
             styled(

--- a/bootstrap/cli/ci/updater.py
+++ b/bootstrap/cli/ci/updater.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
-import urllib.request
 
 from pathlib import Path
 
 import click
+import requests
 
 import bootstrap.config
 
@@ -180,15 +180,25 @@ def register_raw_data_commands(ci: click.Group) -> None:
         if public_url:
             url = f"{public_url}/build-dependencies/py27.zip"
         output.parent.mkdir(parents=True, exist_ok=True)
-        request = urllib.request.Request(
-            url,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; EFA-CI/1.0)"},
-        )
-        with (
-            urllib.request.urlopen(request) as response,
-            open(output, "wb") as f,
-        ):
-            shutil.copyfileobj(response, f)
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; EFA-CI/1.0)"}
+        tmp_output = output.with_suffix(output.suffix + ".tmp")
+        try:
+            with requests.get(
+                url,
+                headers=headers,
+                stream=True,
+                timeout=(10, 300),
+            ) as response:
+                response.raise_for_status()
+                with tmp_output.open("wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+            tmp_output.replace(output)
+        except Exception:
+            if tmp_output.exists():
+                tmp_output.unlink()
+            raise
         click.echo(f"Downloaded Python 2.7 to {output}")
 
     @raw_data.command("sync-local")

--- a/bootstrap/cli/ci/updater.py
+++ b/bootstrap/cli/ci/updater.py
@@ -178,6 +178,8 @@ def register_raw_data_commands(ci: click.Group) -> None:
         if public_url is None and ci.storage is not None:
             public_url = ci.storage.public_url
         if public_url:
+            # Strip trailing slash from public_url to avoid double-slash in constructed URL.
+            public_url = public_url.rstrip("/")
             url = f"{public_url}/build-dependencies/py27.zip"
         output.parent.mkdir(parents=True, exist_ok=True)
         headers = {"User-Agent": "Mozilla/5.0 (compatible; EFA-CI/1.0)"}

--- a/bootstrap/cli/ci/updater.py
+++ b/bootstrap/cli/ci/updater.py
@@ -170,8 +170,25 @@ def register_raw_data_commands(ci: click.Group) -> None:
     )
     def raw_data_setup_py27(output: Path, url: str):
         """Download portable Python 2.7 for the FSD dumper."""
+        bootstrap.config.DeveloperConfiguration.ensure_loaded()
+        ci = bootstrap.config.DEV_CONFIGURATION.ci
+        public_url: str | None = None
+        if ci.raw_artifacts is not None:
+            public_url = ci.raw_artifacts.public_url
+        if public_url is None and ci.storage is not None:
+            public_url = ci.storage.public_url
+        if public_url:
+            url = f"{public_url}/build-dependencies/py27.zip"
         output.parent.mkdir(parents=True, exist_ok=True)
-        urllib.request.urlretrieve(url, output)
+        request = urllib.request.Request(
+            url,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; EFA-CI/1.0)"},
+        )
+        with (
+            urllib.request.urlopen(request) as response,
+            open(output, "wb") as f,
+        ):
+            shutil.copyfileobj(response, f)
         click.echo(f"Downloaded Python 2.7 to {output}")
 
     @raw_data.command("sync-local")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable “release data snapshot” and “raw data update” workflows callable with `test_mode`, JSON server selection, and upload controls.
  * Introduced cron automation plus label-gated PR test runs that delegate to the reusable workflows.
* **Workflow Improvements**
  * Release publishing can now optionally `merge` with the existing remote channel head and carries forward missing snapshot entries; testing snapshots are synced to storage.
  * Raw-data updates now expose a `has_updates` signal to gate the follow-up release.
* **Fixes**
  * Improved CI Python 2.7 dependency downloads by preferring the configured public URL and using safer streamed downloads with temporary-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->