### PR TITLE
fix(cli,publisher): skip unchanged snapshots during publish

### DIFF
--- a/bootstrap/remote/publish.py
+++ b/bootstrap/remote/publish.py
@@ -79,18 +79,33 @@ class Publisher:
     def publish_generation(self, channel: str, gen_hash: str) -> None:
         """Upload a single generation and all its referenced snapshots and blobs."""
         gen = self.gen_store.load(gen_hash)
+        parent_gen = self._load_parent_generation(gen)
         prefixes = self._gen_remote_prefix()
 
         self._ensure_alias()
 
-        rm = ResourceManager(self, expected_total=self._count_unique_blobs(gen, prefixes))
+        rm = ResourceManager(
+            self, expected_total=self._count_unique_blobs(gen, parent_gen, prefixes)
+        )
         with rm.progress(), ThreadPoolExecutor(max_workers=self.workers) as ex:
             futures: list[Future[None]] = []
+            changed_resource_hashes = self._changed_resource_snapshots(gen, parent_gen)
+            changed_release = self._changed_release(gen, parent_gen)
             snapshot_uploads = self._enumerate_resource_blobs(
-                gen.resources, prefixes, rm, ex, futures
+                gen.resources,
+                prefixes,
+                rm,
+                ex,
+                futures,
+                only_snapshots=changed_resource_hashes,
             )
             release_dir_upload = self._enumerate_release_blobs(
-                gen.release_pointer, prefixes, rm, ex, futures
+                gen.release_pointer,
+                prefixes,
+                rm,
+                ex,
+                futures,
+                skip=not changed_release,
             )
             for fut in as_completed(futures):
                 fut.result()
@@ -121,18 +136,33 @@ class Publisher:
             return
 
         gen = self.gen_store.load(head.generation_hash)
+        parent_gen = self._load_parent_generation(gen)
         prefixes = self._gen_remote_prefix()
 
         self._ensure_alias()
 
-        rm = ResourceManager(self, expected_total=self._count_unique_blobs(gen, prefixes))
+        rm = ResourceManager(
+            self, expected_total=self._count_unique_blobs(gen, parent_gen, prefixes)
+        )
         with rm.progress(), ThreadPoolExecutor(max_workers=self.workers) as ex:
             futures: list[Future[None]] = []
+            changed_resource_hashes = self._changed_resource_snapshots(gen, parent_gen)
+            changed_release = self._changed_release(gen, parent_gen)
             snapshot_uploads = self._enumerate_resource_blobs(
-                gen.resources, prefixes, rm, ex, futures
+                gen.resources,
+                prefixes,
+                rm,
+                ex,
+                futures,
+                only_snapshots=changed_resource_hashes,
             )
             release_dir_upload = self._enumerate_release_blobs(
-                gen.release_pointer, prefixes, rm, ex, futures
+                gen.release_pointer,
+                prefixes,
+                rm,
+                ex,
+                futures,
+                skip=not changed_release,
             )
             for fut in as_completed(futures):
                 fut.result()
@@ -160,6 +190,42 @@ class Publisher:
         channel-independent.
         """
         return f"{self.remote_root}/"
+
+    def _load_parent_generation(self, gen: Generation) -> Generation | None:
+        """Load the parent generation, if one is recorded and present locally."""
+        parent_hash = gen.metadata.parent or ""
+        if not parent_hash:
+            return None
+        try:
+            return self.gen_store.load(parent_hash)
+        except FileNotFoundError:
+            return None
+
+    def _changed_resource_snapshots(
+        self, gen: Generation, parent_gen: Generation | None
+    ) -> set[str]:
+        """Return the set of resource snapshot hashes that changed vs. parent.
+
+        If there is no parent generation, every snapshot is considered changed.
+        """
+        if parent_gen is None:
+            return {entry.snapshot_hash for entry in gen.resources.entries}
+        parent_hashes = {
+            entry.server_id: entry.snapshot_hash for entry in parent_gen.resources.entries
+        }
+        return {
+            entry.snapshot_hash
+            for entry in gen.resources.entries
+            if parent_hashes.get(entry.server_id) != entry.snapshot_hash
+        }
+
+    def _changed_release(self, gen: Generation, parent_gen: Generation | None) -> bool:
+        """True when the release pointer differs from the parent generation."""
+        if not gen.release_pointer.snapshot_hash:
+            return False
+        if parent_gen is None:
+            return True
+        return gen.release_pointer.snapshot_hash != parent_gen.release_pointer.snapshot_hash
 
     def _ensure_alias(self) -> None:
         """Set the S3 alias once (thread-safe, idempotent)."""
@@ -211,8 +277,15 @@ class Publisher:
         rm: ResourceManager,
         ex: ThreadPoolExecutor,
         futures: list[Future[None]],
+        *,
+        only_snapshots: set[str] | None = None,
     ) -> list[tuple[Path, str]]:
-        """Collect unique snapshot dir uploads (direct) and dispatch their blobs to the RM."""
+        """Collect changed snapshot dir uploads and dispatch their blobs to the RM.
+
+        Snapshots not listed in ``only_snapshots`` are skipped entirely under the
+        assumption that they were already uploaded as part of the parent
+        generation. When ``only_snapshots`` is None, every snapshot is processed.
+        """
         from bootstrap.remote.models import ResourceIndex
 
         seen: set[str] = set()
@@ -222,6 +295,9 @@ class Publisher:
             if snap_hash in seen:
                 continue
             seen.add(snap_hash)
+
+            if only_snapshots is not None and snap_hash not in only_snapshots:
+                continue
 
             snap_dir = resource_snapshot_dir(self.local_root, snap_hash)
             if not snap_dir.is_dir():
@@ -236,12 +312,14 @@ class Publisher:
             for ri_entry in index.entries:
                 ihash = ident_hash(ri_entry.resource_id)
                 bpath = blob_path(self.local_root, ihash, ri_entry.content_hash)
+                remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}"
                 if not bpath.is_file():
+                    if self._remote_exists(remote):
+                        continue
                     raise FileNotFoundError(
                         f"Resource blob missing: {bpath} "
                         f"(snapshot {snap_hash}, resource {ri_entry.resource_id})"
                     )
-                remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}"
                 futures.append(ex.submit(rm.process_blob, bpath, remote))
         return snapshot_uploads
 
@@ -252,9 +330,18 @@ class Publisher:
         rm: ResourceManager,
         ex: ThreadPoolExecutor,
         futures: list[Future[None]],
+        *,
+        skip: bool = False,
     ) -> tuple[Path, str] | None:
-        """Dispatch release APK blobs to the RM; return the release snapshot dir upload."""
+        """Dispatch release APK blobs to the RM; return the release snapshot dir upload.
+
+        When ``skip`` is True, the release snapshot is assumed unchanged from the
+        parent generation and is not enumerated or uploaded.
+        """
         from bootstrap.remote.models import ReleaseIndex
+
+        if skip:
+            return None
 
         snap_hash = pointer.snapshot_hash
         if not snap_hash:
@@ -285,25 +372,36 @@ class Publisher:
             v = getattr(android, variant_name)
             ihash = ident_hash(v.identifier)
             bpath = blob_path(self.local_root, ihash, v.content_hash)
+            remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
             if not bpath.is_file():
+                if self._remote_exists(remote):
+                    continue
                 raise FileNotFoundError(
                     f"Release blob missing: {bpath} (snapshot {snap_hash}, variant {variant_name})"
                 )
-            remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
             futures.append(ex.submit(rm.process_blob, bpath, remote))
         return dir_upload
 
-    def _count_unique_blobs(self, gen: Generation, prefixes: str) -> int:
-        """Pre-count unique blob remote paths to seed the progress bar total (spec §4)."""
+    def _count_unique_blobs(
+        self, gen: Generation, parent_gen: Generation | None, prefixes: str
+    ) -> int:
+        """Pre-count unique blob remote paths for changed snapshots only.
+
+        Unchanged snapshots inherited from the parent generation are not
+        counted, because they are skipped during enumeration.
+        """
         from bootstrap.remote.models import ReleaseIndex
         from bootstrap.remote.models import ResourceIndex
+
+        changed_resource_hashes = self._changed_resource_snapshots(gen, parent_gen)
+        changed_release = self._changed_release(gen, parent_gen)
 
         unique: set[str] = set()
 
         seen: set[str] = set()
         for entry in gen.resources.entries:
             snap_hash = entry.snapshot_hash
-            if snap_hash in seen:
+            if snap_hash in seen or snap_hash not in changed_resource_hashes:
                 continue
             seen.add(snap_hash)
             snap_dir = resource_snapshot_dir(self.local_root, snap_hash)
@@ -321,27 +419,28 @@ class Publisher:
                         prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}"
                     )
 
-        snap_hash = gen.release_pointer.snapshot_hash
-        if snap_hash:
-            snap_dir = release_snapshot_dir(self.local_root, snap_hash)
-            pb2_file = snap_dir / "releases.pb2"
-            if snap_dir.is_dir() and pb2_file.is_file():
-                try:
-                    rel_index = read_pb2(pb2_file, ReleaseIndex)
-                except Exception:
-                    rel_index = None
-                if rel_index is not None and rel_index.HasField("android"):
-                    android = rel_index.android
-                    for variant_name in _RELEASE_VARIANT_NAMES:
-                        if not android.HasField(variant_name):
-                            continue
-                        v = getattr(android, variant_name)
-                        ihash = ident_hash(v.identifier)
-                        bpath = blob_path(self.local_root, ihash, v.content_hash)
-                        if bpath.is_file():
-                            unique.add(
-                                prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
-                            )
+        if changed_release:
+            snap_hash = gen.release_pointer.snapshot_hash
+            if snap_hash:
+                snap_dir = release_snapshot_dir(self.local_root, snap_hash)
+                pb2_file = snap_dir / "releases.pb2"
+                if snap_dir.is_dir() and pb2_file.is_file():
+                    try:
+                        rel_index = read_pb2(pb2_file, ReleaseIndex)
+                    except Exception:
+                        rel_index = None
+                    if rel_index is not None and rel_index.HasField("android"):
+                        android = rel_index.android
+                        for variant_name in _RELEASE_VARIANT_NAMES:
+                            if not android.HasField(variant_name):
+                                continue
+                            v = getattr(android, variant_name)
+                            ihash = ident_hash(v.identifier)
+                            bpath = blob_path(self.local_root, ihash, v.content_hash)
+                            if bpath.is_file():
+                                unique.add(
+                                    prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
+                                )
 
         return len(unique)
 

--- a/bootstrap/remote/publish.py
+++ b/bootstrap/remote/publish.py
@@ -13,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 from typing import TYPE_CHECKING
 
+from google.protobuf.message import DecodeError
 from tqdm import tqdm
 
 from bootstrap.remote.generation import GenerationStore
@@ -314,12 +315,22 @@ class Publisher:
                 bpath = blob_path(self.local_root, ihash, ri_entry.content_hash)
                 remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{ri_entry.content_hash}"
                 if not bpath.is_file():
-                    if self._remote_exists(remote):
-                        continue
-                    raise FileNotFoundError(
-                        f"Resource blob missing: {bpath} "
-                        f"(snapshot {snap_hash}, resource {ri_entry.resource_id})"
-                    )
+
+                    def _check_remote_resource(
+                        local_bpath: Path = bpath,
+                        remote_path: str = remote,
+                        snap: str = snap_hash,
+                        res_id: str = ri_entry.resource_id,
+                    ) -> None:
+                        if self._remote_exists(remote_path):
+                            return
+                        raise FileNotFoundError(
+                            f"Resource blob missing: {local_bpath} "
+                            f"(snapshot {snap}, resource {res_id})"
+                        )
+
+                    futures.append(ex.submit(_check_remote_resource))
+                    continue
                 futures.append(ex.submit(rm.process_blob, bpath, remote))
         return snapshot_uploads
 
@@ -374,11 +385,21 @@ class Publisher:
             bpath = blob_path(self.local_root, ihash, v.content_hash)
             remote = prefixes + f"assets/blobs/{ihash[:2]}/{ihash}/{v.content_hash}"
             if not bpath.is_file():
-                if self._remote_exists(remote):
-                    continue
-                raise FileNotFoundError(
-                    f"Release blob missing: {bpath} (snapshot {snap_hash}, variant {variant_name})"
-                )
+
+                def _check_remote_release(
+                    local_bpath: Path = bpath,
+                    remote_path: str = remote,
+                    snap: str = snap_hash,
+                    variant: str = variant_name,
+                ) -> None:
+                    if self._remote_exists(remote_path):
+                        return
+                    raise FileNotFoundError(
+                        f"Release blob missing: {local_bpath} (snapshot {snap}, variant {variant})"
+                    )
+
+                futures.append(ex.submit(_check_remote_release))
+                continue
             futures.append(ex.submit(rm.process_blob, bpath, remote))
         return dir_upload
 
@@ -427,7 +448,7 @@ class Publisher:
                 if snap_dir.is_dir() and pb2_file.is_file():
                     try:
                         rel_index = read_pb2(pb2_file, ReleaseIndex)
-                    except Exception:
+                    except (OSError, DecodeError):
                         rel_index = None
                     if rel_index is not None and rel_index.HasField("android"):
                         android = rel_index.android

--- a/bootstrap/tests/test_resource_manager.py
+++ b/bootstrap/tests/test_resource_manager.py
@@ -415,7 +415,127 @@ def _build_apk_dedup_generation(root: Path) -> dict[str, str]:
     return {"apk_remote": remote_blob_path(apk_id, apk_chash)}
 
 
+def _build_inherited_release_generation(root: Path) -> dict[str, str]:
+    """Parent generation with resources only; child generation adds a release."""
+    snap_store = SnapshotStore(root)
+    gen_store = GenerationStore(root)
+    head_store = ChannelHeadStore(root)
+
+    a_data = b"unique-a-bytes"
+    a_chash = content_hash(a_data)
+    b_data = b"unique-b-bytes"
+    b_chash = content_hash(b_data)
+    make_blob(root, "resource://a.bin", a_chash, a_data)
+    make_blob(root, "resource://b.bin", b_chash, b_data)
+
+    idx_a = ResourceIndex()
+    idx_a.schema_version = 1
+    e = idx_a.entries.add()
+    e.resource_id = "resource://a.bin"
+    e.content_hash = a_chash
+    e.size = len(a_data)
+    meta_a = ResourceSnapshotMetadata(
+        serverId="srvA",
+        gameBuild="1.0",
+        gameVersion="Test",
+        resourceCount=1,
+        createdAt="2026-01-01T00:00:00Z",
+    )
+    snap_a = snap_store.create_resource_snapshot(meta_a, idx_a)
+
+    idx_b = ResourceIndex()
+    idx_b.schema_version = 1
+    e = idx_b.entries.add()
+    e.resource_id = "resource://b.bin"
+    e.content_hash = b_chash
+    e.size = len(b_data)
+    meta_b = ResourceSnapshotMetadata(
+        serverId="srvB",
+        gameBuild="1.0",
+        gameVersion="Test",
+        resourceCount=1,
+        createdAt="2026-01-01T00:00:00Z",
+    )
+    snap_b = snap_store.create_resource_snapshot(meta_b, idx_b)
+
+    server_index = make_server_index(
+        [
+            ("srvA", {"en": "Server A"}, "1.0", "Test", "", "", ""),
+            ("srvB", {"en": "Server B"}, "1.0", "Test", "", "", ""),
+        ]
+    )
+    resources = make_generation_resources([("srvA", snap_a), ("srvB", snap_b)])
+
+    parent_release_ptr = make_generation_pointer("")
+    parent_meta = GenerationMetadata(channel="stable", timestamp="2026-01-01T00:00:00Z")
+    parent_hash = gen_store.create(parent_meta, server_index, resources, parent_release_ptr)
+
+    apk_data = b"apk-bytes"
+    apk_chash = content_hash(apk_data)
+    apk_id = "release://1.0.0/android/general"
+    make_blob(root, apk_id, apk_chash, apk_data)
+    rel_index = make_release_index(
+        release_id="rel-001",
+        version="1.0.0",
+        android={
+            "general": {
+                "identifier": apk_id,
+                "content_hash": apk_chash,
+                "size": len(apk_data),
+            }
+        },
+    )
+    rel_meta = ReleaseSnapshotMetadata(releaseCount=1, createdAt="2026-01-01T00:00:00Z")
+    release_snap = snap_store.create_release_snapshot(rel_meta, rel_index)
+
+    child_release_ptr = make_generation_pointer(release_snap)
+    child_meta = GenerationMetadata(
+        channel="stable",
+        timestamp="2026-01-01T01:00:00Z",
+        parent=parent_hash,
+    )
+    child_hash = gen_store.create(child_meta, server_index, resources, child_release_ptr)
+
+    head_store.ensure_channel("stable")
+    head_store.push("stable", child_hash)
+
+    return {
+        "parent_hash": parent_hash,
+        "child_hash": child_hash,
+        "snap_a": snap_a,
+        "snap_b": snap_b,
+        "release_snap": release_snap,
+        "a_remote": remote_blob_path("resource://a.bin", a_chash),
+        "b_remote": remote_blob_path("resource://b.bin", b_chash),
+        "apk_remote": remote_blob_path(apk_id, apk_chash),
+    }
+
+
 class TestPublisherIntegration:
+    def test_publish_only_uploads_changed_snapshots(self, tmp_path: Path) -> None:
+        root = tmp_path / "local"
+        root.mkdir(parents=True, exist_ok=True)
+        origin = make_origin(tmp_path)
+        info = _build_inherited_release_generation(root)
+        pub = Publisher(root, origin_dir=origin)
+        head_store = ChannelHeadStore(root)
+
+        head_store.push("stable", info["parent_hash"])
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            pub.publish_all_for_head("stable")
+        parent_puts = blob_puts(spy)
+        assert info["a_remote"] in parent_puts
+        assert info["b_remote"] in parent_puts
+        assert info["apk_remote"] not in parent_puts
+
+        head_store.push("stable", info["child_hash"])
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            pub.publish_all_for_head("stable")
+        child_puts = blob_puts(spy)
+        assert info["a_remote"] not in child_puts
+        assert info["b_remote"] not in child_puts
+        assert info["apk_remote"] in child_puts
+
     def test_publish_dedups_shared_blob(self, tmp_path: Path) -> None:
         root = tmp_path / "local"
         root.mkdir(parents=True, exist_ok=True)
@@ -446,6 +566,72 @@ class TestPublisherIntegration:
         assert (base / "assets" / "releases" / info["release_snap"] / "metadata.json").is_file()
         assert (base / "channels" / "refs" / info["gen_hash"] / "metadata.json").is_file()
         assert (base / "channels" / "heads" / "stable" / "metadata.json").is_file()
+
+    def test_publish_skips_missing_local_blob_when_remote_exists(self, tmp_path: Path) -> None:
+        root = tmp_path / "local"
+        root.mkdir(parents=True, exist_ok=True)
+        origin = make_origin(tmp_path)
+        _build_shared_blob_generation(root)
+        pub = Publisher(root, origin_dir=origin)
+
+        pub.publish_all_for_head("stable")
+
+        local_shared = blob_path(
+            root,
+            ident_hash("resource://shared.bin"),
+            content_hash(b"shared-resource-bytes"),
+        )
+        assert local_shared.is_file()
+        local_shared.unlink()
+
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            pub.publish_all_for_head("stable")
+
+        puts = blob_puts(spy)
+        shared_remote = remote_blob_path(
+            "resource://shared.bin", content_hash(b"shared-resource-bytes")
+        )
+        assert shared_remote not in puts
+
+    def test_publish_skips_missing_local_release_blob_when_remote_exists(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "local"
+        root.mkdir(parents=True, exist_ok=True)
+        origin = make_origin(tmp_path)
+        _build_apk_dedup_generation(root)
+        pub = Publisher(root, origin_dir=origin)
+
+        pub.publish_all_for_head("stable")
+
+        apk_id = "release://2.0.0/android/general"
+        apk_chash = content_hash(b"apk-and-resource-identical")
+        local_apk = blob_path(root, ident_hash(apk_id), apk_chash)
+        assert local_apk.is_file()
+        local_apk.unlink()
+
+        with mock.patch.object(pub, "_upload_file", wraps=pub._upload_file) as spy:
+            pub.publish_all_for_head("stable")
+
+        puts = blob_puts(spy)
+        assert remote_blob_path(apk_id, apk_chash) not in puts
+
+    def test_publish_fails_when_blob_missing_everywhere(self, tmp_path: Path) -> None:
+        root = tmp_path / "local"
+        root.mkdir(parents=True, exist_ok=True)
+        origin = make_origin(tmp_path)
+        _build_shared_blob_generation(root)
+        pub = Publisher(root, origin_dir=origin)
+
+        local_shared = blob_path(
+            root,
+            ident_hash("resource://shared.bin"),
+            content_hash(b"shared-resource-bytes"),
+        )
+        local_shared.unlink()
+
+        with pytest.raises(FileNotFoundError, match="Resource blob missing"):
+            pub.publish_all_for_head("stable")
 
     def test_republish_is_noop(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         root = tmp_path / "local"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing inherited generations now performs delta-aware uploads, transferring only resource snapshots that changed versus the parent and skipping unchanged release uploads.
  * Release-related uploads are included only when the release pointer differs from the parent.

* **Bug Fixes**
  * Publishing is idempotent for missing local files: if the corresponding remote blob already exists, uploads are skipped instead of erroring.
  * Upload progress totals better reflect the actual set of files considered, including safer handling when release indexes can’t be decoded.

* **Tests**
  * Added integration coverage for delta-aware inherited publishing and for skipping or failing when blobs are missing locally/remote.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->