### PR TITLE
ci(workflows): sign release APKs with the EFA release key

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -286,6 +286,7 @@ jobs:
             ${{ secrets.APP_KEYSTORE }}
             ${{ secrets.APP_KEYSTORE_PASSWORD }}
             ${{ secrets.APP_KEY_PASSWORD }}
+            ${{ secrets.APP_KEY_ALIAS }}
 
       - name: Clean up keystore
         if: always()

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -59,8 +59,33 @@ jobs:
       - name: Generate all
         run: nix develop .#full --command bash -c 'uv run x.py generate -f all'
 
+      - name: Prepare release signing
+        if: inputs.test_mode == false
+        env:
+          APP_KEYSTORE: ${{ secrets.APP_KEYSTORE }}
+          APP_KEYSTORE_PASSWORD: ${{ secrets.APP_KEYSTORE_PASSWORD }}
+          APP_KEY_ALIAS: ${{ secrets.APP_KEY_ALIAS }}
+          APP_KEY_PASSWORD: ${{ secrets.APP_KEY_PASSWORD }}
+        run: |
+          printf '%s' "$APP_KEYSTORE" | base64 -d > "$RUNNER_TEMP/efa-release.keystore"
+          chmod 600 "$RUNNER_TEMP/efa-release.keystore"
+          {
+            echo "EFA_KEYSTORE_FILE=$RUNNER_TEMP/efa-release.keystore"
+            echo "EFA_KEYSTORE_PASSWORD=$APP_KEYSTORE_PASSWORD"
+            echo "EFA_KEY_ALIAS=$APP_KEY_ALIAS"
+            echo "EFA_KEY_PASSWORD=$APP_KEY_PASSWORD"
+          } >> "$GITHUB_ENV"
+
       - name: Build APK
         run: nix develop .#full --command bash -c 'uv run x.py build apk'
+
+      - name: Verify APK signature
+        if: inputs.test_mode == false
+        env:
+          APP_KEY_SHA256: ${{ vars.APP_KEY_SHA256 }}
+        run: |
+          nix develop .#full --command bash -c \
+            'uv run x.py ci release verify-signing'
 
       - name: Merge release registry
         run: |
@@ -258,6 +283,13 @@ jobs:
           redact-values: |
             ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
             ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
+            ${{ secrets.APP_KEYSTORE }}
+            ${{ secrets.APP_KEYSTORE_PASSWORD }}
+            ${{ secrets.APP_KEY_PASSWORD }}
+
+      - name: Clean up keystore
+        if: always()
+        run: rm -f "$RUNNER_TEMP/efa-release.keystore"
 
   tag:
     name: Create Git tag

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -156,7 +156,7 @@ environment protection rules gate which refs may do so.
 
 | Environment | Protection | Contents | Consumed by |
 |-------------|------------|----------|-------------|
-| `production-app` | Required reviewers + `dev` branch only | Secrets: `REMOTE_STORAGE_ENDPOINT`, `REMOTE_STORAGE_ACCESS_KEY`, `REMOTE_STORAGE_SECRET_KEY`. Variable: `REMOTE_STORAGE_BUCKET` | `_release.yml` (real app releases) |
+| `production-app` | Required reviewers + `dev` branch only | Secrets: `REMOTE_STORAGE_ENDPOINT`, `REMOTE_STORAGE_ACCESS_KEY`, `REMOTE_STORAGE_SECRET_KEY`; signing secrets `APP_KEYSTORE` (base64-encoded keystore), `APP_KEYSTORE_PASSWORD`, `APP_KEY_ALIAS`, `APP_KEY_PASSWORD`. Variables: `REMOTE_STORAGE_BUCKET`, `APP_KEY_SHA256` (release-key certificate fingerprint) | `_release.yml` (real app releases) |
 | `production-data` | `dev` branch only (unattended cron) | Secrets: `REMOTE_STORAGE_*` (same three). Variables: `REMOTE_STORAGE_BUCKET`, `CI_STORAGE_BUCKET` | `_release-data.yml` publish job (real data releases) |
 | `ci-write` | `dev` branch only | Secrets: `CI_STORAGE_ENDPOINT`, `CI_STORAGE_ACCESS_KEY`, `CI_STORAGE_SECRET_KEY` (write-scoped token). Variable: `CI_STORAGE_BUCKET` | `_update-raw-data.yml` upload job |
 | `ci-testing` | None (empty environment) | Nothing — no secrets, no variables | `_release.yml` and `_release-data.yml` in `test_mode` (`V-Test`, `D-*` runs) |
@@ -184,6 +184,16 @@ Operational notes:
 - Real app releases pause for a required-reviewer approval before the job can
   access `production-app` secrets. Data releases and raw-data uploads run
   unattended (`dev`-branch restriction only).
+- Android release signing: real app releases sign the APK with the EFA release
+  key. `_release.yml` decodes `APP_KEYSTORE` (base64) into a runner-temp file
+  and passes it plus the passwords/alias to Gradle as `EFA_*` environment
+  variables (`android/app/build.gradle.kts` falls back to debug signing when
+  they are absent, so test mode and local builds are unaffected). After the
+  build the workflow runs `./x ci release verify-signing`, which checks every
+  APK's certificate SHA-256 against the `APP_KEY_SHA256` variable and aborts
+  before publish on mismatch. The
+  Bitwarden vault item holding the keystore and passwords is the source of
+  truth; the GitHub secrets are a mirror — rotate both together.
 - Cleanup after the migration: once the PR test paths and a dispatched cron run
   are green, delete the repository-level `REMOTE_STORAGE_*` secrets and any
   legacy `CI_STORAGE_BUCKET` secret left over from before the migration. Retain

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,6 +5,17 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+val releaseKeystoreFile = System.getenv("EFA_KEYSTORE_FILE")
+val releaseKeystorePassword = System.getenv("EFA_KEYSTORE_PASSWORD")
+val releaseKeyAlias = System.getenv("EFA_KEY_ALIAS")
+val releaseKeyPassword = System.getenv("EFA_KEY_PASSWORD")
+val releaseSigningAvailable = listOf(
+    releaseKeystoreFile,
+    releaseKeystorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword,
+).all { !it.isNullOrEmpty() }
+
 android {
     namespace = "net.efa_tech.eve_fit_assistant"
     compileSdk = flutter.compileSdkVersion
@@ -30,11 +41,27 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        if (releaseSigningAvailable) {
+            create("release") {
+                storeFile = file(releaseKeystoreFile)
+                storePassword = releaseKeystorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // Release builds are signed with the EFA release key when the EFA_* environment
+            // variables are provided (CI real releases); otherwise they fall back to the
+            // debug keys so `flutter run --release` and CI test-mode builds keep working.
+            signingConfig = if (releaseSigningAvailable) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/bootstrap/ci/release.py
+++ b/bootstrap/ci/release.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
 import tomllib
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import click
 
@@ -14,11 +15,8 @@ from bootstrap.config import ProjectVersion
 from bootstrap.constant import PROJECT_ROOT
 
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
-
 _VERSION_RE = re.compile(r"^version\s*:\s*(.+?)\s*$", re.MULTILINE)
+_APKSIGNER_DIGEST_RE = re.compile(r"certificate SHA-256 digest:\s*([0-9a-fA-F:]+)")
 
 
 def _version_key(version: ProjectVersion) -> tuple[object, ...]:
@@ -283,6 +281,76 @@ def _check_build() -> None:
     runtime.execute([flutter, "analyze"], "FLUTTER ANALYZE")
 
 
+def _normalize_sha256(value: str) -> str:
+    """Normalize a SHA-256 fingerprint for comparison (strip colons/spaces, lowercase)."""
+    return value.replace(":", "").replace(" ", "").strip().lower()
+
+
+def _parse_apksigner_digest(output: str) -> str:
+    """Extract the first signer certificate SHA-256 digest from apksigner output."""
+    match = _APKSIGNER_DIGEST_RE.search(output)
+    if not match:
+        raise click.ClickException("apksigner output has no certificate SHA-256 digest")
+    return _normalize_sha256(match.group(1))
+
+
+def _find_apksigner() -> Path:
+    """Locate the newest apksigner under the Android SDK build-tools directories."""
+    candidates: list[Path] = []
+    for env_name in ("ANDROID_HOME", "ANDROID_SDK_ROOT"):
+        root = os.environ.get(env_name)
+        if root:
+            candidates.extend(Path(root).glob("build-tools/*/apksigner"))
+    if not candidates:
+        raise click.ClickException(
+            "apksigner not found: set ANDROID_HOME or ANDROID_SDK_ROOT to the Android SDK"
+        )
+
+    def sort_key(path: Path) -> tuple[int, ...]:
+        return tuple(int(part) if part.isdigit() else 0 for part in path.parent.name.split("."))
+
+    return sorted(candidates, key=sort_key)[-1]
+
+
+def _verify_apk_signature(apksigner: Path, apk: Path, expected: str) -> None:
+    """Verify one APK's signature and certificate digest against the expected value."""
+    try:
+        result = subprocess.run(
+            [str(apksigner), "verify", "--print-certs", str(apk)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise click.ClickException(f"apksigner is not executable: {apksigner}") from exc
+    if result.returncode != 0:
+        raise click.ClickException(
+            f"apksigner verification failed for {apk}:\n{result.stderr.strip()}"
+        )
+    digest = _parse_apksigner_digest(result.stdout)
+    if digest != expected:
+        raise click.ClickException(
+            f"{apk}: certificate SHA-256 mismatch\n  expected: {expected}\n  actual:   {digest}"
+        )
+    click.echo(f"  {apk} OK (SHA-256: {digest})")
+
+
+def _verify_signing(apk_dir: Path, expected_sha256: str | None) -> None:
+    """Verify every APK under apk_dir is signed with the expected release key."""
+    if not expected_sha256:
+        raise click.ClickException(
+            "Expected fingerprint missing: pass --expected-sha256 or set APP_KEY_SHA256"
+        )
+    expected = _normalize_sha256(expected_sha256)
+    apks = sorted(apk_dir.rglob("*.apk"))
+    if not apks:
+        raise click.ClickException(f"No APKs found under {apk_dir}")
+    apksigner = _find_apksigner()
+    for apk in apks:
+        _verify_apk_signature(apksigner, apk, expected)
+    click.echo(f"Signature check OK: {len(apks)} APK(s) verified")
+
+
 def register_ci_release_commands(ci_group: click.Group) -> None:
     @ci_group.group("release")
     def release_group():
@@ -435,3 +503,21 @@ def register_ci_release_commands(ci_group: click.Group) -> None:
             click.echo("  Tests OK")
 
         click.echo(f"Expected tag: {tag}")
+
+    @release_group.command("verify-signing")
+    @click.option(
+        "--apk-dir",
+        type=click.Path(file_okay=False, path_type=Path),
+        default=str(PROJECT_ROOT / "cache" / "releases" / "apk"),
+        show_default=True,
+        help="Directory containing built APKs (searched recursively).",
+    )
+    @click.option(
+        "--expected-sha256",
+        envvar="APP_KEY_SHA256",
+        default=None,
+        help="Expected release-key certificate SHA-256 fingerprint.",
+    )
+    def release_verify_signing(apk_dir: Path, expected_sha256: str | None):
+        """Verify all built APKs are signed with the expected release key."""
+        _verify_signing(apk_dir, expected_sha256)

--- a/bootstrap/ci/release.py
+++ b/bootstrap/ci/release.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 import sys
@@ -13,6 +12,7 @@ import click
 from bootstrap.cli import runtime
 from bootstrap.config import ProjectVersion
 from bootstrap.constant import PROJECT_ROOT
+from bootstrap.utils import get_command
 
 
 _VERSION_RE = re.compile(r"^version\s*:\s*(.+?)\s*$", re.MULTILINE)
@@ -294,40 +294,25 @@ def _parse_apksigner_digest(output: str) -> str:
     return _normalize_sha256(match.group(1))
 
 
-def _find_apksigner() -> Path:
-    """Locate the newest apksigner under the Android SDK build-tools directories."""
-    candidates: list[Path] = []
-    for env_name in ("ANDROID_HOME", "ANDROID_SDK_ROOT"):
-        root = os.environ.get(env_name)
-        if root:
-            candidates.extend(Path(root).glob("build-tools/*/apksigner"))
-    if not candidates:
-        raise click.ClickException(
-            "apksigner not found: set ANDROID_HOME or ANDROID_SDK_ROOT to the Android SDK"
-        )
-
-    def sort_key(path: Path) -> tuple[int, ...]:
-        return tuple(int(part) if part.isdigit() else 0 for part in path.parent.name.split("."))
-
-    return sorted(candidates, key=sort_key)[-1]
-
-
-def _verify_apk_signature(apksigner: Path, apk: Path, expected: str) -> None:
-    """Verify one APK's signature and certificate digest against the expected value."""
+def _find_apksigner() -> str:
+    """Locate the apksigner executable on PATH."""
     try:
-        result = subprocess.run(
-            [str(apksigner), "verify", "--print-certs", str(apk)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        return get_command("apksigner")
     except FileNotFoundError as exc:
-        raise click.ClickException(f"apksigner is not executable: {apksigner}") from exc
-    if result.returncode != 0:
         raise click.ClickException(
-            f"apksigner verification failed for {apk}:\n{result.stderr.strip()}"
-        )
-    digest = _parse_apksigner_digest(result.stdout)
+            "apksigner not found on PATH: run inside the Nix dev shell "
+            "or install the Android SDK build-tools"
+        ) from exc
+
+
+def _verify_apk_signature(apksigner: str, apk: Path, expected: str) -> None:
+    """Verify one APK's signature and certificate digest against the expected value."""
+    output = runtime.execute(
+        [apksigner, "verify", "--print-certs", str(apk)],
+        "APKSIGNER VERIFY",
+        capture_stdout=True,
+    )
+    digest = _parse_apksigner_digest(output)
     if digest != expected:
         raise click.ClickException(
             f"{apk}: certificate SHA-256 mismatch\n  expected: {expected}\n  actual:   {digest}"

--- a/bootstrap/tests/test_ci_release_verify_signing.py
+++ b/bootstrap/tests/test_ci_release_verify_signing.py
@@ -56,6 +56,20 @@ def _make_fake_apksigner(
     return script
 
 
+def _put_apksigner_on_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    output: str = _APKSIGNER_OUTPUT,
+    exit_code: int = 0,
+) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    script = _make_fake_apksigner(bin_dir, output=output, exit_code=exit_code)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    return script
+
+
 class TestNormalizeSha256:
     def test_plain_lowercase(self) -> None:
         assert _normalize_sha256(_DIGEST) == _DIGEST
@@ -77,28 +91,12 @@ class TestParseApksignerDigest:
 
 
 class TestFindApksigner:
-    def test_picks_newest_build_tools(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        for version in ("30.0.3", "34.0.0", "33.0.1"):
-            tool_dir = tmp_path / "build-tools" / version
-            tool_dir.mkdir(parents=True)
-            (tool_dir / "apksigner").write_text("", encoding="utf-8")
-        monkeypatch.setenv("ANDROID_HOME", str(tmp_path))
-        monkeypatch.delenv("ANDROID_SDK_ROOT", raising=False)
-        assert _find_apksigner() == tmp_path / "build-tools" / "34.0.0" / "apksigner"
+    def test_finds_on_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        script = _put_apksigner_on_path(tmp_path, monkeypatch)
+        assert _find_apksigner() == str(script)
 
-    def test_falls_back_to_sdk_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        tool_dir = tmp_path / "build-tools" / "34.0.0"
-        tool_dir.mkdir(parents=True)
-        (tool_dir / "apksigner").write_text("", encoding="utf-8")
-        monkeypatch.delenv("ANDROID_HOME", raising=False)
-        monkeypatch.setenv("ANDROID_SDK_ROOT", str(tmp_path))
-        assert _find_apksigner() == tool_dir / "apksigner"
-
-    def test_missing_sdk_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("ANDROID_HOME", raising=False)
-        monkeypatch.delenv("ANDROID_SDK_ROOT", raising=False)
+    def test_missing_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PATH", str(tmp_path))
         with pytest.raises(click.ClickException, match="apksigner not found"):
             _find_apksigner()
 
@@ -108,32 +106,28 @@ class TestVerifyApkSignature:
         apksigner = _make_fake_apksigner(tmp_path)
         apk = tmp_path / "app-release.apk"
         apk.write_bytes(b"fake-apk")
-        _verify_apk_signature(apksigner, apk, _DIGEST)
+        _verify_apk_signature(str(apksigner), apk, _DIGEST)
 
     def test_mismatched_digest_fails(self, tmp_path: Path) -> None:
         apksigner = _make_fake_apksigner(tmp_path)
         apk = tmp_path / "app-release.apk"
         apk.write_bytes(b"fake-apk")
         with pytest.raises(click.ClickException, match="certificate SHA-256 mismatch"):
-            _verify_apk_signature(apksigner, apk, "ff" * 32)
+            _verify_apk_signature(str(apksigner), apk, "ff" * 32)
 
     def test_apksigner_failure_fails(self, tmp_path: Path) -> None:
         apksigner = _make_fake_apksigner(tmp_path, exit_code=1)
         apk = tmp_path / "app-release.apk"
         apk.write_bytes(b"fake-apk")
-        with pytest.raises(click.ClickException, match="apksigner verification failed"):
-            _verify_apk_signature(apksigner, apk, _DIGEST)
+        with pytest.raises(SystemExit):
+            _verify_apk_signature(str(apksigner), apk, _DIGEST)
 
 
 class TestVerifySigning:
     def test_verifies_all_apks_recursively(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        tool_dir = tmp_path / "sdk" / "build-tools" / "34.0.0"
-        tool_dir.mkdir(parents=True)
-        _make_fake_apksigner(tool_dir)
-        monkeypatch.setenv("ANDROID_HOME", str(tmp_path / "sdk"))
-        monkeypatch.delenv("ANDROID_SDK_ROOT", raising=False)
+        _put_apksigner_on_path(tmp_path, monkeypatch)
         apk_dir = tmp_path / "out"
         (apk_dir / "nested").mkdir(parents=True)
         (apk_dir / "app-release.apk").write_bytes(b"fake-apk")
@@ -153,11 +147,7 @@ class TestVerifySigningCommand:
     def test_expected_sha256_from_env(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        tool_dir = tmp_path / "sdk" / "build-tools" / "34.0.0"
-        tool_dir.mkdir(parents=True)
-        _make_fake_apksigner(tool_dir)
-        monkeypatch.setenv("ANDROID_HOME", str(tmp_path / "sdk"))
-        monkeypatch.delenv("ANDROID_SDK_ROOT", raising=False)
+        _put_apksigner_on_path(tmp_path, monkeypatch)
         monkeypatch.setenv("APP_KEY_SHA256", _DIGEST_COLONED)
         (tmp_path / "app-release.apk").write_bytes(b"fake-apk")
 

--- a/bootstrap/tests/test_ci_release_verify_signing.py
+++ b/bootstrap/tests/test_ci_release_verify_signing.py
@@ -1,0 +1,179 @@
+"""Tests for the `x ci release verify-signing` command."""
+
+from __future__ import annotations
+
+import os
+import stat
+
+from typing import TYPE_CHECKING
+
+import click
+import click.testing
+import pytest
+
+from bootstrap.ci.release import _find_apksigner
+from bootstrap.ci.release import _normalize_sha256
+from bootstrap.ci.release import _parse_apksigner_digest
+from bootstrap.ci.release import _verify_apk_signature
+from bootstrap.ci.release import _verify_signing
+from bootstrap.cli import register_all_commands
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_DIGEST = "aa11bb22cc33dd44ee55ff6600112233445566778899aabbccddeeff001122"
+_DIGEST_COLONED = ":".join(_DIGEST[i : i + 2] for i in range(0, len(_DIGEST), 2)).upper()
+
+_APKSIGNER_OUTPUT = f"""\
+Verifies
+Verified using v1 scheme (JAR signing): true
+Verified using v2 scheme (APK Signature Scheme v2): true
+Verified using v3 scheme (APK Signature Scheme v3): false
+Number of signers: 1
+Signer #1 certificate DN: CN=EFA, O=EFA Tech
+Signer #1 certificate SHA-256 digest: {_DIGEST}
+Signer #1 certificate SHA-1 digest: 00112233445566778899aabbccddeeff00112233
+Signer #1 certificate MD5 digest: 00112233445566778899aabbccddeeff
+Signer #1 key algorithm: RSA
+Signer #1 key size (bits): 2048
+"""
+
+
+def _make_fake_apksigner(
+    root: Path, *, output: str = _APKSIGNER_OUTPUT, exit_code: int = 0
+) -> Path:
+    script = root / "apksigner"
+    lines = ["#!/usr/bin/env bash"]
+    if exit_code == 0:
+        lines.append(f"cat <<'APKSIGNER_EOF'\n{output}APKSIGNER_EOF")
+    else:
+        lines.append("echo 'verification failed' >&2")
+    lines.append(f"exit {exit_code}")
+    script.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    return script
+
+
+class TestNormalizeSha256:
+    def test_plain_lowercase(self) -> None:
+        assert _normalize_sha256(_DIGEST) == _DIGEST
+
+    def test_coloned_uppercase(self) -> None:
+        assert _normalize_sha256(_DIGEST_COLONED) == _DIGEST
+
+    def test_whitespace_stripped(self) -> None:
+        assert _normalize_sha256(f"  {_DIGEST_COLONED} \n") == _DIGEST
+
+
+class TestParseApksignerDigest:
+    def test_parses_first_signer_digest(self) -> None:
+        assert _parse_apksigner_digest(_APKSIGNER_OUTPUT) == _DIGEST
+
+    def test_missing_digest_raises(self) -> None:
+        with pytest.raises(click.ClickException, match="no certificate SHA-256 digest"):
+            _parse_apksigner_digest("Verifies\nNumber of signers: 0\n")
+
+
+class TestFindApksigner:
+    def test_picks_newest_build_tools(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for version in ("30.0.3", "34.0.0", "33.0.1"):
+            tool_dir = tmp_path / "build-tools" / version
+            tool_dir.mkdir(parents=True)
+            (tool_dir / "apksigner").write_text("", encoding="utf-8")
+        monkeypatch.setenv("ANDROID_HOME", str(tmp_path))
+        monkeypatch.delenv("ANDROID_SDK_ROOT", raising=False)
+        assert _find_apksigner() == tmp_path / "build-tools" / "34.0.0" / "apksigner"
+
+    def test_falls_back_to_sdk_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        tool_dir = tmp_path / "build-tools" / "34.0.0"
+        tool_dir.mkdir(parents=True)
+        (tool_dir / "apksigner").write_text("", encoding="utf-8")
+        monkeypatch.delenv("ANDROID_HOME", raising=False)
+        monkeypatch.setenv("ANDROID_SDK_ROOT", str(tmp_path))
+        assert _find_apksigner() == tool_dir / "apksigner"
+
+    def test_missing_sdk_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANDROID_HOME", raising=False)
+        monkeypatch.delenv("ANDROID_SDK_ROOT", raising=False)
+        with pytest.raises(click.ClickException, match="apksigner not found"):
+            _find_apksigner()
+
+
+class TestVerifyApkSignature:
+    def test_matching_digest_passes(self, tmp_path: Path) -> None:
+        apksigner = _make_fake_apksigner(tmp_path)
+        apk = tmp_path / "app-release.apk"
+        apk.write_bytes(b"fake-apk")
+        _verify_apk_signature(apksigner, apk, _DIGEST)
+
+    def test_mismatched_digest_fails(self, tmp_path: Path) -> None:
+        apksigner = _make_fake_apksigner(tmp_path)
+        apk = tmp_path / "app-release.apk"
+        apk.write_bytes(b"fake-apk")
+        with pytest.raises(click.ClickException, match="certificate SHA-256 mismatch"):
+            _verify_apk_signature(apksigner, apk, "ff" * 32)
+
+    def test_apksigner_failure_fails(self, tmp_path: Path) -> None:
+        apksigner = _make_fake_apksigner(tmp_path, exit_code=1)
+        apk = tmp_path / "app-release.apk"
+        apk.write_bytes(b"fake-apk")
+        with pytest.raises(click.ClickException, match="apksigner verification failed"):
+            _verify_apk_signature(apksigner, apk, _DIGEST)
+
+
+class TestVerifySigning:
+    def test_verifies_all_apks_recursively(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tool_dir = tmp_path / "sdk" / "build-tools" / "34.0.0"
+        tool_dir.mkdir(parents=True)
+        _make_fake_apksigner(tool_dir)
+        monkeypatch.setenv("ANDROID_HOME", str(tmp_path / "sdk"))
+        monkeypatch.delenv("ANDROID_SDK_ROOT", raising=False)
+        apk_dir = tmp_path / "out"
+        (apk_dir / "nested").mkdir(parents=True)
+        (apk_dir / "app-release.apk").write_bytes(b"fake-apk")
+        (apk_dir / "nested" / "app-arm64-release.apk").write_bytes(b"fake-apk")
+        _verify_signing(apk_dir, _DIGEST_COLONED)
+
+    def test_no_apks_fails(self, tmp_path: Path) -> None:
+        with pytest.raises(click.ClickException, match="No APKs found"):
+            _verify_signing(tmp_path, _DIGEST)
+
+    def test_missing_expected_fails(self, tmp_path: Path) -> None:
+        with pytest.raises(click.ClickException, match="Expected fingerprint missing"):
+            _verify_signing(tmp_path, None)
+
+
+class TestVerifySigningCommand:
+    def test_expected_sha256_from_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tool_dir = tmp_path / "sdk" / "build-tools" / "34.0.0"
+        tool_dir.mkdir(parents=True)
+        _make_fake_apksigner(tool_dir)
+        monkeypatch.setenv("ANDROID_HOME", str(tmp_path / "sdk"))
+        monkeypatch.delenv("ANDROID_SDK_ROOT", raising=False)
+        monkeypatch.setenv("APP_KEY_SHA256", _DIGEST_COLONED)
+        (tmp_path / "app-release.apk").write_bytes(b"fake-apk")
+
+        cli = click.Group()
+        register_all_commands(cli)
+        runner = click.testing.CliRunner()
+        result = runner.invoke(cli, ["ci", "release", "verify-signing", "--apk-dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "1 APK(s) verified" in result.output
+
+    def test_missing_expected_sha256_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "app-release.apk").write_bytes(b"fake-apk")
+        env = {k: v for k, v in os.environ.items() if k != "APP_KEY_SHA256"}
+        cli = click.Group()
+        register_all_commands(cli)
+        runner = click.testing.CliRunner(env=env)
+        result = runner.invoke(cli, ["ci", "release", "verify-signing", "--apk-dir", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "Expected fingerprint missing" in result.output

--- a/flake.nix
+++ b/flake.nix
@@ -190,6 +190,7 @@
             ++ [
               androidSdk
               androidComposition.platform-tools
+              pkgs.apksigner
               pkgs.rustup
             ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Android release builds can now use configured release signing credentials.
  - Release packages are automatically checked to confirm they carry the expected signing certificate.
  - Signing verification reports successful APK checks and flags invalid or mismatched signatures.

- **Documentation**
  - Added guidance for configuring Android release signing credentials and validating signed packages.
  - Documented the approved source for signing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->