### PR TITLE
fix(ci): fix app signing failure

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -187,8 +187,9 @@ Operational notes:
 - Android release signing: real app releases sign the APK with the EFA release
   key. `_release.yml` decodes `APP_KEYSTORE` (base64) into a runner-temp file
   and passes it plus the passwords/alias to Gradle as `EFA_*` environment
-  variables (`android/app/build.gradle.kts` falls back to debug signing when
-  they are absent, so test mode and local builds are unaffected). After the
+   variables (`android/app/build.gradle.kts` fails the build when only some of
+   them are set, and falls back to debug signing only when all are absent, so
+   test mode and local builds are unaffected). After the
   build the workflow runs `./x ci release verify-signing`, which checks every
   APK's certificate SHA-256 against the `APP_KEY_SHA256` variable and aborts
   before publish on mismatch. The

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,16 +5,21 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
-val releaseKeystoreFile = System.getenv("EFA_KEYSTORE_FILE")
-val releaseKeystorePassword = System.getenv("EFA_KEYSTORE_PASSWORD")
-val releaseKeyAlias = System.getenv("EFA_KEY_ALIAS")
-val releaseKeyPassword = System.getenv("EFA_KEY_PASSWORD")
-val releaseSigningAvailable = listOf(
-    releaseKeystoreFile,
-    releaseKeystorePassword,
-    releaseKeyAlias,
-    releaseKeyPassword,
-).all { !it.isNullOrEmpty() }
+val releaseSigningVars = mapOf(
+    "EFA_KEYSTORE_FILE" to System.getenv("EFA_KEYSTORE_FILE"),
+    "EFA_KEYSTORE_PASSWORD" to System.getenv("EFA_KEYSTORE_PASSWORD"),
+    "EFA_KEY_ALIAS" to System.getenv("EFA_KEY_ALIAS"),
+    "EFA_KEY_PASSWORD" to System.getenv("EFA_KEY_PASSWORD"),
+)
+val releaseSigningConfigured = releaseSigningVars.values.count { !it.isNullOrEmpty() }
+val releaseSigningAvailable = releaseSigningConfigured == releaseSigningVars.size
+if (releaseSigningConfigured in 1 until releaseSigningVars.size) {
+    val missing = releaseSigningVars.filterValues { it.isNullOrEmpty() }.keys
+    throw GradleException(
+        "Incomplete release signing configuration: $missing not set or empty. " +
+            "Set all EFA_* variables or none (debug fallback)."
+    )
+}
 
 android {
     namespace = "net.efa_tech.eve_fit_assistant"
@@ -44,10 +49,10 @@ android {
     signingConfigs {
         if (releaseSigningAvailable) {
             create("release") {
-                storeFile = file(releaseKeystoreFile)
-                storePassword = releaseKeystorePassword
-                keyAlias = releaseKeyAlias
-                keyPassword = releaseKeyPassword
+                storeFile = file(releaseSigningVars.getValue("EFA_KEYSTORE_FILE"))
+                storePassword = releaseSigningVars.getValue("EFA_KEYSTORE_PASSWORD")
+                keyAlias = releaseSigningVars.getValue("EFA_KEY_ALIAS")
+                keyPassword = releaseSigningVars.getValue("EFA_KEY_PASSWORD")
             }
         }
     }
@@ -55,8 +60,9 @@ android {
     buildTypes {
         release {
             // Release builds are signed with the EFA release key when the EFA_* environment
-            // variables are provided (CI real releases); otherwise they fall back to the
-            // debug keys so `flutter run --release` and CI test-mode builds keep working.
+            // variables are provided (CI real releases); a partially provided set fails the
+            // build loudly, and a fully absent set falls back to the debug keys so
+            // `flutter run --release` and CI test-mode builds keep working.
             signingConfig = if (releaseSigningAvailable) {
                 signingConfigs.getByName("release")
             } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Android release builds now clearly report incomplete signing configuration instead of failing with ambiguous errors.
  - Builds fall back to debug signing only when no release signing settings are provided.

- **Documentation**
  - Updated release guidance to explain signing configuration requirements and confirm that test mode and local builds remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->