### PR TITLE
ci(release): default release-data publish to merge

### DIFF
--- a/.github/workflows/_release-data.yml
+++ b/.github/workflows/_release-data.yml
@@ -159,8 +159,7 @@ jobs:
               ci release-data publish testing \
               --hashes snapshot-hashes.json \
               --schema-root cache/remote \
-              --target s3 \
-              --merge'
+              --target s3'
 
       - name: Publish to testing channel (MinIO mock)
         if: inputs.test_mode

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -347,10 +347,10 @@ def register_ci_commands(cli_group: click.Group) -> None:
         help="Max generations to sync after publish (default: 1).",
     )
     @click.option(
-        "--merge",
+        "--merge/--no-merge",
         is_flag=True,
-        default=False,
-        help="Include unchanged server snapshots from the current channel head.",
+        default=True,
+        help="Include unchanged server snapshots from the current channel head (default: true).",
     )
     @click.pass_context
     def release_data_publish(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release data publishing to consistently include unchanged snapshots from the current channel by default.
  * Added an explicit option to disable snapshot merging when publishing.
  * Adjusted testing-channel publishing to use the updated merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->