### PR TITLE
feat(ci): add GitHub Release upload

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -18,6 +18,7 @@ jobs:
     environment: ${{ inputs.test_mode && 'ci-testing' || 'production-app' }}
     outputs:
       tag: ${{ steps.verify.outputs.tag }}
+      version: ${{ steps.verify.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -306,7 +307,19 @@ jobs:
       contents: write
     env:
       TAG: ${{ needs.release.outputs.tag }}
+      VERSION: ${{ needs.release.outputs.version }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Install Python dependencies
+        run: nix develop .#python --command bash -c 'uv sync'
+
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -332,3 +345,12 @@ jobs:
               sha: context.sha,
             });
             core.info(`Created tag ${tag}`)
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py ci release github-release \
+              --version "$VERSION" \
+              --tag "$TAG"'

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -274,11 +274,12 @@ jobs:
           echo "Remote head verified: $synced_hash"
 
       - name: Upload APK artifacts
-        if: inputs.test_mode
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: apk
-          path: cache/releases/apk/**/*.apk
+          path: |
+            cache/releases/apk/**/*.apk
+            cache/releases/apk/**/*.sha1
           retention-days: 1
 
       - name: Upload diagnostics
@@ -319,6 +320,11 @@ jobs:
 
       - name: Install Python dependencies
         run: nix develop .#python --command bash -c 'uv sync'
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: apk
+          path: cache/releases/apk
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -16,6 +16,7 @@ from bootstrap.ci.codegen import run_codegen
 from bootstrap.ci.diagnostics import register_ci_diagnostics_commands
 from bootstrap.ci.lint import run_lint
 from bootstrap.ci.release import register_ci_release_commands
+from bootstrap.ci.release_github import register_github_release_command
 from bootstrap.ci.suites import SUITE_DEFINITIONS
 from bootstrap.ci.suites import calculate_ci_matrix
 from bootstrap.cli import runtime
@@ -33,6 +34,7 @@ def register_ci_commands(cli_group: click.Group) -> None:
         """CI/CD helper commands."""
 
     register_ci_release_commands(ci)
+    register_github_release_command(ci)
     register_ci_diagnostics_commands(ci)
 
     @ci.command("matrix")

--- a/bootstrap/ci/release_github.py
+++ b/bootstrap/ci/release_github.py
@@ -98,6 +98,7 @@ def register_github_release_command(ci_group: click.Group) -> None:
 
         with tempfile.NamedTemporaryFile(
             mode="w",
+            encoding="utf-8",
             suffix=".md",
             prefix=f"github_release_{tag}_",
             delete=False,

--- a/bootstrap/ci/release_github.py
+++ b/bootstrap/ci/release_github.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import tempfile
+
+from pathlib import Path
+
+import click
+
+from bootstrap.cli.runtime import execute
+from bootstrap.constant import PROJECT_ROOT
+from bootstrap.docs.document_parser import parse_locale_document
+
+
+def register_github_release_command(ci_group: click.Group) -> None:
+    release_group = ci_group.commands.get("release")
+    if release_group is None:
+        raise click.ClickException(
+            "ci release group not found; register_ci_release_commands must be called first"
+        )
+
+    @release_group.command("github-release")
+    @click.option(
+        "--version",
+        "version_str",
+        required=True,
+        help="Full version (render_full()).",
+    )
+    @click.option(
+        "--tag",
+        required=True,
+        help="Git tag (render_tag()).",
+    )
+    @click.option(
+        "--apk-dir",
+        type=click.Path(file_okay=False, path_type=Path),
+        default=PROJECT_ROOT / "cache" / "releases" / "apk",
+        show_default=True,
+        help="Base directory containing versioned APK output directories.",
+    )
+    @click.option(
+        "--dry-run",
+        is_flag=True,
+        default=False,
+        help="Show what would be done without creating the release.",
+    )
+    def github_release(
+        version_str: str,
+        tag: str,
+        apk_dir: Path,
+        dry_run: bool,
+    ) -> None:
+        """Create a GitHub Release with APK assets and changelog body.
+
+        Reads the human release body from content.en.md and the
+        auto-generated changelog from changelog.md, composes them,
+        then uploads the APK and SHA1 artifacts as release assets
+        via \b\bgh release create.
+        """
+        semver = version_str.split("+")[0]
+        notes_dir_name = semver.replace(".", "-")
+        notes_dir = PROJECT_ROOT / "docs" / "changelog" / notes_dir_name
+
+        if not notes_dir.is_dir():
+            raise click.ClickException(
+                f"Changelog directory not found: {notes_dir}\n"
+                f"Expected docs/changelog/{notes_dir_name}/"
+            )
+
+        content_path = notes_dir / "content.en.md"
+        if not content_path.is_file():
+            raise click.ClickException(f"Missing {content_path} — content.en.md is required")
+        parsed = parse_locale_document(content_path, "en")
+        human_body = parsed.body_markdown
+
+        changelog_path = notes_dir / "changelog.md"
+        if not changelog_path.is_file():
+            raise click.ClickException(f"Missing {changelog_path} — changelog.md is required")
+        changelog_body = changelog_path.read_text(encoding="utf-8")
+
+        body_parts = [
+            human_body.strip(),
+            "",
+            "## Full Changelog",
+            "",
+            changelog_body.strip(),
+        ]
+        release_body = "\n".join(body_parts) + "\n"
+
+        version_apk_dir = apk_dir / version_str
+        if not version_apk_dir.is_dir():
+            raise click.ClickException(f"APK directory not found: {version_apk_dir}")
+
+        apk_files = sorted(version_apk_dir.glob("*.apk"))
+        sha1_files = sorted(version_apk_dir.glob("*.sha1"))
+
+        if not apk_files:
+            raise click.ClickException(f"No APK files found in {version_apk_dir}")
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".md",
+            prefix=f"github_release_{tag}_",
+            delete=False,
+        ) as f:
+            body_path = Path(f.name)
+            f.write(release_body)
+
+        is_prerelease = "-" in semver
+
+        cmd = ["gh", "release", "create", tag]
+        cmd.extend(["--title", tag])
+        if is_prerelease:
+            cmd.append("--prerelease")
+        cmd.extend(["--notes-file", str(body_path)])
+        cmd.extend(str(f) for f in apk_files)
+        cmd.extend(str(f) for f in sha1_files)
+
+        if dry_run:
+            click.echo(f"[DRY-RUN] Would run: {' '.join(cmd)}")
+            body_path.unlink()
+            return
+
+        try:
+            execute(cmd, "GITHUB RELEASE CREATE")
+        finally:
+            body_path.unlink(missing_ok=True)
+
+        click.echo(f"GitHub Release created: {tag}")

--- a/bootstrap/tests/test_ci_release_github.py
+++ b/bootstrap/tests/test_ci_release_github.py
@@ -2,24 +2,18 @@
 
 from __future__ import annotations
 
-import tempfile
-
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 import click.testing
-import pytest
 
 from bootstrap.cli import register_all_commands
 
 
-@pytest.fixture
-def tmp_project() -> Path:
-    d = Path(tempfile.mkdtemp(prefix="efa-release-github-"))
-    yield d
-    import shutil
+if TYPE_CHECKING:
+    from pathlib import Path
 
-    shutil.rmtree(d, ignore_errors=True)
+    import pytest
 
 
 def _make_notes(root: Path, version_str: str) -> Path:
@@ -81,15 +75,15 @@ def _invoke(root: Path, version_str: str, tag: str) -> click.testing.Result:
 
 class TestGithubReleaseCommand:
     def test_dry_run_shows_command_with_assets(
-        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         version = "0.3.0-alpha.1+42"
         tag = "v0.3.0-alpha.1"
-        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
-        _make_notes(tmp_project, version)
-        _make_apks(tmp_project, version)
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
+        _make_notes(tmp_path, version)
+        _make_apks(tmp_path, version)
 
-        result = _invoke(tmp_project, version, tag)
+        result = _invoke(tmp_path, version, tag)
 
         assert result.exit_code == 0, result.output
         assert "[DRY-RUN]" in result.output
@@ -100,14 +94,12 @@ class TestGithubReleaseCommand:
         assert "0.3.0-alpha.1+42-android-arm64.apk" in result.output
         assert "0.3.0-alpha.1+42-android.apk.sha1" in result.output
 
-    def test_dry_run_stable_release(
-        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_dry_run_stable_release(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         version = "1.0.0"
         tag = "v1.0.0"
-        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
         semver = version.split("+")[0]
-        notes_dir = tmp_project / "docs" / "changelog" / semver.replace(".", "-")
+        notes_dir = tmp_path / "docs" / "changelog" / semver.replace(".", "-")
         notes_dir.mkdir(parents=True, exist_ok=True)
         (notes_dir / "spec.yaml").write_text(
             f"publishedAt: '2026-06-06T08:44:24Z'\nappVersion: {semver}\n",
@@ -119,23 +111,23 @@ class TestGithubReleaseCommand:
         (notes_dir / "content.en.md").write_text(
             "# v1.0.0\n\nFirst stable release.\n", encoding="utf-8"
         )
-        apk_dir = tmp_project / "cache" / "releases" / "apk" / version
+        apk_dir = tmp_path / "cache" / "releases" / "apk" / version
         apk_dir.mkdir(parents=True, exist_ok=True)
         (apk_dir / f"{version}-android.apk").write_text("fake", encoding="utf-8")
 
-        result = _invoke(tmp_project, version, tag)
+        result = _invoke(tmp_path, version, tag)
 
         assert result.exit_code == 0, result.output
         assert "--prerelease" not in result.output
 
     def test_fails_missing_content_en(
-        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         version = "0.3.0-alpha.1"
         tag = "v0.3.0-alpha.1"
-        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
         semver = version.split("+")[0]
-        notes_dir = tmp_project / "docs" / "changelog" / semver.replace(".", "-")
+        notes_dir = tmp_path / "docs" / "changelog" / semver.replace(".", "-")
         notes_dir.mkdir(parents=True, exist_ok=True)
         (notes_dir / "spec.yaml").write_text(
             f"publishedAt: '2026-06-06T08:44:24Z'\nappVersion: {semver}\n",
@@ -143,32 +135,30 @@ class TestGithubReleaseCommand:
         )
         (notes_dir / "changelog.md").write_text("## Changelog\n", encoding="utf-8")
 
-        result = _invoke(tmp_project, version, tag)
+        result = _invoke(tmp_path, version, tag)
 
         assert result.exit_code != 0
         assert "content.en.md is required" in result.output
 
-    def test_fails_missing_apk_dir(
-        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_fails_missing_apk_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         version = "0.3.0-alpha.1+42"
         tag = "v0.3.0-alpha.1"
-        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
-        _make_notes(tmp_project, version)
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
+        _make_notes(tmp_path, version)
 
-        result = _invoke(tmp_project, version, tag)
+        result = _invoke(tmp_path, version, tag)
 
         assert result.exit_code != 0
         assert "APK directory not found" in result.output
 
     def test_fails_missing_changelog_dir(
-        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         version = "0.3.0-alpha.1+42"
         tag = "v0.3.0-alpha.1"
-        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
 
-        result = _invoke(tmp_project, version, tag)
+        result = _invoke(tmp_path, version, tag)
 
         assert result.exit_code != 0
         assert "Changelog directory not found" in result.output

--- a/bootstrap/tests/test_ci_release_github.py
+++ b/bootstrap/tests/test_ci_release_github.py
@@ -1,0 +1,174 @@
+"""Tests for the `x ci release github-release` command."""
+
+from __future__ import annotations
+
+import tempfile
+
+from pathlib import Path
+
+import click
+import click.testing
+import pytest
+
+from bootstrap.cli import register_all_commands
+
+
+@pytest.fixture
+def tmp_project() -> Path:
+    d = Path(tempfile.mkdtemp(prefix="efa-release-github-"))
+    yield d
+    import shutil
+
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _make_notes(root: Path, version_str: str) -> Path:
+    semver = version_str.split("+")[0]
+    notes_dir = root / "docs" / "changelog" / semver.replace(".", "-")
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    (notes_dir / "spec.yaml").write_text(
+        "publishedAt: '2026-06-06T08:44:24Z'\n"
+        "tags:\n- release-note\n"
+        "channels:\n- testing\n"
+        "platforms:\n- android\n"
+        f"appVersion: {semver}\n",
+        encoding="utf-8",
+    )
+    (notes_dir / "changelog.md").write_text(
+        "## [v0.3.0-alpha.1] - 2026-07-01\n\n### Added\n\n- **feature:** new stuff\n",
+        encoding="utf-8",
+    )
+    (notes_dir / "content.en.md").write_text(
+        "# v0.3.0-alpha.1 Release Notes\n\nThis is a test release.\n\n- Item one\n",
+        encoding="utf-8",
+    )
+    return notes_dir
+
+
+def _make_apks(root: Path, version_str: str) -> Path:
+    apk_dir = root / "cache" / "releases" / "apk" / version_str
+    apk_dir.mkdir(parents=True, exist_ok=True)
+    (apk_dir / f"{version_str}-android.apk").write_text("fake apk", encoding="utf-8")
+    (apk_dir / f"{version_str}-android-arm64.apk").write_text("fake apk", encoding="utf-8")
+    (apk_dir / f"{version_str}-android.apk.sha1").write_text("deadbeef", encoding="utf-8")
+    (apk_dir / f"{version_str}-android-arm64.apk.sha1").write_text("deadbeef", encoding="utf-8")
+    return apk_dir
+
+
+def _invoke(root: Path, version_str: str, tag: str) -> click.testing.Result:
+    @click.group()
+    def cli() -> None:
+        pass
+
+    register_all_commands(cli)
+    runner = click.testing.CliRunner()
+    return runner.invoke(
+        cli,
+        [
+            "ci",
+            "release",
+            "github-release",
+            "--version",
+            version_str,
+            "--tag",
+            tag,
+            "--apk-dir",
+            str(root / "cache" / "releases" / "apk"),
+            "--dry-run",
+        ],
+    )
+
+
+class TestGithubReleaseCommand:
+    def test_dry_run_shows_command_with_assets(
+        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = "0.3.0-alpha.1+42"
+        tag = "v0.3.0-alpha.1"
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
+        _make_notes(tmp_project, version)
+        _make_apks(tmp_project, version)
+
+        result = _invoke(tmp_project, version, tag)
+
+        assert result.exit_code == 0, result.output
+        assert "[DRY-RUN]" in result.output
+        assert "gh release create" in result.output
+        assert tag in result.output
+        assert "--prerelease" in result.output
+        assert "0.3.0-alpha.1+42-android.apk" in result.output
+        assert "0.3.0-alpha.1+42-android-arm64.apk" in result.output
+        assert "0.3.0-alpha.1+42-android.apk.sha1" in result.output
+
+    def test_dry_run_stable_release(
+        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = "1.0.0"
+        tag = "v1.0.0"
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
+        semver = version.split("+")[0]
+        notes_dir = tmp_project / "docs" / "changelog" / semver.replace(".", "-")
+        notes_dir.mkdir(parents=True, exist_ok=True)
+        (notes_dir / "spec.yaml").write_text(
+            f"publishedAt: '2026-06-06T08:44:24Z'\nappVersion: {semver}\n",
+            encoding="utf-8",
+        )
+        (notes_dir / "changelog.md").write_text(
+            "## [v1.0.0]\n\nStable release.\n", encoding="utf-8"
+        )
+        (notes_dir / "content.en.md").write_text(
+            "# v1.0.0\n\nFirst stable release.\n", encoding="utf-8"
+        )
+        apk_dir = tmp_project / "cache" / "releases" / "apk" / version
+        apk_dir.mkdir(parents=True, exist_ok=True)
+        (apk_dir / f"{version}-android.apk").write_text("fake", encoding="utf-8")
+
+        result = _invoke(tmp_project, version, tag)
+
+        assert result.exit_code == 0, result.output
+        assert "--prerelease" not in result.output
+
+    def test_fails_missing_content_en(
+        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = "0.3.0-alpha.1"
+        tag = "v0.3.0-alpha.1"
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
+        semver = version.split("+")[0]
+        notes_dir = tmp_project / "docs" / "changelog" / semver.replace(".", "-")
+        notes_dir.mkdir(parents=True, exist_ok=True)
+        (notes_dir / "spec.yaml").write_text(
+            f"publishedAt: '2026-06-06T08:44:24Z'\nappVersion: {semver}\n",
+            encoding="utf-8",
+        )
+        (notes_dir / "changelog.md").write_text("## Changelog\n", encoding="utf-8")
+
+        result = _invoke(tmp_project, version, tag)
+
+        assert result.exit_code != 0
+        assert "content.en.md is required" in result.output
+
+    def test_fails_missing_apk_dir(
+        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = "0.3.0-alpha.1+42"
+        tag = "v0.3.0-alpha.1"
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
+        _make_notes(tmp_project, version)
+
+        result = _invoke(tmp_project, version, tag)
+
+        assert result.exit_code != 0
+        assert "APK directory not found" in result.output
+
+    def test_fails_missing_changelog_dir(
+        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = "0.3.0-alpha.1+42"
+        tag = "v0.3.0-alpha.1"
+        monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_project)
+
+        result = _invoke(tmp_project, version, tag)
+
+        assert result.exit_code != 0
+        assert "Changelog directory not found" in result.output


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI subcommand to create GitHub Releases from release metadata and combined changelog notes.
  * Release notes now auto-assemble from human-readable content plus changelog details.
  * Releases automatically attach the built APK files and their checksum files; prereleases are detected from the version.
  * Added dry-run mode to show the exact release creation command and expected assets.
* **CI/CD**
  * Release automation now propagates version information through the workflow and creates the GitHub Release after tagging.
* **Tests**
  * Introduced integration-style tests covering dry-run, prerelease/stable behavior, and missing inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->