### PR TITLE
feat(release): add --from-ref option to release relnote

### DIFF
--- a/bootstrap/cli/release.py
+++ b/bootstrap/cli/release.py
@@ -55,6 +55,12 @@ def register_release_commands(cli_group: click.Group) -> None:
         default=False,
         help="Show the target directory without writing files.",
     )
+    @click.option(
+        "--from-ref",
+        default=None,
+        help="Base git ref (tag or commit hash) to compare against. "
+        "If omitted, uses the last tag matching version pattern.",
+    )
     def release_relnote(
         version_override: str | None,
         published_at: str | None,
@@ -62,6 +68,7 @@ def register_release_commands(cli_group: click.Group) -> None:
         platforms: str | None,
         force: bool,
         dry_run: bool,
+        from_ref: str | None,
     ):
         """Create a raw release note in docs/changelog.
 
@@ -84,6 +91,7 @@ def register_release_commands(cli_group: click.Group) -> None:
             published_at=published_at,
             channels=channels_list,
             platforms=platforms_list,
+            from_ref=from_ref,
         )
 
         if dry_run:

--- a/bootstrap/release/relnote.py
+++ b/bootstrap/release/relnote.py
@@ -76,17 +76,20 @@ def split_csv(value: str | None) -> list[str] | None:
     return [part.strip() for part in value.split(",") if part.strip()]
 
 
-def _run_cliff(tag: str) -> str:
+def _run_cliff(tag: str, from_ref: str | None = None) -> str:
     cmd = [
         get_command("git-cliff"),
         "--config",
         str(CLIFF_CONFIG),
-        "--unreleased",
         "--tag",
         tag,
         "--strip",
         "header",
     ]
+    if from_ref is not None:
+        cmd.append(f"{from_ref}..HEAD")
+    else:
+        cmd.append("--unreleased")
     # CWE-78 / S603 are false positives here: cmd is a list passed without
     # shell=True, and tag originates from a Pydantic-validated ProjectVersion,
     # so there is no shell-interpretation vector.
@@ -113,11 +116,12 @@ def _build_spec(
     published_at: str | None,
     channels: list[str] | None,
     platforms: list[str] | None,
+    from_ref: str | None = None,
 ) -> dict[str, object]:
     app_version = version.render_semver()
     entry_id = version_dir_to_entry_id(app_version)
     when = published_at or dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    return {
+    spec: dict[str, object] = {
         "id": entry_id,
         "publishedAt": when,
         "tags": _DEFAULT_TAGS,
@@ -125,6 +129,9 @@ def _build_spec(
         "platforms": platforms if platforms is not None else _DEFAULT_PLATFORMS,
         "appVersion": app_version,
     }
+    if from_ref is not None:
+        spec["fromRef"] = from_ref
+    return spec
 
 
 def create_raw_release_note(
@@ -135,6 +142,7 @@ def create_raw_release_note(
     published_at: str | None = None,
     channels: list[str] | None = None,
     platforms: list[str] | None = None,
+    from_ref: str | None = None,
 ) -> tuple[Path, str]:
     """Create a raw release note directory under docs/changelog.
 
@@ -164,12 +172,13 @@ def create_raw_release_note(
         published_at=published_at,
         channels=channels,
         platforms=platforms,
+        from_ref=from_ref,
     )
     spec_path = directory / "spec.yaml"
     changelog_path = directory / "changelog.md"
 
     tag = version.render_tag()
-    changelog_body = _run_cliff(tag)
+    changelog_body = _run_cliff(tag, from_ref=from_ref)
 
     spec_path.write_text(
         yaml.safe_dump(spec, allow_unicode=True, sort_keys=False),

--- a/bootstrap/tests/test_release_relnote.py
+++ b/bootstrap/tests/test_release_relnote.py
@@ -174,3 +174,66 @@ def test_create_raw_release_note_dry_run_force_preserves_existing(
 def test_version_dir_to_entry_id() -> None:
     assert relnote.version_dir_to_entry_id("0.2.0") == "version-0-2-0"
     assert relnote.version_dir_to_entry_id("0.2.0-beta.1") == "version-0-2-0-beta-1"
+
+
+def test_run_cliff_passes_from_ref_as_range() -> None:
+    captured_cmd: list[str] = []
+
+    def _mock_run(cmd, **_kw):
+        captured_cmd.extend(cmd)
+        import subprocess
+
+        result = subprocess.CompletedProcess(cmd, 0, "## [v0.3.0]\n", "")
+        return result
+
+    with (
+        patch("bootstrap.release.relnote.get_command", return_value="/usr/bin/git-cliff"),
+        patch("bootstrap.release.relnote.subprocess.run", side_effect=_mock_run),
+    ):
+        result = relnote._run_cliff("v0.3.0", from_ref="v0.2.0")
+
+    assert captured_cmd[-1] == "v0.2.0..HEAD"
+    assert "--unreleased" not in captured_cmd
+    assert result == "## [v0.3.0]\n"
+
+
+def test_create_raw_release_note_with_from_ref(
+    tmp_path: Path,
+    version: ProjectVersion,
+    isolated_changelog_root: Path,
+) -> None:
+    stub = _write_cliff_stub(tmp_path)
+
+    with (
+        patch.object(relnote, "CHANGELOG_ROOT", isolated_changelog_root),
+        patch("bootstrap.release.relnote.get_command", return_value=str(stub)),
+    ):
+        directory, _ = relnote.create_raw_release_note(
+            version,
+            from_ref="v0.1.0",
+        )
+
+    spec = yaml.safe_load(
+        (directory / "spec.yaml").read_text(encoding="utf-8"),
+    )
+    assert spec["fromRef"] == "v0.1.0"
+    assert spec["appVersion"] == "0.2.0-beta.1"
+    assert directory.is_dir()
+
+
+def test_create_raw_release_note_with_from_ref_dry_run(
+    version: ProjectVersion,
+    isolated_changelog_root: Path,
+) -> None:
+    directory = isolated_changelog_root / "0-2-0-beta-1"
+
+    with patch.object(relnote, "CHANGELOG_ROOT", isolated_changelog_root):
+        returned_directory, entry_id = relnote.create_raw_release_note(
+            version,
+            dry_run=True,
+            from_ref="v0.1.0",
+        )
+
+    assert returned_directory == directory
+    assert entry_id == "version-0-2-0-beta-1"
+    assert not directory.exists()

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,13 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 body = """\
 ## [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
-{%- if group != "<!-- skip -->" %}
 ### {{ group }}
 {% for commit in commits %}
 - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message }}
-{%- endfor -%}
-{% endif %}
+{%- endfor %}
 {% endfor %}
+
 """
 footer = ""
 trim = true
@@ -28,14 +27,20 @@ tag_pattern = "v[0-9]*"
 skip_tags = "alpha-v.*"
 
 commit_parsers = [
+  { message = "^fixup", skip = true },
+  { message = "^revert", skip = true },
+  { message = "^test", skip = true },
+  { message = "^.+\\(ci\\)", skip = true },
+  { message = "^.+\\(cli\\)", skip = true },
+  { message = "^.+\\(test\\)", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^style", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "update codeart", skip = true },
   { message = "^feat", group = "Added" },
   { message = "^fix", group = "Fixed" },
   { message = "^perf", group = "Changed" },
-  { message = "^refactor", group = "Changed" },
   { message = "^docs", group = "Documentation" },
   { message = "^chore\\(deps\\)", group = "Dependencies" },
   { message = "^chore", group = "Chore" },
-  { message = "^test", group = "<!-- skip -->" },
-  { message = "^ci", group = "<!-- skip -->" },
-  { message = "^style", group = "<!-- skip -->" },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--from-ref` option to release note generation, allowing changelogs to be created from a specified tag or commit.
  * Generated release specifications now record the selected starting reference.
  * Dry-run mode continues to preview release notes without creating files.

* **Tests**
  * Added coverage for custom reference ranges, specification output, and dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->