### PR TITLE
fix(remote): skip local body check for unchanged remote announcements

### DIFF
--- a/bootstrap/docs/announcements_remote.py
+++ b/bootstrap/docs/announcements_remote.py
@@ -565,7 +565,11 @@ def run_preflight_validation(
         except (json.JSONDecodeError, ValueError) as e:
             errors.append(f"Failed to load active.json: {e}")
 
-    # Check 6-10: Entry-level validations across all pages
+    # Check 6-10: Entry-level validations across all pages.
+    # Bodies unchanged from the remote mirror already exist on the remote, so
+    # they are not required in the local documents/ directory.
+    remote_body_hashes = _load_remote_body_hashes(remote_dir)
+
     ws = _FakeWorkspaceRead(workspace_dir)
     for page_meta in catalog.pages:
         page_uuid = page_meta.uuid
@@ -600,6 +604,8 @@ def run_preflight_validation(
 
                 doc_path = documents_dir / f"{loc.body_hash}.md"
                 if not doc_path.exists():
+                    if remote_body_hashes.get(entry_id, {}).get(locale) == loc.body_hash:
+                        continue
                     errors.append(
                         f"entry {entry_id}/{locale}: body {loc.body_hash} not found in documents/"
                     )
@@ -657,6 +663,30 @@ class _FakeWorkspaceRead:
         if uuid == active_uuid:
             return self._read_active(workspace_dir)
         return self._read_page(workspace_dir, uuid)
+
+
+def _load_remote_body_hashes(remote_dir: Path | None) -> dict[str, dict[str, str]]:
+    """Map entry id → locale → bodyHash from the last-synced remote mirror.
+
+    Used by preflight to skip local body checks for entries whose bodies are
+    unchanged and therefore already published on the remote.
+    """
+    hashes: dict[str, dict[str, str]] = {}
+    if remote_dir is None or not (remote_dir / "catalog.json").exists():
+        return hashes
+    ws = _FakeWorkspaceRead(remote_dir)
+    try:
+        catalog = ws._read_catalog(remote_dir)
+    except (json.JSONDecodeError, ValueError):
+        return hashes
+    for page_meta in catalog.pages:
+        with contextlib.suppress(FileNotFoundError):
+            page = ws._read_any_page(remote_dir, page_meta.uuid)
+            for entry in page.entries:
+                hashes[entry.id] = {
+                    locale: loc.body_hash for locale, loc in entry.localizations.items()
+                }
+    return hashes
 
 
 def _run_remote_compatibility_check(

--- a/bootstrap/tests/test_announcements_remote.py
+++ b/bootstrap/tests/test_announcements_remote.py
@@ -720,6 +720,52 @@ class TestPreflightValidation:
         )
         assert any("exists on remote but not in staging" in e for e in errors)
 
+    def test_unchanged_remote_bodies_not_required_locally(self, workspace: AnnouncementWorkspace):
+        """Publish scenario: remote entries keep their bodies on the remote.
+
+        Only the newly staged entry's bodies are stored locally; preflight
+        must not demand local copies of unchanged remote bodies.
+        """
+        old_entry = _make_entry(entry_id="old-entry", zh_body="old zh", en_body="old en")
+        _setup_remote(workspace, [old_entry])
+
+        new_entry = _make_entry(entry_id="new-entry", zh_body="new zh", en_body="new en")
+        workspace.store_document("new zh")
+        workspace.store_document("new en")
+        overlay = workspace.overlay_upsert_entry(ACTIVE_KEY, new_entry)
+        workspace.write_overlay(overlay)
+
+        temp = workspace.root / "temp"
+        workspace.build_publish_workspace(temp)
+        errors = run_preflight_validation(
+            workspace_dir=temp,
+            documents_dir=workspace.documents_dir,
+            remote_dir=workspace.remote_dir,
+            check_remote=True,
+        )
+        assert errors == []
+
+    def test_changed_body_still_required_locally(self, workspace: AnnouncementWorkspace):
+        """Editing an entry's body requires the new body in documents/."""
+        old_entry = _make_entry(entry_id="edit-me", zh_body="old zh", en_body="old en")
+        _setup_remote(workspace, [old_entry])
+
+        edited = _make_entry(entry_id="edit-me", zh_body="revised zh", en_body="old en")
+        overlay = workspace.overlay_upsert_entry(ACTIVE_KEY, edited)
+        workspace.write_overlay(overlay)
+
+        temp = workspace.root / "temp"
+        workspace.build_publish_workspace(temp)
+        errors = run_preflight_validation(
+            workspace_dir=temp,
+            documents_dir=workspace.documents_dir,
+            remote_dir=workspace.remote_dir,
+            check_remote=True,
+        )
+        zh_hash = edited.localizations["zh"].body_hash
+        assert any(f"body {zh_hash} not found" in e for e in errors)
+        assert not any("edit-me/en" in e for e in errors)
+
 
 # ---------------------------------------------------------------------------
 # Status diff tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publish preflight validation for content already synchronized with the remote workspace.
  * Local copies of unchanged remote documents are no longer required during validation.
  * Updated content is still checked locally, with clear errors reported when required document content is missing or invalid.
* **Tests**
  * Added coverage for unchanged and modified remote document scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->