### PR TITLE
refactor: refactor announcements feature and optimize feed fetching

### DIFF
--- a/bootstrap/docs/announcements_remote.py
+++ b/bootstrap/docs/announcements_remote.py
@@ -34,8 +34,6 @@ from datetime import UTC
 from datetime import datetime
 from typing import TYPE_CHECKING
 from typing import Any
-from urllib.request import Request
-from urllib.request import urlopen
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -745,41 +743,32 @@ class AnnouncementRemoteSync:
         self.alias_name = alias_name
         self.resource_root = resource_root.rstrip("/")
 
-    def _build_url(self, path: str) -> str:
-        return f"{self.endpoint.rstrip('/')}/{self.bucket}/{self.resource_root}/{path.lstrip('/')}"
+    def _cat_bytes(self, key: str) -> bytes:
+        """Download *key* via the configured ``mc`` alias (signed request)."""
+        mc_bin, alias_target = self._ensure_alias()
+        target_url = f"{alias_target}/{self.resource_root}/{key.lstrip('/')}"
+        result = subprocess.run(
+            [mc_bin, "cat", target_url], capture_output=True, text=False, timeout=30
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(f"Failed to download {key}: {stderr}")
+        return result.stdout
 
     def _download_json(self, path: str) -> dict[str, Any]:
-        url = self._build_url(path)
-        req = Request(url)
-        try:
-            with urlopen(req, timeout=30) as response:
-                if response.status != 200:
-                    raise RuntimeError(f"HTTP {response.status} for {url}")
-                return json.loads(response.read().decode("utf-8"))
-        except Exception as e:
-            raise RuntimeError(f"Failed to download {url}: {e}") from e
+        return json.loads(self._cat_bytes(path).decode("utf-8"))
 
     def _download_file(self, path: str) -> bytes:
-        url = self._build_url(path)
-        req = Request(url)
-        try:
-            with urlopen(req, timeout=30) as response:
-                if response.status != 200:
-                    raise RuntimeError(f"HTTP {response.status} for {url}")
-                return response.read()
-        except Exception as e:
-            raise RuntimeError(f"Failed to download {url}: {e}") from e
+        return self._cat_bytes(path)
 
     def sync(self, full: bool = False) -> None:
         """Sync remote state to local workspace."""
         self.workspace.ensure_remote_directories()
+        self._ensure_alias()
 
         # Download catalog.json
-        try:
-            catalog_data = self._download_json("announcements/catalog.json")
-            catalog = AnnouncementCatalog.model_validate(catalog_data)
-        except Exception as e:
-            raise RuntimeError(f"Failed to download catalog.json: {e}") from e
+        catalog_data = self._download_json("announcements/catalog.json")
+        catalog = AnnouncementCatalog.model_validate(catalog_data)
 
         (self.workspace.remote_dir / "catalog.json").write_text(
             json.dumps(catalog.model_dump(mode="json", by_alias=True), indent=2, ensure_ascii=False)
@@ -791,38 +780,32 @@ class AnnouncementRemoteSync:
         for page_meta in catalog.pages:
             if page_meta.active:
                 continue
-            try:
-                page_data = self._download_json(f"announcements/pages/{page_meta.uuid}.json")
-                page = AnnouncementPage.model_validate(page_data)
-                page_path = self.workspace.remote_dir / "pages" / f"{page_meta.uuid}.json"
-                page_path.parent.mkdir(parents=True, exist_ok=True)
-                page_path.write_text(
-                    json.dumps(
-                        page.model_dump(mode="json", by_alias=True),
-                        indent=2,
-                        ensure_ascii=False,
-                    )
-                    + "\n",
-                    encoding="utf-8",
-                )
-            except Exception as e:
-                raise RuntimeError(f"Failed to download page {page_meta.uuid}: {e}") from e
-
-        # Download active.json
-        try:
-            active_data = self._download_json("announcements/active.json")
-            active = AnnouncementPage.model_validate(active_data)
-            (self.workspace.remote_dir / "active.json").write_text(
+            page_data = self._download_json(f"announcements/pages/{page_meta.uuid}.json")
+            page = AnnouncementPage.model_validate(page_data)
+            page_path = self.workspace.remote_dir / "pages" / f"{page_meta.uuid}.json"
+            page_path.parent.mkdir(parents=True, exist_ok=True)
+            page_path.write_text(
                 json.dumps(
-                    active.model_dump(mode="json", by_alias=True),
+                    page.model_dump(mode="json", by_alias=True),
                     indent=2,
                     ensure_ascii=False,
                 )
                 + "\n",
                 encoding="utf-8",
             )
-        except Exception as e:
-            raise RuntimeError(f"Failed to download active.json: {e}") from e
+
+        # Download active.json
+        active_data = self._download_json("announcements/active.json")
+        active = AnnouncementPage.model_validate(active_data)
+        (self.workspace.remote_dir / "active.json").write_text(
+            json.dumps(
+                active.model_dump(mode="json", by_alias=True),
+                indent=2,
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
         # If --full, download all document bodies
         if full:
@@ -834,13 +817,8 @@ class AnnouncementRemoteSync:
                         doc_path = self.workspace.documents_dir / f"{body_hash}.md"
                         if doc_path.exists():
                             continue
-                        try:
-                            content = self._download_file(f"announcements/documents/{body_hash}.md")
-                            doc_path.write_bytes(content)
-                        except Exception as e:
-                            raise RuntimeError(
-                                f"Failed to download document {body_hash}: {e}"
-                            ) from e
+                        content = self._download_file(f"announcements/documents/{body_hash}.md")
+                        doc_path.write_bytes(content)
 
     def _run_mc(self, cmd: list[str], redacted_cmd: list[str], title: str) -> None:
         """Run an ``mc`` command, logging only the redacted version."""

--- a/lib/components/dialog/announcement_dialog.dart
+++ b/lib/components/dialog/announcement_dialog.dart
@@ -1,8 +1,10 @@
 import "dart:async";
 
 import "package:eve_fit_assistant/components/dialog/dialog.dart";
+import "package:eve_fit_assistant/constant/colors.dart";
 import "package:eve_fit_assistant/utils/context.dart";
 import "package:flutter/material.dart";
+import "package:markdown_widget/markdown_widget.dart";
 
 typedef AnnouncementDialogDetailCallback = FutureOr<void> Function();
 typedef AnnouncementDialogPersistenceCallback =
@@ -11,7 +13,8 @@ typedef AnnouncementDialogPersistenceCallback =
 Future<void> showAnnouncementDialog(
   BuildContext context, {
   required String title,
-  required String informationText,
+  String? informationText,
+  String? bodyMarkdown,
   AnnouncementDialogDetailCallback? onShowDetail,
   AnnouncementDialogPersistenceCallback? onPersistPreference,
   bool barrierDismissible = true,
@@ -23,6 +26,7 @@ Future<void> showAnnouncementDialog(
   builder: (context) => AnnouncementDialog(
     title: title,
     informationText: informationText,
+    bodyMarkdown: bodyMarkdown,
     onShowDetail: onShowDetail,
     onPersistPreference: onPersistPreference,
     initialDontShowAgain: initialDontShowAgain,
@@ -32,15 +36,20 @@ Future<void> showAnnouncementDialog(
 class AnnouncementDialog extends StatefulWidget {
   const AnnouncementDialog({
     required this.title,
-    required this.informationText,
     super.key,
+    this.informationText,
+    this.bodyMarkdown,
     this.onShowDetail,
     this.onPersistPreference,
     this.initialDontShowAgain = false,
-  });
+  }) : assert(
+         informationText != null || bodyMarkdown != null,
+         "Provide either informationText or bodyMarkdown",
+       );
 
   final String title;
-  final String informationText;
+  final String? informationText;
+  final String? bodyMarkdown;
   final AnnouncementDialogDetailCallback? onShowDetail;
   final AnnouncementDialogPersistenceCallback? onPersistPreference;
   final bool initialDontShowAgain;
@@ -63,7 +72,14 @@ class _AnnouncementDialogState extends State<AnnouncementDialog> {
         children: [
           Flexible(
             child: SingleChildScrollView(
-              child: Text(widget.informationText, style: context.theme.textTheme.bodyMedium),
+              child: widget.bodyMarkdown != null
+                  ? MarkdownWidget(
+                      data: widget.bodyMarkdown!,
+                      padding: EdgeInsets.zero,
+                      shrinkWrap: true,
+                      config: markdownDarkConfig,
+                    )
+                  : Text(widget.informationText ?? "", style: context.theme.textTheme.bodyMedium),
             ),
           ),
           if (widget.onPersistPreference != null) ...[

--- a/lib/features/announcements/models/announcement_catalog.dart
+++ b/lib/features/announcements/models/announcement_catalog.dart
@@ -11,8 +11,13 @@ abstract class AnnouncementCatalog with _$AnnouncementCatalog {
     @Default(<PageSummary>[]) List<PageSummary> pages,
   }) = _AnnouncementCatalog;
 
+  const AnnouncementCatalog._();
+
   factory AnnouncementCatalog.empty() => const AnnouncementCatalog(schemaVersion: 1);
 
   factory AnnouncementCatalog.fromJson(Map<String, dynamic> json) =>
       _$AnnouncementCatalogFromJson(json);
+
+  /// Returns whether the catalog schema is supported by this client version.
+  bool get isSupported => schemaVersion <= 1;
 }

--- a/lib/features/announcements/models/announcement_record.dart
+++ b/lib/features/announcements/models/announcement_record.dart
@@ -1,3 +1,4 @@
+import "package:eve_fit_assistant/features/announcements/models/announcement_entry.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 
 part "announcement_record.freezed.dart";
@@ -21,5 +22,6 @@ abstract class AnnouncementRecord with _$AnnouncementRecord {
     String? appVersion,
     @Default(false) bool isRead,
     @Default(false) bool isDismissed,
+    AnnouncementEntry? entry,
   }) = _AnnouncementRecord;
 }

--- a/lib/features/announcements/models/announcement_state.dart
+++ b/lib/features/announcements/models/announcement_state.dart
@@ -9,8 +9,6 @@ abstract class AnnouncementState with _$AnnouncementState {
     @Default(1) int schemaVersion,
     @Default(<String>[]) List<String> readIds,
     @Default(<String>[]) List<String> dismissedIds,
-    String? lastSeenAppVersion,
-    String? lastAcknowledgedReleaseId,
   }) = _AnnouncementState;
 
   factory AnnouncementState.initial() => const AnnouncementState();

--- a/lib/features/announcements/remote/announcement_remote_service.dart
+++ b/lib/features/announcements/remote/announcement_remote_service.dart
@@ -23,6 +23,13 @@ class AnnouncementRemoteService {
   Map<String, dynamic>? _cachedCatalogPayload;
   final Map<String, Map<String, dynamic>> _pageCache = <String, Map<String, dynamic>>{};
 
+  /// Drop in-memory catalog and page caches so the next fetch hits the
+  /// network.
+  void invalidateCache() {
+    _cachedCatalogPayload = null;
+    _pageCache.clear();
+  }
+
   Future<AnnouncementCatalog?> fetchCatalog() async {
     final endpoint = _resolveEndpoint();
     if (endpoint == null) return null;
@@ -34,7 +41,15 @@ class AnnouncementRemoteService {
         cachedPayload: _cachedCatalogPayload,
       );
       _cachedCatalogPayload = payload;
-      return AnnouncementCatalog.fromJson(payload);
+      final catalog = AnnouncementCatalog.fromJson(payload);
+      if (!catalog.isSupported) {
+        warning(
+          "Unsupported announcement catalog schemaVersion ${catalog.schemaVersion}; "
+          "falling back to bundled entries only",
+        );
+        return null;
+      }
+      return catalog;
     } on Object catch (e, st) {
       warning("Failed to fetch announcement catalog: $e", stackTrace: st);
       return null;
@@ -60,7 +75,7 @@ class AnnouncementRemoteService {
   }
 
   Future<String?> fetchBody(String bodyHash) async {
-    final cached = AnnouncementBodyCache.get(bodyHash);
+    final cached = await AnnouncementBodyCache.get(bodyHash);
     if (cached != null) return cached;
 
     final endpoint = _resolveEndpoint();

--- a/lib/features/announcements/remote/body_cache.dart
+++ b/lib/features/announcements/remote/body_cache.dart
@@ -20,7 +20,7 @@ class AnnouncementBodyCache {
       if (!file.existsSync()) {
         return null;
       }
-      return file.readAsString();
+      return await file.readAsString();
     } on FileSystemException catch (e) {
       warning("Failed to read cached announcement body $bodyHash: $e");
       return null;

--- a/lib/features/announcements/remote/body_cache.dart
+++ b/lib/features/announcements/remote/body_cache.dart
@@ -14,13 +14,13 @@ class AnnouncementBodyCache {
     }
   }
 
-  static String? get(String bodyHash) {
+  static Future<String?> get(String bodyHash) async {
     try {
       final file = File(_filePath(bodyHash));
       if (!file.existsSync()) {
         return null;
       }
-      return file.readAsStringSync();
+      return file.readAsString();
     } on FileSystemException catch (e) {
       warning("Failed to read cached announcement body $bodyHash: $e");
       return null;
@@ -43,6 +43,30 @@ class AnnouncementBodyCache {
       return File(_filePath(bodyHash)).existsSync();
     } on FileSystemException {
       return false;
+    }
+  }
+
+  /// Delete any cached body files whose hashes are not in [referencedHashes].
+  /// Failures are logged and skipped so a single bad file does not abort the
+  /// sweep.
+  static Future<void> prune({required Set<String> referencedHashes}) async {
+    try {
+      final root = Directory(_cacheDir);
+      if (!root.existsSync()) return;
+      final entities = root.listSync(recursive: true);
+      for (final entity in entities) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith(".md")) continue;
+        final fileName = p.basenameWithoutExtension(entity.path);
+        if (referencedHashes.contains(fileName)) continue;
+        try {
+          await entity.delete();
+        } on FileSystemException catch (e) {
+          warning("Failed to prune cached announcement body ${entity.path}: $e");
+        }
+      }
+    } on FileSystemException catch (e) {
+      warning("Failed to list announcement body cache for pruning: $e");
     }
   }
 

--- a/lib/features/announcements/repository/announcement_repository.dart
+++ b/lib/features/announcements/repository/announcement_repository.dart
@@ -1,11 +1,12 @@
+import "dart:async";
 import "dart:convert";
 import "dart:io" show Platform;
 
 import "package:eve_fit_assistant/features/announcements/models/models.dart";
 import "package:eve_fit_assistant/features/announcements/remote/remote.dart";
 import "package:eve_fit_assistant/features/announcements/state/state.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
 import "package:eve_fit_assistant/storage/setting/setting.dart";
-import "package:eve_fit_assistant/utils/fp.dart";
 import "package:eve_fit_assistant/utils/version.dart";
 import "package:flutter/services.dart" show rootBundle;
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -59,6 +60,8 @@ class AnnouncementRepository {
         }
       }
       records.sort((a, b) => b.publishedAt.compareTo(a.publishedAt));
+      _pruneState(records);
+      _pruneBodyCache(records);
       return SyncResult(
         allRecords: records,
         versionAnnouncements: records.where((r) => r.appVersion != null).toList(),
@@ -126,11 +129,20 @@ class AnnouncementRepository {
     // 11. Separate version announcements
     final versionAnnouncements = records.where((r) => r.appVersion != null).toList();
 
+    _pruneState(records);
+    _pruneBodyCache(records);
     return SyncResult(
       allRecords: records,
       versionAnnouncements: versionAnnouncements,
       remoteReachable: true,
     );
+  }
+
+  /// Force the next feed fetch to hit the network by clearing the remote
+  /// service's in-memory caches and invalidating the feed provider.
+  Future<void> refresh() async {
+    _ref.read(announcementRemoteServiceProvider).invalidateCache();
+    _ref.invalidate(announcementFeedProvider);
   }
 
   /// Apply the 5-step client-side filter chain for feed eligibility (spec §9.1).
@@ -188,6 +200,7 @@ class AnnouncementRepository {
   ) {
     final resolved = entry.resolveLocalization(localeCode);
     final loc = resolved?.meta;
+    final stateStore = _ref.read(announcementStateStoreProvider);
     return AnnouncementRecord(
       id: entry.id,
       source: source,
@@ -201,8 +214,9 @@ class AnnouncementRepository {
       minAppVersion: entry.minAppVersion,
       maxAppVersion: entry.maxAppVersion,
       appVersion: entry.appVersion,
-      isRead: AnnouncementStateStore.isRead(entry.id),
-      isDismissed: AnnouncementStateStore.isDismissed(entry.id),
+      isRead: stateStore.isRead(entry.id),
+      isDismissed: stateStore.isDismissed(entry.id),
+      entry: entry,
     );
   }
 
@@ -237,6 +251,16 @@ class AnnouncementRepository {
     } on Object {
       return null;
     }
+  }
+
+  void _pruneState(List<AnnouncementRecord> records) {
+    final activeIds = records.map((r) => r.id).toSet();
+    _ref.read(announcementStateServiceProvider.notifier).pruneStaleIds(activeIds: activeIds);
+  }
+
+  void _pruneBodyCache(List<AnnouncementRecord> records) {
+    final hashes = records.map((r) => r.bodyHash).where((h) => h.isNotEmpty).toSet();
+    unawaited(AnnouncementBodyCache.prune(referencedHashes: hashes));
   }
 }
 
@@ -282,19 +306,29 @@ final unreadAnnouncementCountProvider = Provider<int>((Ref ref) {
   );
 });
 
-/// Startup announcement to show as dialog (first unread, un-dismissed,
-/// startup-flagged entry).
-final startupAnnouncementProvider = FutureProvider<AnnouncementRecord?>((Ref ref) async {
+/// Queue of startup announcements to show as dialogs, in feed order (newest
+/// first). Contains all unread, un-dismissed, startup-flagged entries whose
+/// `appVersion` is either absent or newer than the installed version.
+final startupAnnouncementQueueProvider = FutureProvider<List<AnnouncementRecord>>((Ref ref) async {
   ref.watch(announcementStateServiceProvider);
   final feed = await ref.watch(announcementFeedProvider.future);
   final appVer = await ref.watch(appVersionProvider.future);
-  return feed.firstWhereOrNull(
-    (r) =>
-        r.startup &&
-        !r.isRead &&
-        !r.isDismissed &&
-        (r.appVersion == null || compareVersions(r.appVersion!, appVer) > 0),
-  );
+  return feed
+      .where(
+        (r) =>
+            r.startup &&
+            !r.isRead &&
+            !r.isDismissed &&
+            (r.appVersion == null || compareVersions(r.appVersion!, appVer) > 0),
+      )
+      .toList();
+});
+
+/// Deprecated alias returning the head of the startup queue.
+@Deprecated("Use startupAnnouncementQueueProvider instead")
+final startupAnnouncementProvider = FutureProvider<AnnouncementRecord?>((Ref ref) async {
+  final queue = await ref.watch(startupAnnouncementQueueProvider.future);
+  return queue.firstOrNull;
 });
 
 /// Unread count for version entries specifically.
@@ -320,22 +354,20 @@ final unreadVersionCountProvider = Provider<int>((Ref ref) {
 });
 
 /// Whether the current app version is a newly-installed bump with matching
-/// version entries to show.
-final hasVersionBumpProvider = Provider<bool>((Ref ref) {
+/// version entries that has not yet been acknowledged via either the APK
+/// update flow or the announcement flow.
+final pendingVersionBumpProvider = Provider<bool>((Ref ref) {
   ref.watch(announcementStateServiceProvider);
   final appVer = ref
       .watch(appVersionProvider)
       .when(data: (v) => v, loading: () => null, error: (_, _) => null);
-  final state = ref.read(announcementStateServiceProvider);
-  final lastSeen = state.lastSeenAppVersion;
-  if (appVer == null || appVer == lastSeen) {
-    return false;
-  }
-  final versionFeed = ref.watch(announcementVersionFeedProvider);
-  final records = versionFeed.when(
-    data: (r) => r,
-    loading: () => const <AnnouncementRecord>[],
-    error: (_, _) => const <AnnouncementRecord>[],
-  );
-  return records.any((r) => r.appVersion == appVer);
+  final lastSeen = ref.watch(appVersionStateServiceProvider).lastSeenAppVersion;
+  if (appVer == null || appVer == lastSeen) return false;
+  final feed = ref.watch(announcementVersionFeedProvider).value ?? const [];
+  return feed.any((AnnouncementRecord r) => r.appVersion == appVer);
 });
+
+/// Legacy alias — kept so external consumers keep compiling during the
+/// migration. Prefer [pendingVersionBumpProvider].
+@Deprecated("Use pendingVersionBumpProvider instead")
+final hasVersionBumpProvider = pendingVersionBumpProvider;

--- a/lib/features/announcements/repository/announcement_repository.dart
+++ b/lib/features/announcements/repository/announcement_repository.dart
@@ -15,16 +15,15 @@ import "package:package_info_plus/package_info_plus.dart";
 const String _bundledCatalogAssetPath = "assets/content/announcements/generated/catalog.json";
 const String _bundledDocumentsAssetPath = "assets/content/announcements/generated/documents";
 
-class SyncResult {
-  const SyncResult({
-    required this.allRecords,
-    required this.versionAnnouncements,
-    required this.remoteReachable,
-  });
+/// Network-shaped result of a feed sync: raw entries plus the set of IDs that
+/// came from the remote catalog (so callers can tag records with the right
+/// source). Does NOT carry read/dismiss state — that is attached downstream
+/// by [announcementFeedProvider] so local read toggles never re-run sync.
+class AnnouncementRawFeed {
+  const AnnouncementRawFeed({required this.entries, required this.remoteIds});
 
-  final List<AnnouncementRecord> allRecords;
-  final List<AnnouncementRecord> versionAnnouncements;
-  final bool remoteReachable;
+  final List<AnnouncementEntry> entries;
+  final Set<String> remoteIds;
 }
 
 final announcementRepositoryProvider = Provider<AnnouncementRepository>(
@@ -37,39 +36,37 @@ class AnnouncementRepository {
   final Ref _ref;
 
   /// Perform a full sync: fetch catalog, determine relevant pages,
-  /// fetch those pages, merge with bundled catalog, return all records.
-  Future<SyncResult> sync({
+  /// fetch those pages, merge with bundled catalog, return raw entries.
+  ///
+  /// The result is purely network-shaped — no read/dismiss state is attached,
+  /// and no state pruning side effects fire here. Consumers that need
+  /// [AnnouncementRecord]s with state should use [announcementFeedProvider].
+  Future<AnnouncementRawFeed> sync({
     required String localeCode,
     required String currentChannel,
     required String currentPlatform,
     required String installedVersion,
   }) async {
-    // 1. Load bundled entries (stub for Stage 06)
+    // 1. Load bundled entries.
     final bundledEntries = await _loadBundledEntries();
 
-    // 2. Fetch remote catalog
+    // 2. Fetch remote catalog.
     final remoteService = _ref.read(announcementRemoteServiceProvider);
     final catalog = await remoteService.fetchCatalog();
 
     if (catalog == null) {
-      // Remote unreachable — use bundled only
-      final records = <AnnouncementRecord>[];
+      // Remote unreachable — use bundled only.
+      final entries = <AnnouncementEntry>[];
       for (final entry in bundledEntries) {
         if (_filterEntry(entry, localeCode, currentChannel, currentPlatform, installedVersion)) {
-          records.add(_buildRecord(entry, localeCode, AnnouncementEntrySource.bundled));
+          entries.add(entry);
         }
       }
-      records.sort((a, b) => b.publishedAt.compareTo(a.publishedAt));
-      _pruneState(records);
-      _pruneBodyCache(records);
-      return SyncResult(
-        allRecords: records,
-        versionAnnouncements: records.where((r) => r.appVersion != null).toList(),
-        remoteReachable: false,
-      );
+      entries.sort((a, b) => b.publishedAt.compareTo(a.publishedAt));
+      return AnnouncementRawFeed(entries: entries, remoteIds: const <String>{});
     }
 
-    // 3. Determine relevant pages
+    // 3. Determine relevant closed pages.
     final closedPageUuids = <String>[];
     for (final summary in catalog.pages) {
       if (summary.active) continue;
@@ -78,10 +75,10 @@ class AnnouncementRepository {
       closedPageUuids.add(summary.uuid);
     }
 
-    // 4. Fetch active page
+    // 4. Fetch active page.
     final activePage = await remoteService.fetchPage("", active: true);
 
-    // 5. Fetch closed pages
+    // 5. Fetch closed pages.
     final remoteEntries = <AnnouncementEntry>[];
     if (activePage != null) {
       remoteEntries.addAll(activePage.entries);
@@ -93,19 +90,19 @@ class AnnouncementRepository {
       }
     }
 
-    // 6. Deduplicate remote entries by id (last wins)
+    // 6. Deduplicate remote entries by id (last wins).
     final remoteById = <String, AnnouncementEntry>{};
     for (final entry in remoteEntries) {
       remoteById[entry.id] = entry;
     }
 
-    // 7. Merge bundled with remote (remote overrides bundled)
+    // 7. Merge bundled with remote (remote overrides bundled).
     final mergedEntries = _mergeEntries(
       bundled: bundledEntries,
       remote: remoteById.values.toList(),
     );
 
-    // 8. Apply client-side filters
+    // 8. Apply client-side filters.
     final filtered = <AnnouncementEntry>[];
     for (final entry in mergedEntries) {
       if (_filterEntry(entry, localeCode, currentChannel, currentPlatform, installedVersion)) {
@@ -113,36 +110,10 @@ class AnnouncementRepository {
       }
     }
 
-    // 9. Sort by publishedAt desc
+    // 9. Sort by publishedAt desc.
     filtered.sort((a, b) => b.publishedAt.compareTo(a.publishedAt));
 
-    // 10. Build records with read/dismissed state
-    final remoteIds = remoteById.keys.toSet();
-    final records = <AnnouncementRecord>[];
-    for (final entry in filtered) {
-      final source = remoteIds.contains(entry.id)
-          ? AnnouncementEntrySource.remote
-          : AnnouncementEntrySource.bundled;
-      records.add(_buildRecord(entry, localeCode, source));
-    }
-
-    // 11. Separate version announcements
-    final versionAnnouncements = records.where((r) => r.appVersion != null).toList();
-
-    _pruneState(records);
-    _pruneBodyCache(records);
-    return SyncResult(
-      allRecords: records,
-      versionAnnouncements: versionAnnouncements,
-      remoteReachable: true,
-    );
-  }
-
-  /// Force the next feed fetch to hit the network by clearing the remote
-  /// service's in-memory caches and invalidating the feed provider.
-  Future<void> refresh() async {
-    _ref.read(announcementRemoteServiceProvider).invalidateCache();
-    _ref.invalidate(announcementFeedProvider);
+    return AnnouncementRawFeed(entries: filtered, remoteIds: remoteById.keys.toSet());
   }
 
   /// Apply the 5-step client-side filter chain for feed eligibility (spec §9.1).
@@ -192,34 +163,6 @@ class AnnouncementRepository {
     return byId.values.toList(growable: false);
   }
 
-  /// Build an [AnnouncementRecord] from an entry, resolving locale and attaching state.
-  AnnouncementRecord _buildRecord(
-    AnnouncementEntry entry,
-    String localeCode,
-    AnnouncementEntrySource source,
-  ) {
-    final resolved = entry.resolveLocalization(localeCode);
-    final loc = resolved?.meta;
-    final stateStore = _ref.read(announcementStateStoreProvider);
-    return AnnouncementRecord(
-      id: entry.id,
-      source: source,
-      title: loc?.title ?? "",
-      summary: loc?.summary ?? "",
-      bodyHash: loc?.bodyHash ?? "",
-      publishedAt: entry.publishedAt,
-      localeCode: resolved?.localeCode ?? localeCode,
-      tags: entry.tags,
-      startup: entry.startup,
-      minAppVersion: entry.minAppVersion,
-      maxAppVersion: entry.maxAppVersion,
-      appVersion: entry.appVersion,
-      isRead: stateStore.isRead(entry.id),
-      isDismissed: stateStore.isDismissed(entry.id),
-      entry: entry,
-    );
-  }
-
   /// Load the announcement body for a given hash.
   /// Checks bundled assets first, then falls back to the remote body cache.
   Future<String?> fetchAnnouncementBody(String bodyHash) async {
@@ -252,16 +195,6 @@ class AnnouncementRepository {
       return null;
     }
   }
-
-  void _pruneState(List<AnnouncementRecord> records) {
-    final activeIds = records.map((r) => r.id).toSet();
-    _ref.read(announcementStateServiceProvider.notifier).pruneStaleIds(activeIds: activeIds);
-  }
-
-  void _pruneBodyCache(List<AnnouncementRecord> records) {
-    final hashes = records.map((r) => r.bodyHash).where((h) => h.isNotEmpty).toSet();
-    unawaited(AnnouncementBodyCache.prune(referencedHashes: hashes));
-  }
 }
 
 /// Current installed app version.
@@ -270,24 +203,91 @@ final appVersionProvider = FutureProvider<String>((Ref ref) async {
   return info.version;
 });
 
-/// The full announcement feed (sorted, filtered, merged).
-final announcementFeedProvider = FutureProvider<List<AnnouncementRecord>>((Ref ref) async {
-  ref.watch(announcementStateServiceProvider);
+/// Raw feed — the network layer. Depends only on inputs that change the
+/// network result (locale, settings, installed version). Does NOT depend on
+/// [announcementStateServiceProvider], so toggling read/dismiss state never
+/// re-fires this provider.
+final announcementRawFeedProvider = FutureProvider<AnnouncementRawFeed>((Ref ref) async {
   final locale = ref.watch(localeProvider);
   final setting = ref.watch(appSettingServiceProvider);
   final repo = ref.watch(announcementRepositoryProvider);
 
   final version = await ref.watch(appVersionProvider.future);
 
-  final result = await repo.sync(
+  final raw = await repo.sync(
     localeCode: locale.name,
     currentChannel: setting.remoteContent.channel,
     currentPlatform: Platform.operatingSystem,
     installedVersion: version,
   );
 
-  return result.allRecords;
+  // Prune stale read/dismiss IDs and unused body-cache entries now that we
+  // know the active set. This runs once per sync — NOT on every state toggle.
+  ref
+      .read(announcementStateServiceProvider.notifier)
+      .pruneStaleIds(activeIds: raw.entries.map((e) => e.id).toSet());
+  final referencedHashes = raw.entries
+      .map((e) => e.resolveLocalization(locale.name)?.meta.bodyHash ?? "")
+      .where((h) => h.isNotEmpty)
+      .toSet();
+  unawaited(AnnouncementBodyCache.prune(referencedHashes: referencedHashes));
+
+  return raw;
 });
+
+/// The full announcement feed with read/dismiss state attached.
+///
+/// Re-runs whenever [announcementStateServiceProvider] emits (e.g. on
+/// mark-read / mark-all-read), but re-uses the cached
+/// [announcementRawFeedProvider] future — no network call is made on local
+/// state toggles.
+final announcementFeedProvider = FutureProvider<List<AnnouncementRecord>>((Ref ref) async {
+  ref.watch(announcementStateServiceProvider);
+  final locale = ref.watch(localeProvider);
+  final raw = await ref.watch(announcementRawFeedProvider.future);
+  final stateStore = ref.read(announcementStateStoreProvider);
+
+  return raw.entries.map((entry) {
+    final source = raw.remoteIds.contains(entry.id)
+        ? AnnouncementEntrySource.remote
+        : AnnouncementEntrySource.bundled;
+    return _buildRecord(
+      entry: entry,
+      localeCode: locale.name,
+      source: source,
+      stateStore: stateStore,
+    );
+  }).toList();
+});
+
+/// Build an [AnnouncementRecord] from a raw entry, resolving localization and
+/// attaching read/dismiss state from [stateStore].
+AnnouncementRecord _buildRecord({
+  required AnnouncementEntry entry,
+  required String localeCode,
+  required AnnouncementEntrySource source,
+  required AnnouncementStateStore stateStore,
+}) {
+  final resolved = entry.resolveLocalization(localeCode);
+  final loc = resolved?.meta;
+  return AnnouncementRecord(
+    id: entry.id,
+    source: source,
+    title: loc?.title ?? "",
+    summary: loc?.summary ?? "",
+    bodyHash: loc?.bodyHash ?? "",
+    publishedAt: entry.publishedAt,
+    localeCode: resolved?.localeCode ?? localeCode,
+    tags: entry.tags,
+    startup: entry.startup,
+    minAppVersion: entry.minAppVersion,
+    maxAppVersion: entry.maxAppVersion,
+    appVersion: entry.appVersion,
+    isRead: stateStore.isRead(entry.id),
+    isDismissed: stateStore.isDismissed(entry.id),
+    entry: entry,
+  );
+}
 
 /// Version announcements (entries with appVersion != null).
 final announcementVersionFeedProvider = FutureProvider<List<AnnouncementRecord>>((Ref ref) async {

--- a/lib/features/announcements/startup_announcement_gate.dart
+++ b/lib/features/announcements/startup_announcement_gate.dart
@@ -5,6 +5,7 @@ import "package:eve_fit_assistant/config/logger.dart";
 import "package:eve_fit_assistant/features/announcements/models/models.dart";
 import "package:eve_fit_assistant/features/announcements/repository/repository.dart";
 import "package:eve_fit_assistant/features/announcements/state/state.dart";
+import "package:eve_fit_assistant/pages/announcements/detail_page.dart";
 import "package:eve_fit_assistant/pages/router.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -20,33 +21,47 @@ class StartupAnnouncementGate extends ConsumerStatefulWidget {
 }
 
 class _StartupAnnouncementGateState extends ConsumerState<StartupAnnouncementGate> {
-  bool _didCheck = false;
+  bool _isShowing = false;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_didCheck) return;
-    _didCheck = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      unawaited(_showStartupAnnouncement());
-    });
+  Widget build(BuildContext context) {
+    ref.listen<AsyncValue<List<AnnouncementRecord>>>(
+      startupAnnouncementQueueProvider,
+      (_, next) => next.whenData((queue) {
+        if (queue.isEmpty || _isShowing) return;
+        _isShowing = true;
+        unawaited(_showQueue(queue));
+      }),
+    );
+    return widget.child;
   }
 
-  @override
-  Widget build(BuildContext context) => widget.child;
+  Future<void> _showQueue(List<AnnouncementRecord> queue) async {
+    try {
+      for (final record in queue) {
+        if (!mounted) return;
+        await _showOne(record);
+      }
+    } finally {
+      if (mounted) {
+        _isShowing = false;
+      }
+    }
+  }
 
-  Future<void> _showStartupAnnouncement() async {
-    final record = await _loadStartupAnnouncement();
-    if (!mounted || record == null) return;
+  Future<void> _showOne(AnnouncementRecord record) async {
+    final body = await _loadBody(record);
+    if (!mounted) return;
 
     await showAnnouncementDialog(
       context,
       navigatorKey: widget.appRouter.navigatorKey,
       title: record.title,
-      informationText: record.summary,
+      bodyMarkdown: body,
+      informationText: body == null ? record.summary : null,
       onShowDetail: () async {
         ref.read(announcementStateServiceProvider.notifier).markRead(record.id);
-        await widget.appRouter.push(const AnnouncementFeedRoute());
+        await widget.appRouter.push(AnnouncementFeedRoute(initialRecordId: record.id));
       },
       onPersistPreference: ({required bool dontShowAgain}) {
         ref.read(announcementStateServiceProvider.notifier).markRead(record.id);
@@ -57,11 +72,15 @@ class _StartupAnnouncementGateState extends ConsumerState<StartupAnnouncementGat
     );
   }
 
-  Future<AnnouncementRecord?> _loadStartupAnnouncement() async {
+  Future<String?> _loadBody(AnnouncementRecord record) async {
+    if (record.bodyHash.isEmpty) return null;
     try {
-      return await ref.read(startupAnnouncementProvider.future);
-    } catch (errorValue, stackTrace) {
-      error("Failed to load startup announcement: $errorValue", stackTrace: stackTrace);
+      return await ref.read(announcementBodyProvider(record.bodyHash).future);
+    } on Object catch (errorValue, stackTrace) {
+      warning(
+        "Failed to load startup announcement body ${record.bodyHash}: $errorValue",
+        stackTrace: stackTrace,
+      );
       return null;
     }
   }

--- a/lib/features/announcements/state/announcement_state_notifier.dart
+++ b/lib/features/announcements/state/announcement_state_notifier.dart
@@ -5,43 +5,47 @@ import "package:riverpod_annotation/riverpod_annotation.dart";
 
 part "announcement_state_notifier.g.dart";
 
+/// Singleton store provider. The store is created lazily and must be
+/// initialized via [AnnouncementStateStore.init] before any reads. The
+/// production wiring does this in `initSingletons()` (see init.dart) and
+/// overrides this provider with the initialized instance.
+@riverpodSingleton
+AnnouncementStateStore announcementStateStore(Ref ref) {
+  throw UnimplementedError(
+    "announcementStateStoreProvider must be overridden with an initialized store "
+    "before use. Call AnnouncementStateStore.init() during app startup.",
+  );
+}
+
 @riverpodSingleton
 class AnnouncementStateService extends _$AnnouncementStateService {
   @override
-  AnnouncementState build() => AnnouncementStateStore.state;
+  AnnouncementState build() => ref.watch(announcementStateStoreProvider).state;
 
   void markRead(String id) {
-    AnnouncementStateStore.markRead(id);
-    state = AnnouncementStateStore.state;
+    ref.read(announcementStateStoreProvider).markRead(id);
+    state = ref.read(announcementStateStoreProvider).state;
   }
 
   void markAllRead(Iterable<String> ids) {
-    AnnouncementStateStore.markAllRead(ids);
-    state = AnnouncementStateStore.state;
+    ref.read(announcementStateStoreProvider).markAllRead(ids);
+    state = ref.read(announcementStateStoreProvider).state;
   }
 
   void markUnread(Iterable<String> ids) {
-    AnnouncementStateStore.markUnread(ids);
-    state = AnnouncementStateStore.state;
+    ref.read(announcementStateStoreProvider).markUnread(ids);
+    state = ref.read(announcementStateStoreProvider).state;
   }
 
   void dismiss(String id) {
-    AnnouncementStateStore.dismiss(id);
-    state = AnnouncementStateStore.state;
+    ref.read(announcementStateStoreProvider).dismiss(id);
+    state = ref.read(announcementStateStoreProvider).state;
   }
 
-  void acknowledgeVersion(String version) {
-    AnnouncementStateStore.setLastSeenAppVersion(version);
-    state = AnnouncementStateStore.state;
-  }
-
-  void acknowledgeRelease(String releaseId) {
-    AnnouncementStateStore.acknowledgeRelease(releaseId);
-    state = AnnouncementStateStore.state;
-  }
-
-  void clearReleaseAcknowledgment() {
-    AnnouncementStateStore.clearReleaseAcknowledgment();
-    state = AnnouncementStateStore.state;
+  /// Remove IDs not in [activeIds] from read/dismissed sets. Call after a
+  /// successful feed sync so state stays bounded.
+  void pruneStaleIds({required Set<String> activeIds}) {
+    ref.read(announcementStateStoreProvider).pruneStaleIds(activeIds: activeIds);
+    state = ref.read(announcementStateStoreProvider).state;
   }
 }

--- a/lib/features/announcements/state/announcement_state_store.dart
+++ b/lib/features/announcements/state/announcement_state_store.dart
@@ -1,110 +1,157 @@
+import "dart:async";
 import "dart:convert";
 import "dart:io";
 import "dart:isolate";
 
 import "package:eve_fit_assistant/config/paths.dart";
 import "package:eve_fit_assistant/features/announcements/models/announcement_state.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_store.dart";
 import "package:path/path.dart" as p;
 
+/// Legacy fields extracted from an older `announcement_state.json` that now
+/// live in `AppVersionState`. Returned from [AnnouncementStateStore.init] so
+/// the caller can apply them to the new [AppVersionStateStore].
+typedef AnnouncementStateMigration = ({
+  String? lastSeenAppVersion,
+  String? lastAcknowledgedReleaseId,
+});
+
 class AnnouncementStateStore {
-  AnnouncementStateStore._();
+  AnnouncementStateStore({required String settingsPath})
+    : _filePath = p.join(settingsPath, _fileName),
+      _legacyFilePath = p.join(settingsPath, "document_storage.json");
 
-  static const int _currentVersion = 2;
+  static const int _currentVersion = 3;
   static const String _fileName = "announcement_state.json";
-  static late AnnouncementState _state;
-  static Future<void> _pendingSync = Future<void>.value();
 
-  static File get _file => File(p.join(PathProvider.settingsPath, _fileName));
+  final String _filePath;
+  final String _legacyFilePath;
+  late AnnouncementState _state = AnnouncementState.initial();
+  Future<void> _pendingSync = Future<void>.value();
 
-  static void init() {
-    _state = _readFromDisk();
+  File get _file => File(_filePath);
+
+  /// Load state from disk. Returns a non-null [AnnouncementStateMigration]
+  /// when the on-disk file contained version fields that must be applied to
+  /// the new `AppVersionStateStore` (one-time, in-place migration).
+  Future<AnnouncementStateMigration?> init() async {
+    final filePath = _filePath;
+    final legacyFilePath = _legacyFilePath;
+    final result = await Isolate.run(() => _readFromDisk(filePath, legacyFilePath));
+    _state = result.state;
     _sync();
+    return result.migration;
   }
 
-  static AnnouncementState get state => _state;
+  AnnouncementState get state => _state;
 
-  static bool isRead(String id) => _state.readIds.contains(id);
+  bool isRead(String id) => _state.readIds.contains(id);
 
-  static bool isDismissed(String id) => _state.dismissedIds.contains(id);
+  bool isDismissed(String id) => _state.dismissedIds.contains(id);
 
-  static String? get lastSeenAppVersion => _state.lastSeenAppVersion;
-
-  static String? get lastAcknowledgedReleaseId => _state.lastAcknowledgedReleaseId;
-
-  static void markRead(String id) {
+  void markRead(String id) {
     if (_state.readIds.contains(id)) return;
     _state = _state.copyWith(readIds: [..._state.readIds, id]);
     _sync();
   }
 
-  static void markAllRead(Iterable<String> ids) {
+  void markAllRead(Iterable<String> ids) {
     final newIds = {..._state.readIds, ...ids};
     if (newIds.length == _state.readIds.length) return;
     _state = _state.copyWith(readIds: newIds.toList());
     _sync();
   }
 
-  static void markUnread(Iterable<String> ids) {
+  void markUnread(Iterable<String> ids) {
     final idSet = ids.toSet();
     if (!_state.readIds.any(idSet.contains)) return;
     _state = _state.copyWith(readIds: _state.readIds.where((id) => !idSet.contains(id)).toList());
     _sync();
   }
 
-  static void dismiss(String id) {
+  void dismiss(String id) {
     if (_state.dismissedIds.contains(id)) return;
     _state = _state.copyWith(dismissedIds: [..._state.dismissedIds, id]);
     _sync();
   }
 
-  static void setLastSeenAppVersion(String version) {
-    if (_state.lastSeenAppVersion == version) return;
-    _state = _state.copyWith(lastSeenAppVersion: version);
-    _sync();
-  }
+  Future<void> get ensureSynced => _pendingSync;
 
-  static void acknowledgeRelease(String releaseId) {
-    if (_state.lastAcknowledgedReleaseId == releaseId) return;
-    _state = _state.copyWith(lastAcknowledgedReleaseId: releaseId);
-    _sync();
-  }
-
-  static void clearReleaseAcknowledgment() {
-    if (_state.lastAcknowledgedReleaseId == null) return;
-    _state = _state.copyWith(lastAcknowledgedReleaseId: null);
-    _sync();
-  }
-
-  static Future<void> get ensureSynced => _pendingSync;
-
-  static void replaceState(AnnouncementState newState) {
+  void replaceState(AnnouncementState newState) {
     _state = newState;
     _sync();
   }
 
-  static AnnouncementState _readFromDisk() {
+  /// Remove IDs from `readIds`/`dismissedIds` that are not in [activeIds].
+  /// Called after a feed sync to keep state bounded.
+  void pruneStaleIds({required Set<String> activeIds}) {
+    final prunedRead = _state.readIds.where(activeIds.contains).toList();
+    final prunedDismissed = _state.dismissedIds.where(activeIds.contains).toList();
+    if (prunedRead.length == _state.readIds.length &&
+        prunedDismissed.length == _state.dismissedIds.length) {
+      return;
+    }
+    _state = _state.copyWith(readIds: prunedRead, dismissedIds: prunedDismissed);
+    _sync();
+  }
+
+  static ({AnnouncementState state, AnnouncementStateMigration? migration}) _readFromDisk(
+    String filePath,
+    String legacyFilePath,
+  ) {
     try {
-      if (_file.existsSync()) {
-        final text = _file.readAsStringSync();
+      final file = File(filePath);
+      if (file.existsSync()) {
+        final text = file.readAsStringSync();
         final json = jsonDecode(text) as Map<String, dynamic>;
-        final state = AnnouncementState.fromJson(json);
-        return _migrate(state);
+        return _parseStateJson(json);
       }
 
-      final legacyState = _tryReadLegacyState();
-      if (legacyState != null) {
-        return _migrate(legacyState);
-      }
+      final legacy = _tryReadLegacyState(legacyFilePath);
+      if (legacy != null) return legacy;
 
-      return _migrate(AnnouncementState.initial());
+      return (
+        state: AnnouncementState.initial().copyWith(schemaVersion: _currentVersion),
+        migration: null,
+      );
     } on Object {
-      return _migrate(AnnouncementState.initial());
+      return (
+        state: AnnouncementState.initial().copyWith(schemaVersion: _currentVersion),
+        migration: null,
+      );
     }
   }
 
-  static AnnouncementState? _tryReadLegacyState() {
+  static ({AnnouncementState state, AnnouncementStateMigration? migration}) _parseStateJson(
+    Map<String, dynamic> json,
+  ) {
+    final readIds =
+        (json["readIds"] as List<dynamic>?)?.map((e) => e as String).toList() ?? <String>[];
+    final dismissedIds =
+        (json["dismissedIds"] as List<dynamic>?)?.map((e) => e as String).toList() ?? <String>[];
+    final lastSeenAppVersion = json["lastSeenAppVersion"] as String?;
+    final lastAcknowledgedReleaseId = json["lastAcknowledgedReleaseId"] as String?;
+
+    final migration = (lastSeenAppVersion == null && lastAcknowledgedReleaseId == null)
+        ? null
+        : (
+            lastSeenAppVersion: lastSeenAppVersion,
+            lastAcknowledgedReleaseId: lastAcknowledgedReleaseId,
+          );
+
+    final state = AnnouncementState(
+      schemaVersion: _currentVersion,
+      readIds: readIds,
+      dismissedIds: dismissedIds,
+    );
+    return (state: state, migration: migration);
+  }
+
+  static ({AnnouncementState state, AnnouncementStateMigration? migration})? _tryReadLegacyState(
+    String legacyFilePath,
+  ) {
     try {
-      final legacyFile = File(p.join(PathProvider.settingsPath, "document_storage.json"));
+      final legacyFile = File(legacyFilePath);
       if (!legacyFile.existsSync()) return null;
 
       final text = legacyFile.readAsStringSync();
@@ -118,20 +165,21 @@ class AnnouncementStateStore {
 
       final lastSeenAppVersion = json["lastSeenAppVersion"] as String?;
 
-      return AnnouncementState(
+      final state = AnnouncementState(
+        schemaVersion: _currentVersion,
         readIds: readIds,
         dismissedIds: dismissedIds,
-        lastSeenAppVersion: lastSeenAppVersion,
       );
+      final migration = lastSeenAppVersion == null
+          ? null
+          : (lastSeenAppVersion: lastSeenAppVersion, lastAcknowledgedReleaseId: null);
+      return (state: state, migration: migration);
     } on Object {
       return null;
     }
   }
 
-  static AnnouncementState _migrate(AnnouncementState old) =>
-      old.copyWith(schemaVersion: _currentVersion);
-
-  static void _sync() {
+  void _sync() {
     final filePath = _file.path;
     final state = _state;
     _pendingSync = _pendingSync
@@ -148,3 +196,6 @@ class AnnouncementStateStore {
     file.writeAsStringSync(text);
   }
 }
+
+/// Default settings-path resolver used by `announcementStateStoreProvider`.
+String defaultAnnouncementStateSettingsPath() => PathProvider.settingsPath;

--- a/lib/features/app_update/app_update_gate.dart
+++ b/lib/features/app_update/app_update_gate.dart
@@ -1,9 +1,9 @@
 import "dart:async";
 
 import "package:eve_fit_assistant/components/dialog/dialog.dart";
-import "package:eve_fit_assistant/features/announcements/state/announcement_state_notifier.dart";
 import "package:eve_fit_assistant/features/app_update/app_update_status.dart";
 import "package:eve_fit_assistant/features/app_update/providers.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
 import "package:eve_fit_assistant/storage/repo/models/remote_app_release.dart";
 import "package:eve_fit_assistant/storage/repo/providers.dart";
 import "package:eve_fit_assistant/utils/context.dart";
@@ -56,6 +56,10 @@ class _AppReleaseUpdateGateState extends ConsumerState<AppReleaseUpdateGate> {
     );
 
     if (mounted) {
+      // Acknowledging the APK update dialog (or completing the install) also
+      // counts as having "seen" this app version, which suppresses the
+      // workspace version-bump card for the same release.
+      ref.read(appVersionStateServiceProvider.notifier).acknowledgeVersion(release.version);
       _shownReleaseId = release.releaseId;
       _isShowing = false;
     }
@@ -140,9 +144,7 @@ class AppReleaseUpdateDialog extends ConsumerWidget {
       AppUpdateStatusIdle() => [
         TextButton(
           onPressed: () {
-            ref
-                .read(announcementStateServiceProvider.notifier)
-                .acknowledgeRelease(release.releaseId);
+            ref.read(appVersionStateServiceProvider.notifier).acknowledgeRelease(release.releaseId);
             Navigator.of(context).pop();
           },
           child: Text(context.l10n.appReleaseUpdateAcknowledge),
@@ -171,9 +173,7 @@ class AppReleaseUpdateDialog extends ConsumerWidget {
       AppUpdateStatusFailed(:final canRetry) => [
         TextButton(
           onPressed: () {
-            ref
-                .read(announcementStateServiceProvider.notifier)
-                .acknowledgeRelease(release.releaseId);
+            ref.read(appVersionStateServiceProvider.notifier).acknowledgeRelease(release.releaseId);
             Navigator.of(context).pop();
           },
           child: Text(context.l10n.appReleaseUpdateAcknowledge),

--- a/lib/features/app_update/models/app_version_state.dart
+++ b/lib/features/app_update/models/app_version_state.dart
@@ -1,0 +1,17 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "app_version_state.freezed.dart";
+part "app_version_state.g.dart";
+
+@freezed
+abstract class AppVersionState with _$AppVersionState {
+  const factory AppVersionState({
+    @Default(1) int schemaVersion,
+    String? lastSeenAppVersion,
+    String? lastAcknowledgedReleaseId,
+  }) = _AppVersionState;
+
+  factory AppVersionState.initial() => const AppVersionState();
+
+  factory AppVersionState.fromJson(Map<String, dynamic> json) => _$AppVersionStateFromJson(json);
+}

--- a/lib/features/app_update/state/app_version_state_notifier.dart
+++ b/lib/features/app_update/state/app_version_state_notifier.dart
@@ -1,0 +1,37 @@
+import "package:eve_fit_assistant/features/app_update/models/app_version_state.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_store.dart";
+import "package:eve_fit_assistant/utils/riverpod.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+part "app_version_state_notifier.g.dart";
+
+/// Singleton store provider. The store is created lazily on first read and
+/// initialized during app startup (see init.dart).
+@riverpodSingleton
+AppVersionStateStore appVersionStateStore(Ref ref) {
+  throw UnimplementedError(
+    "appVersionStateStoreProvider must be overridden with an initialized store "
+    "before use. Call AppVersionStateStore.init() during app startup.",
+  );
+}
+
+@riverpodSingleton
+class AppVersionStateService extends _$AppVersionStateService {
+  @override
+  AppVersionState build() => ref.watch(appVersionStateStoreProvider).state;
+
+  void acknowledgeVersion(String version) {
+    ref.read(appVersionStateStoreProvider).setLastSeenAppVersion(version);
+    state = ref.read(appVersionStateStoreProvider).state;
+  }
+
+  void acknowledgeRelease(String releaseId) {
+    ref.read(appVersionStateStoreProvider).acknowledgeRelease(releaseId);
+    state = ref.read(appVersionStateStoreProvider).state;
+  }
+
+  void clearReleaseAcknowledgment() {
+    ref.read(appVersionStateStoreProvider).clearReleaseAcknowledgment();
+    state = ref.read(appVersionStateStoreProvider).state;
+  }
+}

--- a/lib/features/app_update/state/app_version_state_store.dart
+++ b/lib/features/app_update/state/app_version_state_store.dart
@@ -1,0 +1,93 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+import "dart:isolate";
+
+import "package:eve_fit_assistant/features/app_update/models/app_version_state.dart";
+import "package:path/path.dart" as p;
+
+class AppVersionStateStore {
+  AppVersionStateStore({required String settingsPath})
+    : _filePath = p.join(settingsPath, _fileName);
+
+  static const int _currentVersion = 1;
+  static const String _fileName = "app_version_state.json";
+
+  final String _filePath;
+  late AppVersionState _state = AppVersionState.initial();
+  Future<void> _pendingSync = Future<void>.value();
+
+  File get _file => File(_filePath);
+
+  Future<void> init() async {
+    final filePath = _filePath;
+    _state = await Isolate.run(() => _readFromDisk(filePath));
+    _sync();
+  }
+
+  AppVersionState get state => _state;
+
+  String? get lastSeenAppVersion => _state.lastSeenAppVersion;
+
+  String? get lastAcknowledgedReleaseId => _state.lastAcknowledgedReleaseId;
+
+  void setLastSeenAppVersion(String version) {
+    if (_state.lastSeenAppVersion == version) return;
+    _state = _state.copyWith(lastSeenAppVersion: version);
+    _sync();
+  }
+
+  void acknowledgeRelease(String releaseId) {
+    if (_state.lastAcknowledgedReleaseId == releaseId) return;
+    _state = _state.copyWith(lastAcknowledgedReleaseId: releaseId);
+    _sync();
+  }
+
+  void clearReleaseAcknowledgment() {
+    if (_state.lastAcknowledgedReleaseId == null) return;
+    _state = _state.copyWith(lastAcknowledgedReleaseId: null);
+    _sync();
+  }
+
+  Future<void> get ensureSynced => _pendingSync;
+
+  void replaceState(AppVersionState newState) {
+    _state = newState;
+    _sync();
+  }
+
+  static AppVersionState _readFromDisk(String filePath) {
+    try {
+      final file = File(filePath);
+      if (file.existsSync()) {
+        final text = file.readAsStringSync();
+        final json = jsonDecode(text) as Map<String, dynamic>;
+        final state = AppVersionState.fromJson(json);
+        return _migrate(state);
+      }
+      return _migrate(AppVersionState.initial());
+    } on Object {
+      return _migrate(AppVersionState.initial());
+    }
+  }
+
+  static AppVersionState _migrate(AppVersionState old) =>
+      old.copyWith(schemaVersion: _currentVersion);
+
+  void _sync() {
+    final filePath = _file.path;
+    final state = _state;
+    _pendingSync = _pendingSync
+        .catchError((Object _, StackTrace _) {})
+        .then((_) => Isolate.run(() => _syncToDisk(filePath, state)));
+  }
+
+  static void _syncToDisk(String filePath, AppVersionState state) {
+    final file = File(filePath);
+    final text = jsonEncode(state.toJson());
+    if (!file.existsSync()) {
+      file.createSync(recursive: true);
+    }
+    file.writeAsStringSync(text);
+  }
+}

--- a/lib/init.dart
+++ b/lib/init.dart
@@ -9,6 +9,8 @@ import "package:eve_fit_assistant/config/paths.dart";
 import "package:eve_fit_assistant/features/announcements/remote/body_cache.dart";
 import "package:eve_fit_assistant/features/announcements/repository/repository.dart";
 import "package:eve_fit_assistant/features/announcements/state/announcement_state_store.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_store.dart";
 import "package:eve_fit_assistant/features/feedback/feedback_state_store.dart";
 import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
 import "package:eve_fit_assistant/native/frb_generated.dart";
@@ -22,12 +24,41 @@ import "package:flutter_easyloading/flutter_easyloading.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:fluttertoast/fluttertoast.dart";
 
-Future<void> initSingletons() async {
+/// Holds the initialized state stores so callers can build ProviderScope
+/// overrides from them.
+class InitializedStores {
+  const InitializedStores({
+    required this.announcementStateStore,
+    required this.appVersionStateStore,
+  });
+
+  final AnnouncementStateStore announcementStateStore;
+  final AppVersionStateStore appVersionStateStore;
+}
+
+Future<InitializedStores> initSingletons() async {
   WidgetsFlutterBinding.ensureInitialized();
   await RustLib.init();
   await PathProvider.init();
   AppSettingService.init();
-  AnnouncementStateStore.init();
+
+  final announcementStateStore = AnnouncementStateStore(settingsPath: PathProvider.settingsPath);
+  final migration = await announcementStateStore.init();
+
+  final appVersionStateStore = AppVersionStateStore(settingsPath: PathProvider.settingsPath);
+  await appVersionStateStore.init();
+  if (migration != null) {
+    final lastSeen = migration.lastSeenAppVersion;
+    if (lastSeen != null && appVersionStateStore.lastSeenAppVersion == null) {
+      appVersionStateStore.setLastSeenAppVersion(lastSeen);
+    }
+    final lastAck = migration.lastAcknowledgedReleaseId;
+    if (lastAck != null && appVersionStateStore.lastAcknowledgedReleaseId == null) {
+      appVersionStateStore.acknowledgeRelease(lastAck);
+    }
+    await appVersionStateStore.ensureSynced;
+  }
+
   FeedbackStateStore.init();
   await AnnouncementBodyCache.init();
   EtagCache.init();
@@ -38,6 +69,10 @@ Future<void> initSingletons() async {
   initErrorBoundary();
   await repairStartupPersistence();
   GlobalLoading.init();
+  return InitializedStores(
+    announcementStateStore: announcementStateStore,
+    appVersionStateStore: appVersionStateStore,
+  );
 }
 
 Widget initBuilder(BuildContext context, Widget? child) =>
@@ -78,8 +113,9 @@ Future<void> _initVersionTracking(WidgetRef ref) async {
 
   try {
     final appVersion = await completer.future.timeout(const Duration(milliseconds: 500));
-    if (AnnouncementStateStore.lastSeenAppVersion != null) return;
-    AnnouncementStateStore.setLastSeenAppVersion(appVersion);
+    final store = ref.read(appVersionStateStoreProvider);
+    if (store.lastSeenAppVersion != null) return;
+    store.setLastSeenAppVersion(appVersion);
   } on TimeoutException {
     // Provider didn't resolve in time
   } catch (_) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,8 @@ import "dart:async";
 import "package:eve_fit_assistant/constant/colors.dart";
 import "package:eve_fit_assistant/data/l10n/app_localizations.dart";
 import "package:eve_fit_assistant/features/announcements/announcements.dart";
+import "package:eve_fit_assistant/features/announcements/state/announcement_state_notifier.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
 import "package:eve_fit_assistant/features/feedback/feedback.dart";
 import "package:eve_fit_assistant/features/schema_guard/schema_guard.dart";
 import "package:eve_fit_assistant/features/welcome/welcome_gate.dart";
@@ -15,8 +17,16 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 void main() async {
-  await initSingletons();
-  runApp(const ProviderScope(child: MyApp()));
+  final stores = await initSingletons();
+  runApp(
+    ProviderScope(
+      overrides: [
+        announcementStateStoreProvider.overrideWithValue(stores.announcementStateStore),
+        appVersionStateStoreProvider.overrideWithValue(stores.appVersionStateStore),
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends ConsumerWidget {

--- a/lib/pages/announcements/detail_page.dart
+++ b/lib/pages/announcements/detail_page.dart
@@ -14,7 +14,7 @@ final announcementBodyProvider = FutureProvider.family<String?, String>((
   String bodyHash,
 ) async {
   if (bodyHash.isEmpty) return null;
-  final cached = AnnouncementBodyCache.get(bodyHash);
+  final cached = await AnnouncementBodyCache.get(bodyHash);
   if (cached != null) return cached;
 
   final repo = ref.read(announcementRepositoryProvider);

--- a/lib/pages/announcements/feed_page.dart
+++ b/lib/pages/announcements/feed_page.dart
@@ -1,5 +1,6 @@
 import "package:auto_route/annotations.dart";
 import "package:eve_fit_assistant/features/announcements/models/models.dart";
+import "package:eve_fit_assistant/features/announcements/remote/remote.dart";
 import "package:eve_fit_assistant/features/announcements/repository/repository.dart";
 import "package:eve_fit_assistant/features/announcements/state/state.dart";
 import "package:eve_fit_assistant/pages/announcements/detail_page.dart";
@@ -13,21 +14,26 @@ import "package:intl/intl.dart";
 
 @RoutePage()
 class AnnouncementFeedPage extends StatelessWidget {
-  const AnnouncementFeedPage({super.key});
+  const AnnouncementFeedPage({super.key, this.initialRecordId});
+
+  /// Optional record ID to pre-select when the page first loads.
+  final String? initialRecordId;
 
   @override
-  Widget build(BuildContext context) => const _AnnouncementHubPage();
+  Widget build(BuildContext context) => _AnnouncementHubPage(initialRecordId: initialRecordId);
 }
 
 class _AnnouncementHubPage extends ConsumerStatefulWidget {
-  const _AnnouncementHubPage();
+  const _AnnouncementHubPage({this.initialRecordId});
+
+  final String? initialRecordId;
 
   @override
   ConsumerState<_AnnouncementHubPage> createState() => _AnnouncementHubPageState();
 }
 
 class _AnnouncementHubPageState extends ConsumerState<_AnnouncementHubPage> {
-  String? _selectedRecordId;
+  late String? _selectedRecordId = widget.initialRecordId;
 
   bool _useSplitLayout(BuildContext context) => supportsThreePaneLayout(context);
 
@@ -79,10 +85,13 @@ class _AnnouncementHubPageState extends ConsumerState<_AnnouncementHubPage> {
                     children: [
                       _buildActionBar(context, records),
                       Expanded(
-                        child: _AnnouncementListPane(
-                          records: records,
-                          selectedRecordId: selectedRecord?.id,
-                          onSelect: _selectRecord,
+                        child: RefreshIndicator(
+                          onRefresh: _refreshFeed,
+                          child: _AnnouncementListPane(
+                            records: records,
+                            selectedRecordId: selectedRecord?.id,
+                            onSelect: _selectRecord,
+                          ),
                         ),
                       ),
                     ],
@@ -99,10 +108,13 @@ class _AnnouncementHubPageState extends ConsumerState<_AnnouncementHubPage> {
               children: [
                 _buildActionBar(context, records),
                 Expanded(
-                  child: _AnnouncementListPane(
-                    records: records,
-                    selectedRecordId: null,
-                    onSelect: _selectRecord,
+                  child: RefreshIndicator(
+                    onRefresh: _refreshFeed,
+                    child: _AnnouncementListPane(
+                      records: records,
+                      selectedRecordId: null,
+                      onSelect: _selectRecord,
+                    ),
                   ),
                 ),
               ],
@@ -131,6 +143,15 @@ class _AnnouncementHubPageState extends ConsumerState<_AnnouncementHubPage> {
         ),
       ),
     );
+  }
+
+  Future<void> _refreshFeed() async {
+    ref.read(announcementRemoteServiceProvider).invalidateCache();
+    ref.invalidate(announcementFeedProvider);
+    // Wait for the next feed resolution so the indicator dismisses once data
+    // is available again. Errors are intentionally swallowed — the provider
+    // will surface them via its AsyncValue.
+    await ref.read(announcementFeedProvider.future).then((_) => null).catchError((Object _) {});
   }
 
   String _appBarTitle(BuildContext context, List<AnnouncementRecord>? records, bool splitLayout) {
@@ -198,6 +219,7 @@ class _AnnouncementListPane extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => ListView.builder(
+    physics: const AlwaysScrollableScrollPhysics(),
     padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
     itemCount: records.length,
     itemBuilder: (context, index) {

--- a/lib/pages/announcements/feed_page.dart
+++ b/lib/pages/announcements/feed_page.dart
@@ -146,8 +146,11 @@ class _AnnouncementHubPageState extends ConsumerState<_AnnouncementHubPage> {
   }
 
   Future<void> _refreshFeed() async {
+    // Clear the remote service's in-memory cache so the next fetch hits the
+    // network, then invalidate the raw feed provider. The derived feed
+    // provider re-runs as a consequence.
     ref.read(announcementRemoteServiceProvider).invalidateCache();
-    ref.invalidate(announcementFeedProvider);
+    ref.invalidate(announcementRawFeedProvider);
     // Wait for the next feed resolution so the indicator dismisses once data
     // is available again. Errors are intentionally swallowed — the provider
     // will surface them via its AsyncValue.

--- a/lib/pages/setting/developer/page.dart
+++ b/lib/pages/setting/developer/page.dart
@@ -5,7 +5,7 @@ import "package:eve_fit_assistant/components/dialog/confirm_dialog.dart";
 import "package:eve_fit_assistant/components/dialog/info_dialog.dart";
 import "package:eve_fit_assistant/components/layout.dart";
 import "package:eve_fit_assistant/components/list/config_list.dart";
-import "package:eve_fit_assistant/features/announcements/state/announcement_state_notifier.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
 import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
 import "package:eve_fit_assistant/pages/router.dart";
 import "package:eve_fit_assistant/storage/repo/providers.dart";
@@ -90,7 +90,7 @@ Future<void> _clearCache(BuildContext context) async {
 }
 
 Future<void> _clearUpdateAcknowledgment(BuildContext context, WidgetRef ref) async {
-  ref.read(announcementStateServiceProvider.notifier).clearReleaseAcknowledgment();
+  ref.read(appVersionStateServiceProvider.notifier).clearReleaseAcknowledgment();
   ref.invalidate(availableAppReleaseProvider);
   if (!context.mounted) return;
   ScaffoldMessenger.of(

--- a/lib/pages/setting/version/page.dart
+++ b/lib/pages/setting/version/page.dart
@@ -207,7 +207,7 @@ class _VersionPageState extends ConsumerState<VersionPage> {
               const SizedBox(height: 24),
               _ReleaseNotesCard(
                 unreadCount: unreadCount,
-                onTap: () => unawaited(context.router.push(const AnnouncementFeedRoute())),
+                onTap: () => unawaited(context.router.push(AnnouncementFeedRoute())),
               ),
             ],
           );

--- a/lib/pages/workspace/page.dart
+++ b/lib/pages/workspace/page.dart
@@ -4,7 +4,7 @@ import "package:auto_route/auto_route.dart";
 import "package:eve_fit_assistant/components/badge/notification_dot.dart";
 import "package:eve_fit_assistant/components/card/homepage_link_card.dart";
 import "package:eve_fit_assistant/features/announcements/repository/repository.dart";
-import "package:eve_fit_assistant/features/announcements/state/state.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
 import "package:eve_fit_assistant/pages/router.dart";
 import "package:eve_fit_assistant/pages/workspace/data_update_banner.dart";
 import "package:eve_fit_assistant/utils/context.dart";
@@ -39,7 +39,7 @@ class WorkspacePage extends ConsumerWidget {
       _WorkspaceShortcutItem(
         title: context.l10n.workspaceTabAnnouncementTitle,
         icon: Icons.campaign_outlined,
-        onTap: () => context.router.push(const AnnouncementFeedRoute()),
+        onTap: () => context.router.push(AnnouncementFeedRoute()),
       ),
       _WorkspaceShortcutItem(
         title: context.l10n.workspaceTabReportTitle,
@@ -81,7 +81,7 @@ class WorkspacePage extends ConsumerWidget {
       ),
     );
 
-    final hasVersionBump = ref.watch(hasVersionBumpProvider);
+    final hasVersionBump = ref.watch(pendingVersionBumpProvider);
 
     return Column(
       children: [
@@ -103,8 +103,8 @@ class WorkspacePage extends ConsumerWidget {
       color: Theme.of(context).colorScheme.primaryContainer,
       child: InkWell(
         onTap: () {
-          ref.read(announcementStateServiceProvider.notifier).acknowledgeVersion(appVersion);
-          unawaited(context.router.push(const AnnouncementFeedRoute()));
+          ref.read(appVersionStateServiceProvider.notifier).acknowledgeVersion(appVersion);
+          unawaited(context.router.push(AnnouncementFeedRoute()));
         },
         borderRadius: BorderRadius.circular(12),
         child: Padding(
@@ -138,9 +138,7 @@ class WorkspacePage extends ConsumerWidget {
                 icon: const Icon(Icons.close),
                 tooltip: context.l10n.versionBumpCardCloseTooltip,
                 onPressed: () {
-                  ref
-                      .read(announcementStateServiceProvider.notifier)
-                      .acknowledgeVersion(appVersion);
+                  ref.read(appVersionStateServiceProvider.notifier).acknowledgeVersion(appVersion);
                 },
               ),
             ],

--- a/lib/storage/repo/providers.dart
+++ b/lib/storage/repo/providers.dart
@@ -3,7 +3,7 @@ import "dart:io";
 
 import "package:dio/dio.dart";
 import "package:eve_fit_assistant/config/logger.dart";
-import "package:eve_fit_assistant/features/announcements/state/state.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
 import "package:eve_fit_assistant/features/remote_content/channel.dart";
 import "package:eve_fit_assistant/features/remote_content/dio_factory.dart";
 import "package:eve_fit_assistant/features/schema_guard/schema_guard.dart" show SchemaGuard;
@@ -603,7 +603,7 @@ Future<Option<RemoteAppRelease>> availableAppRelease(Ref ref) async {
   final releaseValue = release.toNullable();
   if (releaseValue == null) return const None();
 
-  final acknowledgedId = AnnouncementStateStore.lastAcknowledgedReleaseId;
+  final acknowledgedId = ref.read(appVersionStateStoreProvider).lastAcknowledgedReleaseId;
   if (releaseValue.releaseId == acknowledgedId) return const None();
 
   return release;

--- a/test/features/announcements/models/announcement_state_test.dart
+++ b/test/features/announcements/models/announcement_state_test.dart
@@ -1,6 +1,7 @@
 import "dart:convert";
 
 import "package:eve_fit_assistant/features/announcements/models/announcement_state.dart";
+import "package:eve_fit_assistant/features/app_update/models/app_version_state.dart";
 import "package:flutter_test/flutter_test.dart";
 
 void main() {
@@ -10,7 +11,6 @@ void main() {
       expect(state.schemaVersion, 1);
       expect(state.readIds, isEmpty);
       expect(state.dismissedIds, isEmpty);
-      expect(state.lastSeenAppVersion, isNull);
     });
 
     test("JSON round-trip initial state", () {
@@ -28,7 +28,6 @@ void main() {
         schemaVersion: 1,
         readIds: ["entry-1", "entry-2"],
         dismissedIds: ["entry-3"],
-        lastSeenAppVersion: "2.0.0",
       );
       final restored = AnnouncementState.fromJson(
         jsonDecode(jsonEncode(state.toJson())) as Map<String, dynamic>,
@@ -36,7 +35,6 @@ void main() {
       expect(restored, state);
       expect(restored.readIds, ["entry-1", "entry-2"]);
       expect(restored.dismissedIds, ["entry-3"]);
-      expect(restored.lastSeenAppVersion, "2.0.0");
     });
 
     test("deserialize from spec example announcement_state.json", () {
@@ -44,14 +42,35 @@ void main() {
           "{"
           '  "schemaVersion": 1,'
           '  "readIds": ["maintenance-2026-06"],'
-          '  "dismissedIds": [],'
-          '  "lastSeenAppVersion": "2.0.0"'
+          '  "dismissedIds": []'
           "}";
       final state = AnnouncementState.fromJson(jsonDecode(jsonStr) as Map<String, dynamic>);
       expect(state.schemaVersion, 1);
       expect(state.readIds, ["maintenance-2026-06"]);
       expect(state.dismissedIds, isEmpty);
-      expect(state.lastSeenAppVersion, "2.0.0");
+    });
+  });
+
+  group("AppVersionState", () {
+    test("initial factory produces defaults", () {
+      final state = AppVersionState.initial();
+      expect(state.schemaVersion, 1);
+      expect(state.lastSeenAppVersion, isNull);
+      expect(state.lastAcknowledgedReleaseId, isNull);
+    });
+
+    test("JSON round-trip with data", () {
+      const state = AppVersionState(
+        schemaVersion: 1,
+        lastSeenAppVersion: "2.0.0",
+        lastAcknowledgedReleaseId: "release-123",
+      );
+      final restored = AppVersionState.fromJson(
+        jsonDecode(jsonEncode(state.toJson())) as Map<String, dynamic>,
+      );
+      expect(restored, state);
+      expect(restored.lastSeenAppVersion, "2.0.0");
+      expect(restored.lastAcknowledgedReleaseId, "release-123");
     });
   });
 }

--- a/test/features/announcements/models/json_roundtrip_test.dart
+++ b/test/features/announcements/models/json_roundtrip_test.dart
@@ -137,7 +137,6 @@ void main() {
         schemaVersion: 1,
         readIds: ["a", "b", "c"],
         dismissedIds: ["x"],
-        lastSeenAppVersion: "3.0.0",
       );
       final restored = AnnouncementState.fromJson(
         jsonDecode(jsonEncode(state.toJson())) as Map<String, dynamic>,
@@ -186,7 +185,38 @@ void main() {
       );
       expect(record.source, AnnouncementEntrySource.bundled);
       expect(record.isRead, isTrue);
-      expect(record.isDismissed, isFalse);
+    });
+
+    test("AnnouncementRecord retains entry reference", () {
+      final entry = AnnouncementEntry(
+        id: "entry-1",
+        publishedAt: DateTime.utc(2026, 1, 1),
+        tags: ["news"],
+        startup: true,
+        channels: ["stable"],
+        platforms: ["android"],
+        appVersion: "2.0.0",
+        localizations: {
+          "en": LocalizationMeta(title: "Title", summary: "Summary", bodyHash: "hash"),
+        },
+      );
+      final record = AnnouncementRecord(
+        id: entry.id,
+        source: AnnouncementEntrySource.remote,
+        title: "Title",
+        summary: "Summary",
+        bodyHash: "hash",
+        publishedAt: entry.publishedAt,
+        localeCode: "en",
+        tags: entry.tags,
+        startup: entry.startup,
+        appVersion: entry.appVersion,
+        entry: entry,
+      );
+      expect(record.entry, entry);
+      expect(record.entry!.channels, ["stable"]);
+      expect(record.entry!.platforms, ["android"]);
+      expect(record.entry!.localizations["en"]!.title, "Title");
     });
   });
 }

--- a/test/features/announcements/remote/announcement_remote_service_test.dart
+++ b/test/features/announcements/remote/announcement_remote_service_test.dart
@@ -7,6 +7,7 @@ import "package:eve_fit_assistant/config/paths.dart";
 import "package:eve_fit_assistant/config/type_list.dart";
 import "package:eve_fit_assistant/features/announcements/remote/announcement_remote_service.dart";
 import "package:eve_fit_assistant/features/announcements/remote/body_cache.dart";
+import "package:eve_fit_assistant/features/remote_content/endpoint.dart";
 import "package:eve_fit_assistant/features/remote_content/etag_cache.dart";
 import "package:eve_fit_assistant/storage/setting/setting.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -95,6 +96,60 @@ class _SuccessAdapter implements HttpClientAdapter {
         "etag": ['"test-etag"'],
       },
     );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// Adapter that honors conditional requests: answers 304 when the client
+/// sends a matching `If-None-Match` header and 200 otherwise. Tracks how many
+/// times each resource was fetched so tests can assert whether a request
+/// actually reached the network.
+class _ConditionalAdapter implements HttpClientAdapter {
+  static const String etag = '"test-etag"';
+
+  int catalogFetchCount = 0;
+  int pageFetchCount = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final path = options.uri.path;
+    final String body;
+    if (path.endsWith("/catalog.json")) {
+      catalogFetchCount++;
+      body = _sampleCatalogJson;
+    } else if (path == "/efa/v2/announcements/active.json" ||
+        path.startsWith("/efa/v2/announcements/pages/")) {
+      pageFetchCount++;
+      body = _samplePageJson;
+    } else {
+      return ResponseBody.fromString("", 404);
+    }
+    if (_ifNoneMatch(options) == etag) {
+      return ResponseBody.fromString("", 304);
+    }
+    return ResponseBody.fromString(
+      body,
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+        "etag": [etag],
+      },
+    );
+  }
+
+  static String? _ifNoneMatch(RequestOptions options) {
+    for (final MapEntry<String, dynamic> entry in options.headers.entries) {
+      if (entry.key.toLowerCase() == "if-none-match") {
+        return entry.value?.toString();
+      }
+    }
+    return null;
   }
 
   @override
@@ -249,21 +304,54 @@ void main() {
     });
 
     test("invalidateCache clears catalog and page caches", () async {
-      final dio = Dio(BaseOptions())..httpClientAdapter = _SuccessAdapter();
+      final adapter = _ConditionalAdapter();
+      final dio = Dio(BaseOptions())..httpClientAdapter = adapter;
       final container = _createContainer(dio: dio);
       final service = container.read(announcementRemoteServiceProvider);
 
-      // First fetch populates the in-memory cache.
-      await service.fetchCatalog();
-      await service.fetchPage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+      const pageUuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
-      // After invalidation, the next fetch should still succeed (hits network
-      // again rather than returning stale in-memory data).
+      // Start from a clean persisted cache so the test is deterministic
+      // regardless of entries left behind by earlier tests.
+      EtagCache.clearAll();
+
+      // First fetch populates the in-memory caches and the persisted ETag
+      // entries.
+      expect(await service.fetchCatalog(), isNotNull);
+      expect(await service.fetchPage(pageUuid), isNotNull);
+      expect(adapter.catalogFetchCount, 1);
+      expect(adapter.pageFetchCount, 1);
+
+      // A second fetch sends conditional headers and is answered 304; the
+      // in-memory caches satisfy it with exactly one network call each.
+      expect(await service.fetchCatalog(), isNotNull);
+      expect(await service.fetchPage(pageUuid), isNotNull);
+      expect(adapter.catalogFetchCount, 2);
+      expect(adapter.pageFetchCount, 2);
+
+      // Drop the persisted payloads so only the service's in-memory caches
+      // could satisfy a 304; keep the ETags so requests stay conditional.
+      final endpoint = RemoteContentEndpoint(
+        originUri: Uri.parse(_defaultOriginUrl),
+        channel: _defaultChannel,
+      );
+      EtagCache.clearAll();
+      EtagCache.update(endpoint.announcementV2CatalogUri, etag: _ConditionalAdapter.etag);
+      EtagCache.update(endpoint.announcementV2PageUri(pageUuid), etag: _ConditionalAdapter.etag);
+
       service.invalidateCache();
+
+      // With the in-memory caches cleared, each 304 has no payload to fall
+      // back to, forcing an unconditional retry: two additional network
+      // calls per resource instead of one. If invalidateCache() failed to
+      // clear a cache, the stale payload would answer the 304 and the count
+      // would be one lower.
       final catalog = await service.fetchCatalog();
-      final page = await service.fetchPage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+      final page = await service.fetchPage(pageUuid);
       expect(catalog, isNotNull);
       expect(page, isNotNull);
+      expect(adapter.catalogFetchCount, 4);
+      expect(adapter.pageFetchCount, 4);
     });
   });
 

--- a/test/features/announcements/remote/announcement_remote_service_test.dart
+++ b/test/features/announcements/remote/announcement_remote_service_test.dart
@@ -127,6 +127,24 @@ class _NotFoundAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
+class _UnsupportedSchemaAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async => ResponseBody.fromString(
+    '{"schemaVersion": 999, "pages": []}',
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+
+  @override
+  void close({bool force = false}) {}
+}
+
 AppSetting _testAppSetting({bool remoteEnabled = true}) => AppSetting(
   locale: Locale.en,
   enableDebugLog: false,
@@ -220,6 +238,33 @@ void main() {
       final catalog = await service.fetchCatalog();
       expect(catalog, isNull);
     });
+
+    test("returns null for unsupported schema version", () async {
+      final dio = Dio(BaseOptions())..httpClientAdapter = _UnsupportedSchemaAdapter();
+      final container = _createContainer(dio: dio);
+      final service = container.read(announcementRemoteServiceProvider);
+
+      final catalog = await service.fetchCatalog();
+      expect(catalog, isNull);
+    });
+
+    test("invalidateCache clears catalog and page caches", () async {
+      final dio = Dio(BaseOptions())..httpClientAdapter = _SuccessAdapter();
+      final container = _createContainer(dio: dio);
+      final service = container.read(announcementRemoteServiceProvider);
+
+      // First fetch populates the in-memory cache.
+      await service.fetchCatalog();
+      await service.fetchPage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+      // After invalidation, the next fetch should still succeed (hits network
+      // again rather than returning stale in-memory data).
+      service.invalidateCache();
+      final catalog = await service.fetchCatalog();
+      final page = await service.fetchPage("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+      expect(catalog, isNotNull);
+      expect(page, isNotNull);
+    });
   });
 
   group("AnnouncementRemoteService fetchPage", () {
@@ -291,7 +336,7 @@ void main() {
       expect(body, _sampleBodyContent);
 
       // Verify it was cached
-      final cached = AnnouncementBodyCache.get(_bodyHash);
+      final cached = await AnnouncementBodyCache.get(_bodyHash);
       expect(cached, _sampleBodyContent);
     });
 

--- a/test/features/announcements/remote/body_cache_test.dart
+++ b/test/features/announcements/remote/body_cache_test.dart
@@ -26,7 +26,7 @@ void main() {
       const hash = "a1b2c3d4e5f6789012345678901234567890abcd12345678901234567890abcdef";
       const content = "# Hello World\n\nThis is a test body.";
       await AnnouncementBodyCache.put(hash, content);
-      final result = AnnouncementBodyCache.get(hash);
+      final result = await AnnouncementBodyCache.get(hash);
       expect(result, content);
     });
 
@@ -45,9 +45,9 @@ void main() {
       );
     });
 
-    test("get returns null for missing hash", () {
+    test("get returns null for missing hash", () async {
       expect(
-        AnnouncementBodyCache.get(
+        await AnnouncementBodyCache.get(
           "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         ),
         isNull,
@@ -70,7 +70,7 @@ void main() {
       const hash = "1111111111111111111111111111111111111111111111111111111111111111";
       await AnnouncementBodyCache.put(hash, "first");
       await AnnouncementBodyCache.put(hash, "second");
-      expect(AnnouncementBodyCache.get(hash), "second");
+      expect(await AnnouncementBodyCache.get(hash), "second");
     });
 
     test("multiple hashes with same prefix share directory", () async {
@@ -79,11 +79,41 @@ void main() {
       await AnnouncementBodyCache.put(hash1, "one");
       await AnnouncementBodyCache.put(hash2, "two");
 
-      expect(AnnouncementBodyCache.get(hash1), "one");
-      expect(AnnouncementBodyCache.get(hash2), "two");
+      expect(await AnnouncementBodyCache.get(hash1), "one");
+      expect(await AnnouncementBodyCache.get(hash2), "two");
 
       final dir = Directory("$tempDir/announcements/bodies/aa");
       expect(dir.listSync().length, 2);
+    });
+
+    test("prune deletes unreferenced files", () async {
+      const keepHash = "aa00000000000000000000000000000000000000000000000000000000000000";
+      const dropHash = "bb11111111111111111111111111111111111111111111111111111111111111";
+      await AnnouncementBodyCache.put(keepHash, "keep");
+      await AnnouncementBodyCache.put(dropHash, "drop");
+
+      await AnnouncementBodyCache.prune(referencedHashes: {keepHash});
+
+      expect(await AnnouncementBodyCache.get(keepHash), "keep");
+      expect(await AnnouncementBodyCache.get(dropHash), isNull);
+    });
+
+    test("prune keeps all files when all are referenced", () async {
+      const hash1 = "aa00000000000000000000000000000000000000000000000000000000000000";
+      const hash2 = "bb11111111111111111111111111111111111111111111111111111111111111";
+      await AnnouncementBodyCache.put(hash1, "one");
+      await AnnouncementBodyCache.put(hash2, "two");
+
+      await AnnouncementBodyCache.prune(referencedHashes: {hash1, hash2});
+
+      expect(await AnnouncementBodyCache.get(hash1), "one");
+      expect(await AnnouncementBodyCache.get(hash2), "two");
+    });
+
+    test("prune on empty directory is a no-op", () async {
+      await AnnouncementBodyCache.prune(referencedHashes: {});
+      // No crash, no files created.
+      expect(Directory("$tempDir/announcements/bodies").existsSync(), isFalse);
     });
   });
 }

--- a/test/features/announcements/repository/raw_feed_caching_test.dart
+++ b/test/features/announcements/repository/raw_feed_caching_test.dart
@@ -1,0 +1,227 @@
+import "dart:async";
+import "dart:io";
+
+import "package:eve_fit_assistant/config/locale.dart";
+import "package:eve_fit_assistant/config/paths.dart";
+import "package:eve_fit_assistant/config/type_list.dart";
+import "package:eve_fit_assistant/features/announcements/models/models.dart";
+import "package:eve_fit_assistant/features/announcements/remote/remote.dart";
+import "package:eve_fit_assistant/features/announcements/repository/repository.dart";
+import "package:eve_fit_assistant/features/announcements/state/announcement_state_notifier.dart";
+import "package:eve_fit_assistant/features/announcements/state/announcement_state_store.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_store.dart";
+import "package:eve_fit_assistant/storage/setting/setting.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:flutter_test/flutter_test.dart";
+
+const _installedVersion = "2.0.0";
+
+/// Repository that counts how many times [sync] is invoked. Used to detect
+/// accidental re-fetches when only local read/dismiss state changes.
+class _CountingRepository extends AnnouncementRepository {
+  _CountingRepository({required super.ref, required this.feed});
+
+  final AnnouncementRawFeed feed;
+  int syncCount = 0;
+
+  @override
+  Future<AnnouncementRawFeed> sync({
+    required String localeCode,
+    required String currentChannel,
+    required String currentPlatform,
+    required String installedVersion,
+  }) async {
+    syncCount += 1;
+    return feed;
+  }
+}
+
+AppSetting _testAppSetting() => const AppSetting(
+  locale: Locale.en,
+  enableDebugLog: false,
+  shipSelectListDisplayVariant: TypeListDisplayVariant.marketGroup,
+  showCheckoutImpactWarnings: true,
+  typeListReturnBehavior: TypeListReturnBehavior.previousPage,
+  developerMode: false,
+  remoteContent: RemoteContentSetting(originUrl: "https://cdn.example.com/", channel: "stable"),
+);
+
+AnnouncementEntry _entry(String id) => AnnouncementEntry(
+  id: id,
+  publishedAt: DateTime(2026, 6, 15),
+  channels: const ["stable"],
+  platforms: const ["android"],
+  localizations: const {"en": LocalizationMeta(title: "Title", summary: "Summary", bodyHash: "")},
+);
+
+/// Test harness that keeps a long-lived subscription to
+/// [announcementFeedProvider] and lets tests wait for the next `AsyncData`
+/// emission after a state or refresh action.
+class _FeedHarness {
+  _FeedHarness(this.container) {
+    _sub = container.listen(announcementFeedProvider, (prev, next) {
+      _states.add(next);
+      final waiter = _waiter;
+      if (waiter != null && next is AsyncData<List<AnnouncementRecord>>) {
+        _waiter = null;
+        waiter.complete(next.value);
+      }
+    });
+  }
+
+  final ProviderContainer container;
+  late final ProviderSubscription<AsyncValue<List<AnnouncementRecord>>> _sub;
+  final List<AsyncValue<List<AnnouncementRecord>>> _states = [];
+  Completer<List<AnnouncementRecord>>? _waiter;
+
+  /// Trigger the initial evaluation of the feed provider.
+  void start() {
+    container.read(announcementFeedProvider);
+  }
+
+  /// Wait for the next `AsyncData` emission after this call. If the provider
+  /// already holds `AsyncData` and no further emission occurs (i.e. the
+  /// action is a no-op), this times out.
+  Future<List<AnnouncementRecord>> nextData() {
+    final completer = Completer<List<AnnouncementRecord>>();
+    _waiter = completer;
+    // If the provider is currently loading, that loading emission may have
+    // already fired before we registered the waiter. Re-check the current
+    // state and, if it is already data AND the data is fresh (i.e. the last
+    // emission is data and was emitted after this call), complete eagerly.
+    return completer.future.timeout(const Duration(seconds: 5));
+  }
+
+  void dispose() {
+    _sub.close();
+  }
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    // Per-test tempDir so on-disk state does not leak between tests.
+    tempDir = Directory.systemTemp.createTempSync("efa_raw_feed_test_");
+    PathProvider.documentsPath = tempDir.path;
+    PathProvider.tempPath = tempDir.path;
+    PathProvider.appSupportPath = tempDir.path;
+    PathProvider.cachesPath = tempDir.path;
+  });
+
+  late AnnouncementStateStore stateStore;
+  late AppVersionStateStore versionStore;
+
+  setUp(() async {
+    stateStore = AnnouncementStateStore(settingsPath: tempDir.path);
+    await stateStore.init();
+    versionStore = AppVersionStateStore(settingsPath: tempDir.path);
+    await versionStore.init();
+  });
+
+  tearDown(() {
+    tempDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer buildContainer(
+    AnnouncementRawFeed rawFeed,
+    void Function(_CountingRepository) capture,
+  ) => ProviderContainer(
+    overrides: [
+      appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+      announcementStateStoreProvider.overrideWithValue(stateStore),
+      appVersionStateStoreProvider.overrideWithValue(versionStore),
+      appVersionProvider.overrideWith((_) async => _installedVersion),
+      announcementRepositoryProvider.overrideWith((ref) {
+        final repo = _CountingRepository(ref: ref, feed: rawFeed);
+        capture(repo);
+        return repo;
+      }),
+    ],
+  );
+
+  group("announcementRawFeedProvider / announcementFeedProvider split", () {
+    test("mark-all-read re-derives in-memory only — no second sync", () async {
+      final rawFeed = AnnouncementRawFeed(
+        entries: [_entry("a"), _entry("b"), _entry("c")],
+        remoteIds: {"a", "b", "c"},
+      );
+      late _CountingRepository countingRepo;
+      final container = buildContainer(rawFeed, (r) => countingRepo = r);
+      addTearDown(container.dispose);
+
+      final harness = _FeedHarness(container);
+      addTearDown(harness.dispose);
+      harness.start();
+
+      final initial = await harness.nextData();
+      expect(initial.length, 3);
+      expect(initial.every((r) => !r.isRead), isTrue);
+      expect(countingRepo.syncCount, 1);
+
+      container
+          .read(announcementStateServiceProvider.notifier)
+          .markAllRead(initial.map((r) => r.id));
+
+      final updated = await harness.nextData();
+      expect(updated.every((r) => r.isRead), isTrue);
+      expect(countingRepo.syncCount, 1, reason: "state toggle must not re-run sync");
+    });
+
+    test("mark-unread re-derives in-memory only — no second sync", () async {
+      final rawFeed = AnnouncementRawFeed(
+        entries: [_entry("a"), _entry("b")],
+        remoteIds: {"a", "b"},
+      );
+      late _CountingRepository countingRepo;
+      final container = buildContainer(rawFeed, (r) => countingRepo = r);
+      addTearDown(container.dispose);
+
+      final harness = _FeedHarness(container);
+      addTearDown(harness.dispose);
+      harness.start();
+
+      final initial = await harness.nextData();
+      expect(initial.every((r) => !r.isRead), isTrue);
+      expect(countingRepo.syncCount, 1);
+
+      container
+          .read(announcementStateServiceProvider.notifier)
+          .markAllRead(initial.map((r) => r.id));
+      final markedRead = await harness.nextData();
+      expect(markedRead.every((r) => r.isRead), isTrue);
+
+      container
+          .read(announcementStateServiceProvider.notifier)
+          .markUnread(markedRead.map((r) => r.id));
+      final markedUnread = await harness.nextData();
+      expect(markedUnread.every((r) => !r.isRead), isTrue);
+      expect(countingRepo.syncCount, 1, reason: "mark-unread must not re-run sync");
+    });
+
+    test(
+      "remote-cache invalidation + raw-provider invalidation triggers exactly one additional sync",
+      () async {
+        final rawFeed = AnnouncementRawFeed(entries: [_entry("a")], remoteIds: {"a"});
+        late _CountingRepository countingRepo;
+        final container = buildContainer(rawFeed, (r) => countingRepo = r);
+        addTearDown(container.dispose);
+
+        final harness = _FeedHarness(container);
+        addTearDown(harness.dispose);
+        harness.start();
+
+        await harness.nextData();
+        expect(countingRepo.syncCount, 1);
+
+        // Mirror what _refreshFeed does in feed_page.dart.
+        container.read(announcementRemoteServiceProvider).invalidateCache();
+        container.invalidate(announcementRawFeedProvider);
+
+        await harness.nextData();
+        expect(countingRepo.syncCount, 2, reason: "explicit refresh must re-run sync once");
+      },
+    );
+  });
+}

--- a/test/features/announcements/repository/repository_test.dart
+++ b/test/features/announcements/repository/repository_test.dart
@@ -1,7 +1,6 @@
 import "dart:io";
 
 import "package:eve_fit_assistant/config/locale.dart";
-import "package:eve_fit_assistant/config/logger.dart";
 import "package:eve_fit_assistant/config/paths.dart";
 import "package:eve_fit_assistant/config/type_list.dart";
 import "package:eve_fit_assistant/features/announcements/models/models.dart";
@@ -111,7 +110,8 @@ List<AnnouncementRecord> _testFeed() => [
 void main() {
   late Directory tempDir;
 
-  setUpAll(() {
+  setUp(() {
+    // Per-test tempDir so on-disk state does not leak between tests.
     tempDir = Directory.systemTemp.createTempSync("efa_repo_test_");
     PathProvider.documentsPath = tempDir.path;
     PathProvider.tempPath = tempDir.path;
@@ -129,7 +129,11 @@ void main() {
     await versionStore.init();
   });
 
-  tearDownAll(() {
+  tearDown(() async {
+    // Stores sync to disk on a background isolate; wait for pending writes
+    // before deleting the temp dir to avoid racy ENOTEMPTY failures.
+    await stateStore.ensureSynced;
+    await versionStore.ensureSynced;
     tempDir.deleteSync(recursive: true);
   });
 

--- a/test/features/announcements/repository/repository_test.dart
+++ b/test/features/announcements/repository/repository_test.dart
@@ -6,8 +6,10 @@ import "package:eve_fit_assistant/config/paths.dart";
 import "package:eve_fit_assistant/config/type_list.dart";
 import "package:eve_fit_assistant/features/announcements/models/models.dart";
 import "package:eve_fit_assistant/features/announcements/repository/repository.dart";
+import "package:eve_fit_assistant/features/announcements/state/announcement_state_notifier.dart";
 import "package:eve_fit_assistant/features/announcements/state/announcement_state_store.dart";
-import "package:eve_fit_assistant/features/announcements/state/state.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_store.dart";
 import "package:eve_fit_assistant/storage/setting/setting.dart";
 import "package:eve_fit_assistant/utils/version.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -117,61 +119,39 @@ void main() {
     PathProvider.cachesPath = tempDir.path;
   });
 
-  setUp(() {
-    AnnouncementStateStore.init();
+  late AnnouncementStateStore stateStore;
+  late AppVersionStateStore versionStore;
+
+  setUp(() async {
+    stateStore = AnnouncementStateStore(settingsPath: tempDir.path);
+    await stateStore.init();
+    versionStore = AppVersionStateStore(settingsPath: tempDir.path);
+    await versionStore.init();
   });
 
   tearDownAll(() {
     tempDir.deleteSync(recursive: true);
   });
 
-  group("startupAnnouncementProvider version gating", () {
-    test("excludes startup entry where appVersion <= installed", () async {
+  group("startupAnnouncementQueueProvider version gating", () {
+    test("returns queue with eligible entries", () async {
       final container = ProviderContainer(
         overrides: [
           appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
           announcementFeedProvider.overrideWith((_) async => _testFeed()),
           appVersionProvider.overrideWith((_) async => _installedVersion),
         ],
       );
       addTearDown(container.dispose);
 
-      final record = await container.read(startupAnnouncementProvider.future);
-      expect(record, isNotNull);
-      // Should be the "New Version Startup" (3.0.0 > 2.0.0), not the old one
-      expect(record!.id, "new-version-startup");
-    });
-
-    test("includes general startup entry with no appVersion", () async {
-      final feed = [
-        // Only the general startup entry (no appVersion)
-        AnnouncementRecord(
-          id: "general-startup",
-          source: AnnouncementEntrySource.bundled,
-          title: "General Startup",
-          summary: "General announcement",
-          bodyHash: "c".padRight(64, "0"),
-          publishedAt: DateTime(2026, 6, 14),
-          localeCode: "en",
-          tags: ["announcement"],
-          startup: true,
-          isRead: false,
-          isDismissed: false,
-        ),
-      ];
-
-      final container = ProviderContainer(
-        overrides: [
-          appSettingServiceProvider.overrideWithValue(_testAppSetting()),
-          announcementFeedProvider.overrideWith((_) async => feed),
-          appVersionProvider.overrideWith((_) async => _installedVersion),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      final record = await container.read(startupAnnouncementProvider.future);
-      expect(record, isNotNull);
-      expect(record!.id, "general-startup");
+      final queue = await container.read(startupAnnouncementQueueProvider.future);
+      // Old-version-startup (1.0.0 <= 2.0.0) is excluded
+      // New-version-startup (3.0.0 > 2.0.0) is included
+      // General-startup (no appVersion) is included
+      expect(queue.length, 2);
+      expect(queue.map((r) => r.id), containsAll(["new-version-startup", "general-startup"]));
     });
 
     test("excludes read startup entries", () async {
@@ -195,14 +175,16 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
           announcementFeedProvider.overrideWith((_) async => feed),
           appVersionProvider.overrideWith((_) async => _installedVersion),
         ],
       );
       addTearDown(container.dispose);
 
-      final record = await container.read(startupAnnouncementProvider.future);
-      expect(record, isNull);
+      final queue = await container.read(startupAnnouncementQueueProvider.future);
+      expect(queue, isEmpty);
     });
 
     test("excludes dismissed startup entries", () async {
@@ -226,14 +208,35 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
           announcementFeedProvider.overrideWith((_) async => feed),
           appVersionProvider.overrideWith((_) async => _installedVersion),
         ],
       );
       addTearDown(container.dispose);
 
+      final queue = await container.read(startupAnnouncementQueueProvider.future);
+      expect(queue, isEmpty);
+    });
+  });
+
+  group("startupAnnouncementProvider (deprecated alias)", () {
+    test("returns first entry from queue", () async {
+      final container = ProviderContainer(
+        overrides: [
+          appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
+          announcementFeedProvider.overrideWith((_) async => _testFeed()),
+          appVersionProvider.overrideWith((_) async => _installedVersion),
+        ],
+      );
+      addTearDown(container.dispose);
+
       final record = await container.read(startupAnnouncementProvider.future);
-      expect(record, isNull);
+      expect(record, isNotNull);
+      expect(record!.id, "new-version-startup");
     });
   });
 
@@ -242,6 +245,8 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
           announcementFeedProvider.overrideWith((_) async => _testFeed()),
           appVersionProvider.overrideWith((_) async => _installedVersion),
         ],
@@ -253,11 +258,6 @@ void main() {
       await container.read(announcementVersionFeedProvider.future);
 
       final count = container.read(unreadVersionCountProvider);
-      // New-version-non-startup (2.5.0) is read → excluded
-      // Old-version-non-startup (1.5.0 <= installed) → excluded by gating
-      // Old-version-startup (1.0.0 <= installed) → excluded by gating
-      // New-version-startup (3.0.0 > installed) → unread → counted
-      // General-startup (no appVersion) → not in version feed
       expect(count, 1);
     });
 
@@ -296,6 +296,8 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
           announcementFeedProvider.overrideWith((_) async => feed),
           appVersionProvider.overrideWith((_) async => _installedVersion),
         ],
@@ -314,10 +316,10 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
           announcementFeedProvider.overrideWith((_) async => _testFeed()),
           appVersionProvider.overrideWith((_) async {
-            // Simulate never resolving
-            // ignore: only_throw_errors
             throw UnimplementedError();
           }),
         ],
@@ -325,17 +327,88 @@ void main() {
       addTearDown(container.dispose);
 
       final count = container.read(unreadVersionCountProvider);
-      // appVer is null when error → all entries counted (no gating)
-      // But we should still get a number, not crash
       expect(count, greaterThanOrEqualTo(0));
+    });
+  });
+
+  group("pendingVersionBumpProvider", () {
+    test("returns true when version bump and matching entries exist", () async {
+      final feed = [
+        AnnouncementRecord(
+          id: "v-bump",
+          source: AnnouncementEntrySource.remote,
+          title: "Bump",
+          summary: "",
+          bodyHash: "a".padRight(64, "0"),
+          publishedAt: DateTime(2026, 6, 15),
+          localeCode: "en",
+          tags: [],
+          startup: false,
+          appVersion: "2.0.0",
+          isRead: false,
+          isDismissed: false,
+        ),
+      ];
+
+      final container = ProviderContainer(
+        overrides: [
+          appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
+          announcementFeedProvider.overrideWith((_) async => feed),
+          appVersionProvider.overrideWith((_) async => "2.0.0"),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(announcementFeedProvider.future);
+      await container.read(appVersionProvider.future);
+      await container.read(announcementVersionFeedProvider.future);
+
+      expect(container.read(pendingVersionBumpProvider), isTrue);
+    });
+
+    test("returns false when lastSeenAppVersion equals current", () async {
+      versionStore.setLastSeenAppVersion("2.0.0");
+
+      final feed = [
+        AnnouncementRecord(
+          id: "v-bump",
+          source: AnnouncementEntrySource.remote,
+          title: "Bump",
+          summary: "",
+          bodyHash: "a".padRight(64, "0"),
+          publishedAt: DateTime(2026, 6, 15),
+          localeCode: "en",
+          tags: [],
+          startup: false,
+          appVersion: "2.0.0",
+          isRead: false,
+          isDismissed: false,
+        ),
+      ];
+
+      final container = ProviderContainer(
+        overrides: [
+          appSettingServiceProvider.overrideWithValue(_testAppSetting()),
+          announcementStateStoreProvider.overrideWithValue(stateStore),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
+          announcementFeedProvider.overrideWith((_) async => feed),
+          appVersionProvider.overrideWith((_) async => "2.0.0"),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(announcementFeedProvider.future);
+      await container.read(appVersionProvider.future);
+      await container.read(announcementVersionFeedProvider.future);
+
+      expect(container.read(pendingVersionBumpProvider), isFalse);
     });
   });
 
   group("version entry appears in feed when appVersion <= installed", () {
     test("old version entries pass _filterEntry and appear in feed", () {
-      // Verify via compareVersions: the installed version is 2.0.0,
-      // so 1.5.0 <= 2.0.0 — this entry should NOT be filtered by
-      // step 6 (which was removed).
       expect(compareVersions("1.5.0", _installedVersion) <= 0, isTrue);
     });
 

--- a/test/features/announcements/state/announcement_state_notifier_test.dart
+++ b/test/features/announcements/state/announcement_state_notifier_test.dart
@@ -19,9 +19,18 @@ void main() {
     PathProvider.cachesPath = tempDir.path;
   });
 
-  setUp(() {
-    AnnouncementStateStore.init();
+  late AnnouncementStateStore store;
+  late ProviderContainer container;
+
+  setUp(() async {
+    store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+    await store.init();
+    container = ProviderContainer(
+      overrides: [announcementStateStoreProvider.overrideWithValue(store)],
+    );
   });
+
+  tearDown(() => container.dispose());
 
   tearDownAll(() {
     tempDir.deleteSync(recursive: true);
@@ -29,31 +38,22 @@ void main() {
 
   group("AnnouncementStateService", () {
     test("build reads store state correctly", () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-
-      AnnouncementStateStore.markRead("entry-1");
+      store.markRead("entry-1");
       final serviceState = container.read(announcementStateServiceProvider);
 
       expect(serviceState.readIds, contains("entry-1"));
     });
 
     test("markRead updates state reactively", () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-
       final notifier = container.read(announcementStateServiceProvider.notifier);
       notifier.markRead("entry-1");
 
       final serviceState = container.read(announcementStateServiceProvider);
       expect(serviceState.readIds, contains("entry-1"));
-      expect(AnnouncementStateStore.isRead("entry-1"), isTrue);
+      expect(store.isRead("entry-1"), isTrue);
     });
 
     test("markAllRead updates state reactively", () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-
       final notifier = container.read(announcementStateServiceProvider.notifier);
       notifier.markAllRead(["a", "b", "c"]);
 
@@ -62,32 +62,26 @@ void main() {
     });
 
     test("dismiss updates state reactively", () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-
       final notifier = container.read(announcementStateServiceProvider.notifier);
       notifier.dismiss("entry-3");
 
       final serviceState = container.read(announcementStateServiceProvider);
       expect(serviceState.dismissedIds, contains("entry-3"));
-      expect(AnnouncementStateStore.isDismissed("entry-3"), isTrue);
+      expect(store.isDismissed("entry-3"), isTrue);
     });
 
-    test("acknowledgeVersion updates state reactively", () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-
+    test("pruneStaleIds removes stale ids", () {
       final notifier = container.read(announcementStateServiceProvider.notifier);
-      notifier.acknowledgeVersion("5.0.0");
+      notifier.markRead("keep");
+      notifier.markRead("drop");
+
+      notifier.pruneStaleIds(activeIds: {"keep"});
 
       final serviceState = container.read(announcementStateServiceProvider);
-      expect(serviceState.lastSeenAppVersion, "5.0.0");
+      expect(serviceState.readIds, ["keep"]);
     });
 
     test("listener is notified on state change", () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-
       final changes = <AnnouncementState>[];
       container.listen(announcementStateServiceProvider, (_, next) => changes.add(next));
 

--- a/test/features/announcements/state/announcement_state_store_legacy_migration_test.dart
+++ b/test/features/announcements/state/announcement_state_store_legacy_migration_test.dart
@@ -7,8 +7,6 @@ import "package:flutter_test/flutter_test.dart";
 import "package:path/path.dart" as p;
 
 // Regression test for first-ever init() with a legacy document_storage.json.
-// This must live in its own file because AnnouncementStateStore uses static
-// late state; earlier init() calls in other tests would mask the bug.
 void main() {
   test("legacy document_storage.json migrates on first-ever init", () async {
     final tempDir = Directory.systemTemp.createTempSync("efa_legacy_migration_test_");
@@ -28,23 +26,28 @@ void main() {
       }),
     );
 
-    AnnouncementStateStore.init();
-    await AnnouncementStateStore.ensureSynced;
+    final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+    final migration = await store.init();
+    await store.ensureSynced;
 
-    expect(AnnouncementStateStore.state.readIds, containsAll(["legacy-read-1", "legacy-read-2"]));
-    expect(AnnouncementStateStore.state.dismissedIds, ["legacy-dismissed-1"]);
-    expect(AnnouncementStateStore.state.lastSeenAppVersion, "1.2.3");
-    expect(AnnouncementStateStore.state.lastAcknowledgedReleaseId, isNull);
-    expect(AnnouncementStateStore.state.schemaVersion, 2);
+    expect(store.state.readIds, containsAll(["legacy-read-1", "legacy-read-2"]));
+    expect(store.state.dismissedIds, ["legacy-dismissed-1"]);
+    expect(store.state.schemaVersion, 3);
+
+    // The migration data should carry lastSeenAppVersion for the caller to
+    // apply to AppVersionStateStore.
+    expect(migration, isNotNull);
+    expect(migration!.lastSeenAppVersion, "1.2.3");
+    expect(migration.lastAcknowledgedReleaseId, isNull);
 
     final migratedFile = File(p.join(settingsDir.path, "announcement_state.json"));
     expect(migratedFile.existsSync(), isTrue);
 
     final migratedJson = jsonDecode(migratedFile.readAsStringSync()) as Map<String, dynamic>;
-    expect(migratedJson["schemaVersion"], 2);
+    expect(migratedJson["schemaVersion"], 3);
     expect(migratedJson["readIds"], containsAll(["legacy-read-1", "legacy-read-2"]));
     expect(migratedJson["dismissedIds"], ["legacy-dismissed-1"]);
-    expect(migratedJson["lastSeenAppVersion"], "1.2.3");
-    expect(migratedJson["lastAcknowledgedReleaseId"], isNull);
+    expect(migratedJson.containsKey("lastSeenAppVersion"), isFalse);
+    expect(migratedJson.containsKey("lastAcknowledgedReleaseId"), isFalse);
   });
 }

--- a/test/features/announcements/state/announcement_state_store_test.dart
+++ b/test/features/announcements/state/announcement_state_store_test.dart
@@ -8,108 +8,86 @@ import "package:flutter_test/flutter_test.dart";
 import "package:path/path.dart" as p;
 
 void main() {
-  late Directory tempDir;
-
-  setUpAll(() {
-    tempDir = Directory.systemTemp.createTempSync("efa_state_store_test_");
-    PathProvider.documentsPath = tempDir.path;
-    PathProvider.tempPath = tempDir.path;
-    PathProvider.appSupportPath = tempDir.path;
-    PathProvider.cachesPath = tempDir.path;
-  });
+  late AnnouncementStateStore store;
+  late String settingsPath;
 
   setUp(() async {
-    final file = File(p.join(tempDir.path, "settings", "announcement_state.json"));
-    if (file.existsSync()) file.deleteSync();
-    AnnouncementStateStore.init();
-    await AnnouncementStateStore.ensureSynced;
-  });
-
-  tearDownAll(() {
-    tempDir.deleteSync(recursive: true);
+    final testDir = Directory.systemTemp.createTempSync("efa_state_store_test_");
+    // Do not delete in tearDown — Isolate.run writes may still be in flight
+    // when the test completes, causing "Directory not empty" errors. The OS
+    // will reclaim /tmp files.
+    PathProvider.documentsPath = testDir.path;
+    PathProvider.tempPath = testDir.path;
+    PathProvider.appSupportPath = testDir.path;
+    PathProvider.cachesPath = testDir.path;
+    settingsPath = p.join(testDir.path, "settings");
+    store = AnnouncementStateStore(settingsPath: settingsPath);
+    await store.init();
+    await store.ensureSynced;
   });
 
   group("AnnouncementStateStore", () {
     test("init produces initial state on first run", () {
-      expect(AnnouncementStateStore.state.schemaVersion, 2);
-      expect(AnnouncementStateStore.state.readIds, isEmpty);
-      expect(AnnouncementStateStore.state.dismissedIds, isEmpty);
-      expect(AnnouncementStateStore.state.lastSeenAppVersion, isNull);
+      expect(store.state.schemaVersion, 3);
+      expect(store.state.readIds, isEmpty);
+      expect(store.state.dismissedIds, isEmpty);
     });
 
     test("read/write round-trip", () async {
-      AnnouncementStateStore.markRead("entry-1");
-      AnnouncementStateStore.dismiss("entry-2");
-      AnnouncementStateStore.setLastSeenAppVersion("2.0.0");
+      store.markRead("entry-1");
+      store.dismiss("entry-2");
 
-      await AnnouncementStateStore.ensureSynced;
+      await store.ensureSynced;
 
-      AnnouncementStateStore.init();
+      final reloaded = AnnouncementStateStore(settingsPath: settingsPath);
+      await reloaded.init();
 
-      expect(AnnouncementStateStore.isRead("entry-1"), isTrue);
-      expect(AnnouncementStateStore.isDismissed("entry-2"), isTrue);
-      expect(AnnouncementStateStore.lastSeenAppVersion, "2.0.0");
+      expect(reloaded.isRead("entry-1"), isTrue);
+      expect(reloaded.isDismissed("entry-2"), isTrue);
     });
 
     test("markRead is idempotent", () {
-      AnnouncementStateStore.markRead("entry-1");
-      final first = AnnouncementStateStore.state.readIds.length;
-      AnnouncementStateStore.markRead("entry-1");
-      expect(AnnouncementStateStore.state.readIds.length, first);
-      expect(AnnouncementStateStore.isRead("entry-1"), isTrue);
+      store.markRead("entry-1");
+      final first = store.state.readIds.length;
+      store.markRead("entry-1");
+      expect(store.state.readIds.length, first);
+      expect(store.isRead("entry-1"), isTrue);
     });
 
     test("markAllRead with partial overlap", () {
-      AnnouncementStateStore.markRead("entry-1");
-      AnnouncementStateStore.markAllRead(["entry-1", "entry-2", "entry-3"]);
-      expect(AnnouncementStateStore.isRead("entry-1"), isTrue);
-      expect(AnnouncementStateStore.isRead("entry-2"), isTrue);
-      expect(AnnouncementStateStore.isRead("entry-3"), isTrue);
-      expect(AnnouncementStateStore.state.readIds.length, 3);
+      store.markRead("entry-1");
+      store.markAllRead(["entry-1", "entry-2", "entry-3"]);
+      expect(store.isRead("entry-1"), isTrue);
+      expect(store.isRead("entry-2"), isTrue);
+      expect(store.isRead("entry-3"), isTrue);
+      expect(store.state.readIds.length, 3);
     });
 
     test("markUnread removes ids", () {
-      AnnouncementStateStore.markRead("entry-1");
-      AnnouncementStateStore.markRead("entry-2");
-      AnnouncementStateStore.markRead("entry-3");
+      store.markRead("entry-1");
+      store.markRead("entry-2");
+      store.markRead("entry-3");
 
-      AnnouncementStateStore.markUnread(["entry-1", "entry-3"]);
+      store.markUnread(["entry-1", "entry-3"]);
 
-      expect(AnnouncementStateStore.isRead("entry-1"), isFalse);
-      expect(AnnouncementStateStore.isRead("entry-2"), isTrue);
-      expect(AnnouncementStateStore.isRead("entry-3"), isFalse);
+      expect(store.isRead("entry-1"), isFalse);
+      expect(store.isRead("entry-2"), isTrue);
+      expect(store.isRead("entry-3"), isFalse);
     });
 
     test("markUnread is idempotent", () {
-      AnnouncementStateStore.markRead("entry-1");
-      final first = AnnouncementStateStore.state.readIds.length;
-      AnnouncementStateStore.markUnread(["entry-2"]);
-      expect(AnnouncementStateStore.state.readIds.length, first);
+      store.markRead("entry-1");
+      final first = store.state.readIds.length;
+      store.markUnread(["entry-2"]);
+      expect(store.state.readIds.length, first);
     });
 
     test("dismiss is idempotent", () {
-      AnnouncementStateStore.dismiss("entry-1");
-      final first = AnnouncementStateStore.state.dismissedIds.length;
-      AnnouncementStateStore.dismiss("entry-1");
-      expect(AnnouncementStateStore.state.dismissedIds.length, first);
-      expect(AnnouncementStateStore.isDismissed("entry-1"), isTrue);
-    });
-
-    test("setLastSeenAppVersion persists", () async {
-      AnnouncementStateStore.setLastSeenAppVersion("3.0.0");
-      expect(AnnouncementStateStore.lastSeenAppVersion, "3.0.0");
-
-      await AnnouncementStateStore.ensureSynced;
-      AnnouncementStateStore.init();
-
-      expect(AnnouncementStateStore.lastSeenAppVersion, "3.0.0");
-    });
-
-    test("setLastSeenAppVersion is idempotent", () {
-      AnnouncementStateStore.setLastSeenAppVersion("2.0.0");
-      final first = AnnouncementStateStore.state.lastSeenAppVersion;
-      AnnouncementStateStore.setLastSeenAppVersion("2.0.0");
-      expect(AnnouncementStateStore.state.lastSeenAppVersion, first);
+      store.dismiss("entry-1");
+      final first = store.state.dismissedIds.length;
+      store.dismiss("entry-1");
+      expect(store.state.dismissedIds.length, first);
+      expect(store.isDismissed("entry-1"), isTrue);
     });
 
     test("schema version migration", () async {
@@ -117,53 +95,69 @@ void main() {
         "schemaVersion": 0,
         "readIds": ["old-entry"],
         "dismissedIds": [],
-        "lastSeenAppVersion": null,
       });
-      final settingsDir = Directory(p.join(tempDir.path, "settings"));
+      final settingsDir = Directory(settingsPath);
       settingsDir.createSync(recursive: true);
       File(p.join(settingsDir.path, "announcement_state.json")).writeAsStringSync(oldJson);
 
-      AnnouncementStateStore.init();
+      final reloaded = AnnouncementStateStore(settingsPath: settingsPath);
+      await reloaded.init();
 
-      expect(AnnouncementStateStore.state.schemaVersion, 2);
-      expect(AnnouncementStateStore.isRead("old-entry"), isTrue);
+      expect(reloaded.state.schemaVersion, 3);
+      expect(reloaded.isRead("old-entry"), isTrue);
     });
 
-    test("corrupt file falls back to initial", () {
-      final settingsDir = Directory(p.join(tempDir.path, "settings"));
+    test("corrupt file falls back to initial", () async {
+      final settingsDir = Directory(settingsPath);
       settingsDir.createSync(recursive: true);
       File(p.join(settingsDir.path, "announcement_state.json")).writeAsStringSync("not json");
 
-      AnnouncementStateStore.init();
+      final reloaded = AnnouncementStateStore(settingsPath: settingsPath);
+      await reloaded.init();
 
-      expect(AnnouncementStateStore.state.schemaVersion, 2);
-      expect(AnnouncementStateStore.state.readIds, isEmpty);
+      expect(reloaded.state.schemaVersion, 3);
+      expect(reloaded.state.readIds, isEmpty);
     });
 
     test("replaceState replaces entire state", () {
-      AnnouncementStateStore.markRead("entry-1");
-      AnnouncementStateStore.dismiss("entry-2");
+      store.markRead("entry-1");
+      store.dismiss("entry-2");
 
-      AnnouncementStateStore.replaceState(
-        AnnouncementState(
-          readIds: ["migrated-1", "migrated-2"],
-          dismissedIds: ["migrated-3"],
-          lastSeenAppVersion: "4.0.0",
-        ),
+      store.replaceState(
+        AnnouncementState(readIds: ["migrated-1", "migrated-2"], dismissedIds: ["migrated-3"]),
       );
 
-      expect(AnnouncementStateStore.isRead("entry-1"), isFalse);
-      expect(AnnouncementStateStore.isRead("migrated-1"), isTrue);
-      expect(AnnouncementStateStore.isDismissed("migrated-3"), isTrue);
-      expect(AnnouncementStateStore.lastSeenAppVersion, "4.0.0");
+      expect(store.isRead("entry-1"), isFalse);
+      expect(store.isRead("migrated-1"), isTrue);
+      expect(store.isDismissed("migrated-3"), isTrue);
     });
 
     test("isRead returns false for unknown id", () {
-      expect(AnnouncementStateStore.isRead("nonexistent"), isFalse);
+      expect(store.isRead("nonexistent"), isFalse);
     });
 
     test("isDismissed returns false for unknown id", () {
-      expect(AnnouncementStateStore.isDismissed("nonexistent"), isFalse);
+      expect(store.isDismissed("nonexistent"), isFalse);
+    });
+
+    test("pruneStaleIds removes ids not in active set", () {
+      store.markRead("entry-1");
+      store.markRead("entry-2");
+      store.markRead("entry-3");
+      store.dismiss("entry-4");
+
+      store.pruneStaleIds(activeIds: {"entry-1", "entry-4"});
+
+      expect(store.isRead("entry-1"), isTrue);
+      expect(store.isRead("entry-2"), isFalse);
+      expect(store.isRead("entry-3"), isFalse);
+      expect(store.isDismissed("entry-4"), isTrue);
+    });
+
+    test("pruneStaleIds is a no-op when nothing is stale", () {
+      store.markRead("entry-1");
+      store.pruneStaleIds(activeIds: {"entry-1"});
+      expect(store.state.readIds, ["entry-1"]);
     });
   });
 }

--- a/test/features/announcements/state/migration_test.dart
+++ b/test/features/announcements/state/migration_test.dart
@@ -2,7 +2,6 @@ import "dart:convert";
 import "dart:io";
 
 import "package:eve_fit_assistant/config/paths.dart";
-import "package:eve_fit_assistant/features/announcements/models/announcement_state.dart";
 import "package:eve_fit_assistant/features/announcements/state/announcement_state_store.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:path/path.dart" as p;
@@ -22,11 +21,6 @@ void main() {
     tempDir.deleteSync(recursive: true);
   });
 
-  Future<void> initAndSync() async {
-    AnnouncementStateStore.init();
-    await AnnouncementStateStore.ensureSynced;
-  }
-
   Directory settingsDir() => Directory(p.join(tempDir.path, "settings"));
 
   File legacyFile() => File(p.join(tempDir.path, "settings", "document_storage.json"));
@@ -45,15 +39,16 @@ void main() {
 
   group("Migration from legacy document_storage.json", () {
     test("fresh install produces initial state", () async {
-      await initAndSync();
+      final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+      await store.init();
+      await store.ensureSynced;
 
-      expect(AnnouncementStateStore.state.schemaVersion, 2);
-      expect(AnnouncementStateStore.state.readIds, isEmpty);
-      expect(AnnouncementStateStore.state.dismissedIds, isEmpty);
-      expect(AnnouncementStateStore.state.lastSeenAppVersion, isNull);
+      expect(store.state.schemaVersion, 3);
+      expect(store.state.readIds, isEmpty);
+      expect(store.state.dismissedIds, isEmpty);
     });
 
-    test("migrates read IDs, dismissed IDs, and lastSeenAppVersion", () async {
+    test("migrates read IDs and dismissed IDs", () async {
       final legacyJson = {
         "version": 3,
         "readTimestamps": {
@@ -69,13 +64,15 @@ void main() {
       };
       legacyFile().writeAsStringSync(jsonEncode(legacyJson));
 
-      await initAndSync();
+      final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+      final migration = await store.init();
+      await store.ensureSynced;
 
-      expect(AnnouncementStateStore.isRead("announcement-1"), isTrue);
-      expect(AnnouncementStateStore.isRead("announcement-2"), isTrue);
-      expect(AnnouncementStateStore.isDismissed("startup-1"), isTrue);
-      expect(AnnouncementStateStore.isDismissed("startup-2"), isTrue);
-      expect(AnnouncementStateStore.lastSeenAppVersion, "2.0.0");
+      expect(store.isRead("announcement-1"), isTrue);
+      expect(store.isRead("announcement-2"), isTrue);
+      expect(store.isDismissed("startup-1"), isTrue);
+      expect(store.isDismissed("startup-2"), isTrue);
+      expect(migration?.lastSeenAppVersion, "2.0.0");
     });
 
     test("new state file wins over legacy", () async {
@@ -95,23 +92,27 @@ void main() {
       };
       newStateFile().writeAsStringSync(jsonEncode(newStateJson));
 
-      await initAndSync();
+      final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+      final migration = await store.init();
+      await store.ensureSynced;
 
-      expect(AnnouncementStateStore.isRead("modern-entry"), isTrue);
-      expect(AnnouncementStateStore.isRead("legacy-entry"), isFalse);
-      expect(AnnouncementStateStore.isDismissed("modern-dismissed"), isTrue);
-      expect(AnnouncementStateStore.isDismissed("legacy-dismissed"), isFalse);
-      expect(AnnouncementStateStore.lastSeenAppVersion, "3.0.0");
+      expect(store.isRead("modern-entry"), isTrue);
+      expect(store.isRead("legacy-entry"), isFalse);
+      expect(store.isDismissed("modern-dismissed"), isTrue);
+      expect(store.isDismissed("legacy-dismissed"), isFalse);
+      expect(migration?.lastSeenAppVersion, "3.0.0");
     });
 
     test("corrupted legacy file falls back to initial", () async {
       legacyFile().writeAsStringSync("not valid json {{{");
 
-      await initAndSync();
+      final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+      await store.init();
+      await store.ensureSynced;
 
-      expect(AnnouncementStateStore.state.schemaVersion, 2);
-      expect(AnnouncementStateStore.state.readIds, isEmpty);
-      expect(AnnouncementStateStore.state.dismissedIds, isEmpty);
+      expect(store.state.schemaVersion, 3);
+      expect(store.state.readIds, isEmpty);
+      expect(store.state.dismissedIds, isEmpty);
     });
 
     test("post-migration writes announcement_state.json to disk", () async {
@@ -123,12 +124,14 @@ void main() {
       legacyFile().writeAsStringSync(jsonEncode(legacyJson));
 
       expect(newStateFile().existsSync(), isFalse);
-      await initAndSync();
+      final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+      await store.init();
+      await store.ensureSynced;
       expect(newStateFile().existsSync(), isTrue);
 
       final writtenText = newStateFile().readAsStringSync();
       final writtenJson = jsonDecode(writtenText) as Map<String, dynamic>;
-      expect(writtenJson["schemaVersion"], 2);
+      expect(writtenJson["schemaVersion"], 3);
       expect(writtenJson["readIds"], contains("entry-x"));
     });
 
@@ -139,7 +142,9 @@ void main() {
       };
       legacyFile().writeAsStringSync(jsonEncode(legacyJson));
 
-      await initAndSync();
+      final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+      await store.init();
+      await store.ensureSynced;
 
       expect(legacyFile().existsSync(), isTrue);
       final legacyContent = legacyFile().readAsStringSync();
@@ -154,11 +159,13 @@ void main() {
       };
       legacyFile().writeAsStringSync(jsonEncode(legacyJson));
 
-      await initAndSync();
+      final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+      final migration = await store.init();
+      await store.ensureSynced;
 
-      expect(AnnouncementStateStore.state.readIds, isEmpty);
-      expect(AnnouncementStateStore.isDismissed("d-1"), isTrue);
-      expect(AnnouncementStateStore.lastSeenAppVersion, "4.0.0");
+      expect(store.state.readIds, isEmpty);
+      expect(store.isDismissed("d-1"), isTrue);
+      expect(migration?.lastSeenAppVersion, "4.0.0");
     });
 
     test("missing dismissedStartupAnnouncementIds produces empty dismissedIds", () async {
@@ -169,11 +176,13 @@ void main() {
       };
       legacyFile().writeAsStringSync(jsonEncode(legacyJson));
 
-      await initAndSync();
+      final store = AnnouncementStateStore(settingsPath: p.join(tempDir.path, "settings"));
+      final migration = await store.init();
+      await store.ensureSynced;
 
-      expect(AnnouncementStateStore.isRead("entry-a"), isTrue);
-      expect(AnnouncementStateStore.state.dismissedIds, isEmpty);
-      expect(AnnouncementStateStore.lastSeenAppVersion, "5.0.0");
+      expect(store.isRead("entry-a"), isTrue);
+      expect(store.state.dismissedIds, isEmpty);
+      expect(migration?.lastSeenAppVersion, "5.0.0");
     });
   });
 }

--- a/test/features/app_update/app_update_controller_test.dart
+++ b/test/features/app_update/app_update_controller_test.dart
@@ -17,21 +17,21 @@ import "package:mocktail/mocktail.dart";
 class _MockAppUpdateService extends Mock implements AppUpdateService {}
 
 RemoteAppRelease _release({String version = "2.0.0"}) => RemoteAppRelease(
-      releaseId: "rel-2",
-      version: version,
-      snapshotHash: "snapshot",
-      index: ReleaseIndex(
-        schemaVersion: 1,
-        id: "rel-2",
-        version: version,
-        android: AndroidArtifacts()
-          ..general = AndroidArtifactVariant(
-            identifier: "release://2.0.0/android/general",
-            contentHash: "aa" * 32,
-            size: Int64(100),
-          ),
+  releaseId: "rel-2",
+  version: version,
+  snapshotHash: "snapshot",
+  index: ReleaseIndex(
+    schemaVersion: 1,
+    id: "rel-2",
+    version: version,
+    android: AndroidArtifacts()
+      ..general = AndroidArtifactVariant(
+        identifier: "release://2.0.0/android/general",
+        contentHash: "aa" * 32,
+        size: Int64(100),
       ),
-    );
+  ),
+);
 
 void main() {
   late String tempDir;
@@ -50,9 +50,7 @@ void main() {
     mockService = _MockAppUpdateService();
 
     container = ProviderContainer(
-      overrides: [
-        appUpdateServiceProvider.overrideWithValue(mockService),
-      ],
+      overrides: [appUpdateServiceProvider.overrideWithValue(mockService)],
     );
   });
 
@@ -79,13 +77,11 @@ void main() {
         size: 100,
       );
 
-      when(() => mockService.resolveArtifact(release.index.android))
-          .thenAnswer((_) async => Right(artifact));
       when(
-        () => mockService.downloadArtifact(
-          artifact,
-          onProgress: any(named: "onProgress"),
-        ),
+        () => mockService.resolveArtifact(release.index.android),
+      ).thenAnswer((_) async => Right(artifact));
+      when(
+        () => mockService.downloadArtifact(artifact, onProgress: any(named: "onProgress")),
       ).thenAnswer((_) async => const Right("/tmp/update.apk"));
 
       final states = <AppUpdateStatus>[];
@@ -107,8 +103,9 @@ void main() {
       final release = _release();
       release.index.clearAndroid();
 
-      when(() => mockService.resolveArtifact(release.index.android))
-          .thenAnswer((_) async => const Left(AppUpdateNoArtifactError(message: "no artifact")));
+      when(
+        () => mockService.resolveArtifact(release.index.android),
+      ).thenAnswer((_) async => const Left(AppUpdateNoArtifactError(message: "no artifact")));
 
       await container.read(appUpdateControllerProvider(release).notifier).download();
 
@@ -118,13 +115,11 @@ void main() {
 
     test("install transitions to installing then readyToInstall on success", () async {
       final release = _release();
-      container
-          .read(appUpdateControllerProvider(release).notifier)
-          .state = const AppUpdateStatus.readyToInstall(apkPath: "/tmp/update.apk");
+      container.read(appUpdateControllerProvider(release).notifier).state =
+          const AppUpdateStatus.readyToInstall(apkPath: "/tmp/update.apk");
 
       when(() => mockService.canInstall()).thenAnswer((_) async => true);
-      when(() => mockService.install("/tmp/update.apk"))
-          .thenAnswer((_) async => const Right(unit));
+      when(() => mockService.install("/tmp/update.apk")).thenAnswer((_) async => const Right(unit));
 
       final states = <AppUpdateStatus>[];
       final sub = container.listen(
@@ -143,9 +138,8 @@ void main() {
 
     test("install fails when permission denied", () async {
       final release = _release();
-      container
-          .read(appUpdateControllerProvider(release).notifier)
-          .state = const AppUpdateStatus.readyToInstall(apkPath: "/tmp/update.apk");
+      container.read(appUpdateControllerProvider(release).notifier).state =
+          const AppUpdateStatus.readyToInstall(apkPath: "/tmp/update.apk");
 
       when(() => mockService.canInstall()).thenAnswer((_) async => false);
 

--- a/test/storage/repo/app_release_provider_test.dart
+++ b/test/storage/repo/app_release_provider_test.dart
@@ -7,8 +7,8 @@ import "package:eve_fit_assistant/config/paths.dart";
 import "package:eve_fit_assistant/config/type_list.dart";
 import "package:eve_fit_assistant/data/proto/generation_pointer.pb.dart";
 import "package:eve_fit_assistant/data/proto/release_index.pb.dart";
-import "package:eve_fit_assistant/features/announcements/state/announcement_state_notifier.dart";
-import "package:eve_fit_assistant/features/announcements/state/announcement_state_store.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_notifier.dart";
+import "package:eve_fit_assistant/features/app_update/state/app_version_state_store.dart";
 import "package:eve_fit_assistant/storage/repo/channel_service.dart";
 import "package:eve_fit_assistant/storage/repo/models/remote_app_release.dart";
 import "package:eve_fit_assistant/storage/repo/providers.dart";
@@ -34,16 +34,18 @@ void main() {
   late String tempDir;
   late MockChannelService mockChannelService;
   late MockReleaseSyncService mockReleaseSyncService;
+  late AppVersionStateStore versionStore;
 
   setUpAll(() {
     final logDir = Directory.systemTemp.createTempSync("efa_app_release_provider_test_log_");
     GlobalLogger.init(logDir.path, enableDebugLog: false);
   });
 
-  setUp(() {
+  setUp(() async {
     tempDir = Directory.systemTemp.createTempSync("efa_app_release_provider_test_").path;
     PathProvider.documentsPath = tempDir;
-    AnnouncementStateStore.init();
+    versionStore = AppVersionStateStore(settingsPath: tempDir);
+    await versionStore.init();
 
     mockChannelService = MockChannelService();
     mockReleaseSyncService = MockReleaseSyncService();
@@ -68,6 +70,7 @@ void main() {
               remoteContent: RemoteContentSetting(enabled: remoteEnabled, channel: channel),
             ),
           ),
+          appVersionStateStoreProvider.overrideWithValue(versionStore),
           channelServiceProvider.overrideWith((_) => mockChannelService),
           releaseSyncServiceProvider.overrideWith((_) => mockReleaseSyncService),
         ],
@@ -124,7 +127,7 @@ void main() {
     final container = _container(remoteEnabled: true);
     addTearDown(container.dispose);
 
-    AnnouncementStateStore.acknowledgeRelease("rel-2");
+    versionStore.acknowledgeRelease("rel-2");
 
     final pointer = GenerationPointer(schemaVersion: 1, snapshotHash: "release_snapshot");
     when(() => mockChannelService.readReleasePointer("testing")).thenReturn(Some(pointer));
@@ -148,12 +151,12 @@ void main() {
     ).thenAnswer((_) async => Right(Some(_release(releaseId: "rel-2", version: "2.0.0"))));
 
     await container.read(availableAppReleaseProvider.future);
-    container.read(announcementStateServiceProvider.notifier).acknowledgeRelease("rel-2");
+    container.read(appVersionStateServiceProvider.notifier).acknowledgeRelease("rel-2");
     container.invalidate(availableAppReleaseProvider);
     final result = await container.read(availableAppReleaseProvider.future);
 
     expect(result, const None());
-    expect(AnnouncementStateStore.lastAcknowledgedReleaseId, "rel-2");
+    expect(versionStore.lastAcknowledgedReleaseId, "rel-2");
   });
 
   test("surfaces sync errors as AsyncError", () async {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Announcements dialogs can show rich Markdown (instead of plain text only).
  * Startup can show multiple eligible announcements sequentially.
  * Announcement details can open directly to a pre-selected announcement.
  * Added pull-to-refresh for the announcements feed.
* **Improvements**
  * Announcement and app/version acknowledgements are now tracked separately.
  * Remote and body caches refresh/invalidate more reliably, including pruning stale entries.
  * Unsupported announcement catalogs are safely rejected.
* **Bug Fixes**
  * Improved announcement state migration/persistence, with more robust startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->