### PR TITLE
ci(workflows): upload failure diagnostics artifacts across CI jobs

### DIFF
--- a/.github/actions/upload-diagnostics/action.yml
+++ b/.github/actions/upload-diagnostics/action.yml
@@ -1,0 +1,111 @@
+name: Upload diagnostics
+
+description: >-
+  Collect failure diagnostics (x.py logs, JVM crash logs, Gradle daemon logs,
+  MinIO mock log, environment snapshot) into a staging directory, redact any
+  secret values passed via env, and upload them as a workflow artifact.
+  Invoke as the last step of a job with `if: failure()`.
+
+inputs:
+  name:
+    description: "Artifact name (must be unique per job/matrix leg)"
+    required: true
+  retention-days:
+    description: "Artifact retention in days"
+    required: false
+    default: "7"
+  redact-values:
+    description: >-
+      Newline-separated secret values to redact from staged files before upload
+      (artifacts bypass GitHub log masking). Pass secrets via expressions.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Collect diagnostics
+      shell: bash
+      run: |
+        set -u
+        STAGE=".diagnostics"
+        mkdir -p "$STAGE"
+
+        copy_glob() {
+          # copy_glob <subdir> <find args...>
+          local subdir="$1"; shift
+          while IFS= read -r f; do
+            mkdir -p "$STAGE/$subdir"
+            cp "$f" "$STAGE/$subdir/" 2>/dev/null || true
+          done < <(find "$@" 2>/dev/null)
+        }
+
+        # x.py orchestrator logs (repo-relative; works on all runners)
+        if [ -d cache/log ]; then
+          mkdir -p "$STAGE/xpy-log"
+          cp cache/log/*.log "$STAGE/xpy-log/" 2>/dev/null || true
+        fi
+
+        # JVM crash logs (Gradle/AGP); never copy heap dumps or core dumps
+        copy_glob "jvm-crash" . \
+          \( -path ./.git -o -path ./target -o -path ./build -o -path ./android/build \) -prune \
+          -o -type f \( -name 'hs_err_pid*.log' -o -name 'replay_pid*.log' \) -print
+
+        # Gradle daemon logs
+        if [ -d "${HOME:-/nonexistent}/.gradle/daemon" ]; then
+          copy_glob "gradle-daemon" "$HOME/.gradle/daemon" \
+            -type f -name 'daemon-*.out.log'
+        fi
+
+        # MinIO mock daemon log (test-mode release jobs, ubuntu only)
+        for f in /tmp/efa-ci-minio.log; do
+          if [ -f "$f" ]; then
+            mkdir -p "$STAGE/minio"
+            cp "$f" "$STAGE/minio/" 2>/dev/null || true
+          fi
+        done
+
+        # Environment snapshot (disk/memory pressure, OOM-killer evidence)
+        {
+          echo "== date =="; date || true
+          echo "== uname =="; uname -a || true
+          echo "== df -h =="; df -h || true
+          echo "== free -m =="; free -m || true
+          echo "== oom-killer evidence =="
+          if command -v sudo >/dev/null 2>&1; then
+            sudo -n dmesg -T 2>/dev/null | grep -iE 'oom|killed process' || echo "(none)"
+          elif command -v dmesg >/dev/null 2>&1; then
+            dmesg -T 2>/dev/null | grep -iE 'oom|killed process' || echo "(none)"
+          else
+            echo "(dmesg unavailable)"
+          fi
+        } > "$STAGE/environment.txt" 2>&1
+
+        # Guard against multi-GB crash byproducts slipping in
+        find "$STAGE" -type f \( -name '*.hprof' -o -name 'core.[0-9]*' \) -delete 2>/dev/null || true
+
+        echo "Staged diagnostics:"
+        find "$STAGE" -type f -print || true
+
+    - name: Redact secret values
+      shell: bash
+      env:
+        REDACT_VALUES: ${{ inputs.redact-values }}
+      run: |
+        set -u
+        STAGE=".diagnostics"
+        [ -d "$STAGE" ] || exit 0
+        while IFS= read -r value; do
+          if [ -n "$value" ]; then
+            find "$STAGE" -type f -print0 \
+              | xargs -0 sed -i "s|${value}|<redacted>|g" 2>/dev/null || true
+          fi
+        done <<< "$REDACT_VALUES"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: .diagnostics/
+        if-no-files-found: ignore
+        include-hidden-files: true
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/upload-diagnostics/action.yml
+++ b/.github/actions/upload-diagnostics/action.yml
@@ -32,7 +32,15 @@ runs:
         # Collection, redaction and staging are implemented in the x CLI
         # (`uv run x.py ci diagnostics`); see bootstrap/ci/diagnostics.py.
         # Redaction is literal (no regex) and fail-closed per file.
-        nix develop .#python --command uv run x.py ci diagnostics || true
+        # The CLI is best-effort and exits 0 on internal failures, so a
+        # non-zero exit here means the harness itself broke (nix develop,
+        # uv, uncaught error); surface it instead of silently uploading
+        # nothing.
+        status=0
+        nix develop .#python --command uv run x.py ci diagnostics || status=$?
+        if [ "$status" -ne 0 ]; then
+          echo "::warning::Diagnostics collection failed (exit $status); artifact may be missing."
+        fi
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/upload-diagnostics/action.yml
+++ b/.github/actions/upload-diagnostics/action.yml
@@ -24,83 +24,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Collect diagnostics
-      shell: bash
-      run: |
-        set -u
-        STAGE=".diagnostics"
-        mkdir -p "$STAGE"
-
-        copy_glob() {
-          # copy_glob <subdir> <find args...>
-          local subdir="$1"; shift
-          while IFS= read -r f; do
-            mkdir -p "$STAGE/$subdir"
-            cp "$f" "$STAGE/$subdir/" 2>/dev/null || true
-          done < <(find "$@" 2>/dev/null)
-        }
-
-        # x.py orchestrator logs (repo-relative; works on all runners)
-        if [ -d cache/log ]; then
-          mkdir -p "$STAGE/xpy-log"
-          cp cache/log/*.log "$STAGE/xpy-log/" 2>/dev/null || true
-        fi
-
-        # JVM crash logs (Gradle/AGP); never copy heap dumps or core dumps
-        copy_glob "jvm-crash" . \
-          \( -path ./.git -o -path ./target -o -path ./build -o -path ./android/build \) -prune \
-          -o -type f \( -name 'hs_err_pid*.log' -o -name 'replay_pid*.log' \) -print
-
-        # Gradle daemon logs
-        if [ -d "${HOME:-/nonexistent}/.gradle/daemon" ]; then
-          copy_glob "gradle-daemon" "$HOME/.gradle/daemon" \
-            -type f -name 'daemon-*.out.log'
-        fi
-
-        # MinIO mock daemon log (test-mode release jobs, ubuntu only)
-        for f in /tmp/efa-ci-minio.log; do
-          if [ -f "$f" ]; then
-            mkdir -p "$STAGE/minio"
-            cp "$f" "$STAGE/minio/" 2>/dev/null || true
-          fi
-        done
-
-        # Environment snapshot (disk/memory pressure, OOM-killer evidence)
-        {
-          echo "== date =="; date || true
-          echo "== uname =="; uname -a || true
-          echo "== df -h =="; df -h || true
-          echo "== free -m =="; free -m || true
-          echo "== oom-killer evidence =="
-          if command -v sudo >/dev/null 2>&1; then
-            sudo -n dmesg -T 2>/dev/null | grep -iE 'oom|killed process' || echo "(none)"
-          elif command -v dmesg >/dev/null 2>&1; then
-            dmesg -T 2>/dev/null | grep -iE 'oom|killed process' || echo "(none)"
-          else
-            echo "(dmesg unavailable)"
-          fi
-        } > "$STAGE/environment.txt" 2>&1
-
-        # Guard against multi-GB crash byproducts slipping in
-        find "$STAGE" -type f \( -name '*.hprof' -o -name 'core.[0-9]*' \) -delete 2>/dev/null || true
-
-        echo "Staged diagnostics:"
-        find "$STAGE" -type f -print || true
-
-    - name: Redact secret values
+    - name: Collect and redact diagnostics
       shell: bash
       env:
         REDACT_VALUES: ${{ inputs.redact-values }}
       run: |
-        set -u
-        STAGE=".diagnostics"
-        [ -d "$STAGE" ] || exit 0
-        while IFS= read -r value; do
-          if [ -n "$value" ]; then
-            find "$STAGE" -type f -print0 \
-              | xargs -0 sed -i "s|${value}|<redacted>|g" 2>/dev/null || true
-          fi
-        done <<< "$REDACT_VALUES"
+        # Collection, redaction and staging are implemented in the x CLI
+        # (`uv run x.py ci diagnostics`); see bootstrap/ci/diagnostics.py.
+        # Redaction is literal (no regex) and fail-closed per file.
+        nix develop .#python --command uv run x.py ci diagnostics || true
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/_release-data.yml
+++ b/.github/workflows/_release-data.yml
@@ -90,6 +90,15 @@ jobs:
             snapshot-hashes.json
           retention-days: 1
 
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-data-build
+          redact-values: |
+            ${{ secrets.CI_STORAGE_ACCESS_KEY }}
+            ${{ secrets.CI_STORAGE_SECRET_KEY }}
+
   publish:
     name: Publish to testing channel
     needs: build
@@ -169,3 +178,14 @@ jobs:
               --hashes snapshot-hashes.json \
               --schema-root cache/remote \
               --target minio'
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-data-publish
+          redact-values: |
+            ${{ secrets.CI_STORAGE_ACCESS_KEY }}
+            ${{ secrets.CI_STORAGE_SECRET_KEY }}
+            ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
+            ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -249,6 +249,15 @@ jobs:
           path: cache/releases/apk/**/*.apk
           retention-days: 1
 
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-app-release
+          redact-values: |
+            ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
+            ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
+
   tag:
     name: Create Git tag
     needs: release

--- a/.github/workflows/_update-raw-data.yml
+++ b/.github/workflows/_update-raw-data.yml
@@ -66,6 +66,12 @@ jobs:
             echo "has_updates=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-raw-check
+
   update:
     name: Update raw artifacts
     needs: check
@@ -102,6 +108,12 @@ jobs:
           name: raw-artifacts-${{ matrix.server }}
           path: cache/raw-artifacts/${{ matrix.server }}/
           retention-days: 1
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-raw-update-${{ matrix.server }}
 
   upload:
     name: Upload raw artifacts
@@ -149,3 +161,12 @@ jobs:
               --dev-env ci.storage.access_key="$CI_ACCESS_KEY" \
               --dev-env ci.storage.secret_key="$CI_SECRET_KEY" \
               ci raw-data upload --server "$SERVER" --from-dir raw-artifacts/"$SERVER"/'
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-raw-upload-${{ matrix.server }}
+          redact-values: |
+            ${{ secrets.CI_STORAGE_ACCESS_KEY }}
+            ${{ secrets.CI_STORAGE_SECRET_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,9 @@ jobs:
         run: nix develop .#${{ matrix.shell }} --command bash -c '${{ matrix.lint_command }}'
       - name: Test ${{ matrix.suite }}
         run: nix develop .#${{ matrix.shell }} --command bash -c '${{ matrix.command }}'
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-ci-${{ matrix.suite }}

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -36,6 +36,12 @@ jobs:
               --base-ref origin/${{ github.base_ref }} \
               --check-notes --check-tag --check-note-content'
 
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-preflight
+
   drop-labels:
     name: Drop test labels on update
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 migrate_working_dir/
 temp/
 
+# JVM crash byproducts (heap dumps can be multi-GB)
+*.hprof
+core.[0-9]*
+
 # IntelliJ related
 *.iml
 *.ipr

--- a/bootstrap/ci/__init__.py
+++ b/bootstrap/ci/__init__.py
@@ -4,6 +4,9 @@ from bootstrap.ci.codegen import CODEGEN_STEPS
 from bootstrap.ci.codegen import LANGUAGE_STEPS
 from bootstrap.ci.codegen import run_codegen
 from bootstrap.ci.commands import register_ci_commands
+from bootstrap.ci.diagnostics import collect_diagnostics
+from bootstrap.ci.diagnostics import redact_staged_files
+from bootstrap.ci.diagnostics import register_ci_diagnostics_commands
 from bootstrap.ci.lint import run_lint
 from bootstrap.ci.lint import run_site_checks
 from bootstrap.ci.suites import SUITE_DEFINITIONS
@@ -17,9 +20,12 @@ __all__ = [
     "LANGUAGE_STEPS",
     "SUITE_DEFINITIONS",
     "calculate_ci_matrix",
+    "collect_diagnostics",
     "glob_to_regex",
     "match_any_pattern",
+    "redact_staged_files",
     "register_ci_commands",
+    "register_ci_diagnostics_commands",
     "run_codegen",
     "run_lint",
     "run_site_checks",

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -12,6 +12,7 @@ from colorama import Fore
 from colorama import Style
 
 from bootstrap.ci.codegen import run_codegen
+from bootstrap.ci.diagnostics import register_ci_diagnostics_commands
 from bootstrap.ci.lint import run_lint
 from bootstrap.ci.release import register_ci_release_commands
 from bootstrap.ci.suites import SUITE_DEFINITIONS
@@ -31,6 +32,7 @@ def register_ci_commands(cli_group: click.Group) -> None:
         """CI/CD helper commands."""
 
     register_ci_release_commands(ci)
+    register_ci_diagnostics_commands(ci)
 
     @ci.command("matrix")
     @click.option("--from-file", type=click.Path(exists=True), default=None)

--- a/bootstrap/ci/diagnostics.py
+++ b/bootstrap/ci/diagnostics.py
@@ -23,7 +23,17 @@ GRADLE_DAEMON_DIR = "gradle-daemon"
 MINIO_DIR = "minio"
 
 JVM_CRASH_PATTERNS = ("hs_err_pid*.log", "replay_pid*.log")
-PRUNE_PREFIXES = ((".git",), ("target",), ("build",), ("android", "build"))
+PRUNE_DIR_NAMES = frozenset(
+    {
+        ".dart_tool",
+        ".git",
+        ".venv",
+        "__pycache__",
+        "build",
+        "node_modules",
+        "target",
+    }
+)
 CRASH_BYPRODUCT_PATTERNS = ("*.hprof", "core.[0-9]*")
 MINIO_LOG_PATHS = (Path("/tmp/efa-ci-minio.log"),)
 
@@ -48,15 +58,10 @@ def _collect_xpy_logs(root: Path, stage: Path) -> list[Path]:
     return _copy_into(sorted(src.glob("*.log")), stage / XPY_LOG_DIR)
 
 
-def _matches_prune_prefix(path: Path) -> bool:
-    return any(path.parts[: len(prefix)] == prefix for prefix in PRUNE_PREFIXES)
-
-
 def _collect_jvm_crash_logs(root: Path, stage: Path) -> list[Path]:
     found = []
     for dirpath, dirnames, filenames in os.walk(root):
-        rel = Path(dirpath).relative_to(root)
-        dirnames[:] = [d for d in dirnames if not _matches_prune_prefix(rel / d)]
+        dirnames[:] = [d for d in dirnames if d not in PRUNE_DIR_NAMES]
         for name in filenames:
             if any(fnmatch.fnmatch(name, pattern) for pattern in JVM_CRASH_PATTERNS):
                 found.append(Path(dirpath) / name)

--- a/bootstrap/ci/diagnostics.py
+++ b/bootstrap/ci/diagnostics.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import fnmatch
+import os
+import shutil
+import subprocess
+
+from pathlib import Path
+
+import click
+
+from bootstrap.constant import PROJECT_ROOT
+from bootstrap.log import error
+from bootstrap.log import info
+from bootstrap.log import warning
+
+
+REDACTED = b"<redacted>"
+
+XPY_LOG_DIR = "xpy-log"
+JVM_CRASH_DIR = "jvm-crash"
+GRADLE_DAEMON_DIR = "gradle-daemon"
+MINIO_DIR = "minio"
+
+JVM_CRASH_PATTERNS = ("hs_err_pid*.log", "replay_pid*.log")
+PRUNE_PREFIXES = ((".git",), ("target",), ("build",), ("android", "build"))
+CRASH_BYPRODUCT_PATTERNS = ("*.hprof", "core.[0-9]*")
+MINIO_LOG_PATHS = (Path("/tmp/efa-ci-minio.log"),)
+
+
+def _copy_into(files: list[Path], dest: Path) -> list[Path]:
+    copied = []
+    for src in files:
+        try:
+            dest.mkdir(parents=True, exist_ok=True)
+            target = dest / src.name
+            shutil.copy2(src, target)
+            copied.append(target)
+        except OSError as exc:
+            warning(f"Failed to stage {src}: {exc}")
+    return copied
+
+
+def _collect_xpy_logs(root: Path, stage: Path) -> list[Path]:
+    src = root / "cache" / "log"
+    if not src.is_dir():
+        return []
+    return _copy_into(sorted(src.glob("*.log")), stage / XPY_LOG_DIR)
+
+
+def _matches_prune_prefix(path: Path) -> bool:
+    return any(path.parts[: len(prefix)] == prefix for prefix in PRUNE_PREFIXES)
+
+
+def _collect_jvm_crash_logs(root: Path, stage: Path) -> list[Path]:
+    found = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel = Path(dirpath).relative_to(root)
+        dirnames[:] = [d for d in dirnames if not _matches_prune_prefix(rel / d)]
+        for name in filenames:
+            if any(fnmatch.fnmatch(name, pattern) for pattern in JVM_CRASH_PATTERNS):
+                found.append(Path(dirpath) / name)
+    return _copy_into(found, stage / JVM_CRASH_DIR)
+
+
+def _collect_gradle_daemon_logs(stage: Path) -> list[Path]:
+    daemon_dir = Path.home() / ".gradle" / "daemon"
+    if not daemon_dir.is_dir():
+        return []
+    return _copy_into(sorted(daemon_dir.glob("**/daemon-*.out.log")), stage / GRADLE_DAEMON_DIR)
+
+
+def _collect_minio_logs(stage: Path) -> list[Path]:
+    return _copy_into([p for p in MINIO_LOG_PATHS if p.is_file()], stage / MINIO_DIR)
+
+
+def _run_snapshot_command(cmd: list[str]) -> str:
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"(unavailable: {exc})"
+    return (out.stdout + out.stderr).strip() or "(no output)"
+
+
+def _oom_evidence() -> str:
+    if shutil.which("sudo"):
+        cmd = ["sudo", "-n", "dmesg", "-T"]
+    elif shutil.which("dmesg"):
+        cmd = ["dmesg", "-T"]
+    else:
+        return "(dmesg unavailable)"
+    output = _run_snapshot_command(cmd)
+    lines = [
+        line
+        for line in output.splitlines()
+        if "oom" in line.lower() or "killed process" in line.lower()
+    ]
+    return "\n".join(lines) if lines else "(none)"
+
+
+def _write_environment_snapshot(stage: Path) -> Path:
+    sections = [
+        ("date", ["date"]),
+        ("uname", ["uname", "-a"]),
+        ("df -h", ["df", "-h"]),
+        ("free -m", ["free", "-m"]),
+    ]
+    lines = []
+    for title, cmd in sections:
+        lines.append(f"== {title} ==")
+        lines.append(_run_snapshot_command(cmd))
+    lines.append("== oom-killer evidence ==")
+    lines.append(_oom_evidence())
+
+    target = stage / "environment.txt"
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return target
+
+
+def _drop_crash_byproducts(stage: Path) -> None:
+    for path in stage.rglob("*"):
+        if path.is_file() and any(
+            fnmatch.fnmatch(path.name, pattern) for pattern in CRASH_BYPRODUCT_PATTERNS
+        ):
+            try:
+                path.unlink()
+            except OSError as exc:
+                warning(f"Failed to remove crash byproduct {path}: {exc}")
+
+
+def collect_diagnostics(root: Path, stage: Path) -> list[Path]:
+    """Collect failure diagnostics into the staging directory (best effort)."""
+    stage.mkdir(parents=True, exist_ok=True)
+    staged: list[Path] = []
+    collectors = [
+        lambda: _collect_xpy_logs(root, stage),
+        lambda: _collect_jvm_crash_logs(root, stage),
+        lambda: _collect_gradle_daemon_logs(stage),
+        lambda: _collect_minio_logs(stage),
+        lambda: [_write_environment_snapshot(stage)],
+    ]
+    for collector in collectors:
+        try:
+            staged.extend(collector())
+        except Exception as exc:
+            warning(f"Diagnostics collector failed: {exc}")
+    _drop_crash_byproducts(stage)
+    return staged
+
+
+def redact_staged_files(stage: Path, values: list[str]) -> tuple[int, int]:
+    """Replace literal secret values in all staged files.
+
+    Matching is byte-level and fully literal (no regex), so secrets containing
+    metacharacters or delimiter characters are handled safely. Files that
+    cannot be read or rewritten are removed from the staging area instead of
+    being uploaded unredacted (fail-closed).
+
+    Returns (files_scanned, files_redacted).
+    """
+    needles = [v.encode("utf-8", errors="surrogateescape") for v in values if v]
+    scanned = 0
+    redacted = 0
+    for path in sorted(stage.rglob("*")):
+        if not path.is_file():
+            continue
+        scanned += 1
+        try:
+            data = path.read_bytes()
+        except OSError as exc:
+            warning(f"Removing unreadable staged file {path}: {exc}")
+            path.unlink(missing_ok=True)
+            continue
+        new_data = data
+        for needle in needles:
+            new_data = new_data.replace(needle, REDACTED)
+        if new_data == data:
+            continue
+        try:
+            path.write_bytes(new_data)
+        except OSError as exc:
+            warning(f"Failed to redact {path}; removing it from the artifact: {exc}")
+            path.unlink(missing_ok=True)
+            continue
+        redacted += 1
+    return scanned, redacted
+
+
+def register_ci_diagnostics_commands(ci: click.Group) -> None:
+    @ci.command("diagnostics")
+    @click.option(
+        "--stage",
+        type=click.Path(file_okay=False, path_type=Path),
+        default=".diagnostics",
+        help="Staging directory for collected diagnostics (default: .diagnostics).",
+    )
+    @click.option(
+        "--redact-values",
+        envvar="REDACT_VALUES",
+        default="",
+        help="Newline-separated secret values to redact (defaults to REDACT_VALUES env var).",
+    )
+    def ci_diagnostics(stage: Path, redact_values: str):
+        """Collect failure diagnostics into a staging directory and redact secrets."""
+        resolved = stage.resolve()
+        collect_diagnostics(PROJECT_ROOT, resolved)
+
+        values = [line.rstrip("\r") for line in redact_values.splitlines()]
+        values = [v for v in values if v]
+        if values:
+            try:
+                scanned, redacted = redact_staged_files(resolved, values)
+            except Exception as exc:
+                error(f"Redaction failed unexpectedly: {exc}")
+                error("Purging staging directory to avoid uploading unredacted data.")
+                shutil.rmtree(resolved, ignore_errors=True)
+                resolved.mkdir(parents=True, exist_ok=True)
+                return
+            info(f"Redacted secrets in {redacted}/{scanned} staged files.")
+        else:
+            info("No redact values provided; skipping redaction.")
+
+        click.echo("Staged diagnostics:")
+        for path in sorted(resolved.rglob("*")):
+            if path.is_file():
+                click.echo(f"  {path}")

--- a/bootstrap/tests/test_ci_diagnostics.py
+++ b/bootstrap/tests/test_ci_diagnostics.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import os
+
+from typing import TYPE_CHECKING
+
+from bootstrap.ci.diagnostics import collect_diagnostics
+from bootstrap.ci.diagnostics import redact_staged_files
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_redact_literal_metacharacters(tmp_path: Path):
+    target = _write(
+        tmp_path / "log.txt",
+        b"key=a.b*c|d$E and other aXbYc|d$E text\n",
+    )
+    scanned, redacted = redact_staged_files(tmp_path, ["a.b*c|d$E"])
+    assert (scanned, redacted) == (1, 1)
+    assert target.read_bytes() == b"key=<redacted> and other aXbYc|d$E text\n"
+
+
+def test_redact_multiple_values_and_files(tmp_path: Path):
+    first = _write(tmp_path / "a.log", b"alpha secret-one omega\n")
+    second = _write(tmp_path / "nested" / "b.log", b"alpha secret-two omega\n")
+    scanned, redacted = redact_staged_files(tmp_path, ["secret-one", "secret-two"])
+    assert (scanned, redacted) == (2, 2)
+    assert first.read_bytes() == b"alpha <redacted> omega\n"
+    assert second.read_bytes() == b"alpha <redacted> omega\n"
+
+
+def test_redact_skips_empty_values(tmp_path: Path):
+    target = _write(tmp_path / "log.txt", b"unchanged\n")
+    scanned, redacted = redact_staged_files(tmp_path, ["", "   \n".strip()])
+    assert (scanned, redacted) == (1, 0)
+    assert target.read_bytes() == b"unchanged\n"
+
+
+def test_redact_binary_safe(tmp_path: Path):
+    target = _write(tmp_path / "blob.bin", b"\x00\xffsecret\x00\xfe")
+    scanned, redacted = redact_staged_files(tmp_path, ["secret"])
+    assert (scanned, redacted) == (1, 1)
+    assert target.read_bytes() == b"\x00\xff<redacted>\x00\xfe"
+
+
+def test_redact_non_utf8_secret(tmp_path: Path):
+    target = _write(tmp_path / "log.txt", "töken value töken\n".encode())
+    _, redacted = redact_staged_files(tmp_path, ["töken"])
+    assert redacted == 1
+    assert target.read_bytes() == b"<redacted> value <redacted>\n"
+
+
+def test_redact_removes_unreadable_files(tmp_path: Path):
+    target = _write(tmp_path / "log.txt", b"secret\n")
+    os.chmod(target, 0)
+    try:
+        scanned, _ = redact_staged_files(tmp_path, ["secret"])
+        assert scanned == 1
+        assert not target.exists()
+    finally:
+        if target.exists():
+            os.chmod(target, 0o644)
+
+
+def test_collect_xpy_logs_and_byproduct_guard(tmp_path: Path):
+    root = tmp_path / "repo"
+    _write(root / "cache" / "log" / "20240101-000000.log", b"log line\n")
+    _write(root / "cache" / "log" / "not-a-log.txt", b"nope\n")
+    stage = tmp_path / "stage"
+
+    staged = collect_diagnostics(root, stage)
+
+    xpy_log = stage / "xpy-log" / "20240101-000000.log"
+    assert xpy_log in staged
+    assert xpy_log.read_bytes() == b"log line\n"
+    assert not (stage / "xpy-log" / "not-a-log.txt").exists()
+    assert (stage / "environment.txt").is_file()
+
+
+def test_collect_jvm_crash_logs_with_pruning(tmp_path: Path):
+    root = tmp_path / "repo"
+    included = _write(root / "sub" / "hs_err_pid123.log", b"crash\n")
+    _write(root / "build" / "hs_err_pid999.log", b"skip\n")
+    _write(root / "android" / "build" / "replay_pid1.log", b"skip\n")
+    _write(root / ".git" / "hs_err_pid1.log", b"skip\n")
+    stage = tmp_path / "stage"
+
+    collect_diagnostics(root, stage)
+
+    crash_dir = stage / "jvm-crash"
+    copied = [p.name for p in crash_dir.iterdir()]
+    assert copied == [included.name]
+
+
+def test_collect_drops_crash_byproducts(tmp_path: Path):
+    root = tmp_path / "repo"
+    _write(root / "hs_err_pid1.log", b"crash\n")
+    stage = tmp_path / "stage"
+    stage.mkdir(parents=True)
+    _write(stage / "jvm-crash" / "dump.hprof", b"heap\n")
+    _write(stage / "jvm-crash" / "core.1234", b"core\n")
+
+    staged = collect_diagnostics(root, stage)
+
+    assert not (stage / "jvm-crash" / "dump.hprof").exists()
+    assert not (stage / "jvm-crash" / "core.1234").exists()
+    assert (stage / "jvm-crash" / "hs_err_pid1.log") in staged
+
+
+def test_environment_snapshot_content(tmp_path: Path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    stage = tmp_path / "stage"
+
+    collect_diagnostics(root, stage)
+
+    content = (stage / "environment.txt").read_text(encoding="utf-8")
+    assert "== date ==" in content
+    assert "== uname ==" in content
+    assert "== df -h ==" in content
+    assert "== free -m ==" in content
+    assert "== oom-killer evidence ==" in content

--- a/bootstrap/tests/test_ci_diagnostics.py
+++ b/bootstrap/tests/test_ci_diagnostics.py
@@ -52,8 +52,10 @@ def test_redact_binary_safe(tmp_path: Path):
 
 
 def test_redact_non_utf8_secret(tmp_path: Path):
-    target = _write(tmp_path / "log.txt", "töken value töken\n".encode())
-    _, redacted = redact_staged_files(tmp_path, ["töken"])
+    secret_bytes = b"\xff\xfetoken"
+    secret = secret_bytes.decode("utf-8", errors="surrogateescape")
+    target = _write(tmp_path / "log.txt", secret_bytes + b" value " + secret_bytes + b"\n")
+    _, redacted = redact_staged_files(tmp_path, [secret])
     assert redacted == 1
     assert target.read_bytes() == b"<redacted> value <redacted>\n"
 

--- a/bootstrap/tests/test_ci_diagnostics.py
+++ b/bootstrap/tests/test_ci_diagnostics.py
@@ -91,6 +91,8 @@ def test_collect_jvm_crash_logs_with_pruning(tmp_path: Path):
     _write(root / "build" / "hs_err_pid999.log", b"skip\n")
     _write(root / "android" / "build" / "replay_pid1.log", b"skip\n")
     _write(root / ".git" / "hs_err_pid1.log", b"skip\n")
+    _write(root / "sub" / "node_modules" / "hs_err_pid5.log", b"skip\n")
+    _write(root / "sub" / "nested" / ".dart_tool" / "replay_pid7.log", b"skip\n")
     stage = tmp_path / "stage"
 
     collect_diagnostics(root, stage)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically upload diagnostics artifacts when CI, release, preflight, and raw-data workflow stages fail.
  * Diagnostics bundle includes relevant logs/crash evidence plus an environment snapshot for faster debugging.
  * Added secret-value redaction to prevent sensitive data from being included.
* **Chores**
  * Updated ignore rules to exclude JVM heap dump (`*.hprof`) and core dump files.
* **Tests**
  * Added tests covering diagnostic collection and safe, binary-safe redaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->