### PR TITLE
ci(release): publish release notes as remote announcements

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -93,6 +93,41 @@ jobs:
               --channel testing \
               --schema-root cache/remote'
 
+      - name: Initialize remote announcement workspace (MinIO mock)
+        if: inputs.test_mode
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote announce init --target minio --force'
+
+      - name: Sync remote announcements
+        if: inputs.test_mode == false
+        env:
+          REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
+          REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
+          REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
+          REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
+        run: |
+          # shellcheck disable=SC2016
+          nix develop .#python --command bash -c \
+            'uv run x.py \
+              --dev-env remote.s3.endpoint="${REMOTE_ENDPOINT}" \
+              --dev-env remote.s3.bucket="${REMOTE_BUCKET}" \
+              --dev-env remote.s3.access_key="${REMOTE_ACCESS_KEY}" \
+              --dev-env remote.s3.secret_key="${REMOTE_SECRET_KEY}" \
+              remote announce sync \
+              --target s3'
+
+      - name: Sync remote announcements (MinIO mock)
+        if: inputs.test_mode
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote announce sync --target minio'
+
+      - name: Stage release note as announcement
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote announce add-release-note'
+
       - name: Stage release snapshot
         run: |
           VERSION="${{ steps.verify.outputs.version }}"
@@ -129,6 +164,24 @@ jobs:
               --target s3 \
               --schema-root cache/remote'
 
+      - name: Publish announcements
+        if: inputs.test_mode == false
+        env:
+          REMOTE_ENDPOINT: ${{ secrets.REMOTE_STORAGE_ENDPOINT }}
+          REMOTE_BUCKET: ${{ secrets.REMOTE_STORAGE_BUCKET }}
+          REMOTE_ACCESS_KEY: ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
+          REMOTE_SECRET_KEY: ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
+        run: |
+          # shellcheck disable=SC2016
+          nix develop .#python --command bash -c \
+            'uv run x.py \
+              --dev-env remote.s3.endpoint="${REMOTE_ENDPOINT}" \
+              --dev-env remote.s3.bucket="${REMOTE_BUCKET}" \
+              --dev-env remote.s3.access_key="${REMOTE_ACCESS_KEY}" \
+              --dev-env remote.s3.secret_key="${REMOTE_SECRET_KEY}" \
+              remote announce publish \
+              --target s3'
+
       - name: Publish to testing channel (MinIO mock)
         if: inputs.test_mode
         run: |
@@ -136,6 +189,12 @@ jobs:
             'uv run x.py remote publish testing \
               --target minio \
               --schema-root cache/remote'
+
+      - name: Publish announcements (MinIO mock)
+        if: inputs.test_mode
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote announce publish --target minio'
 
       - name: Sync and verify remote head
         if: inputs.test_mode == false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,10 @@ You must author the localized content files separately:
 
 For version `0.1.0-beta.7`, the directory is `docs/changelog/0-1-0-beta-7/`.
 
+When the release PR is merged, the release workflow automatically stages the
+release note as a remote announcement entry and publishes it alongside the
+release channel data.
+
 To override the version or published time:
 
 ```bash
@@ -138,7 +142,9 @@ The `release.yml` workflow on the merge commit then:
 2. Reuses `_release.yml` to build and publish the APK.
 3. Merges the release registry fragment.
 4. Publishes the release to the remote `testing` channel.
-5. Creates a lightweight Git tag (`v<version>`) pointing at the merge commit.
+5. Publishes the release note as a remote announcement entry so users are notified
+   of the new version.
+6. Creates a lightweight Git tag (`v<version>`) pointing at the merge commit.
 
 If the merged PR is missing `V-Tested Release`, the release aborts.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes are now automatically staged and published as announcement entries alongside release channel data.
  * Announcements are published to the appropriate remote storage as part of the release workflow.

* **Documentation**
  * Updated release instructions to explain the automatic announcement publishing step after merging a release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->