### PR TITLE
fix(remote): set `Cache-Control` immutable for blob uploads

### DIFF
--- a/bootstrap/remote/publish.py
+++ b/bootstrap/remote/publish.py
@@ -465,11 +465,13 @@ class Publisher:
 
         return len(unique)
 
-    def _upload_file(self, src: Path, remote_path: str) -> None:
+    def _upload_file(
+        self, src: Path, remote_path: str, *, attrs: dict[str, str] | None = None
+    ) -> None:
         if self.origin_dir is not None:
             self._upload_local(src, remote_path)
         else:
-            self._upload_s3(src, remote_path)
+            self._upload_s3(src, remote_path, attrs=attrs)
 
     def _remote_exists(self, remote_path: str) -> bool:
         """True if the blob already exists at the destination (spec §3.1)."""
@@ -526,7 +528,9 @@ class Publisher:
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
 
-    def _upload_s3(self, src: Path, remote_path: str) -> None:
+    def _upload_s3(
+        self, src: Path, remote_path: str, *, attrs: dict[str, str] | None = None
+    ) -> None:
         if self.mc_bin is None:
             from bootstrap.utils import get_command
 
@@ -535,11 +539,12 @@ class Publisher:
         bucket_target = f"{self.alias_name}/{self.bucket}"
         s3_path = f"{bucket_target}/{remote_path}"
 
-        _run(
-            [self.mc_bin, "cp", str(src), s3_path],
-            [self.mc_bin, "cp", str(src), s3_path],
-            f"PUBLISH {remote_path}",
-        )
+        cmd: list[str] = [self.mc_bin, "cp"]
+        if attrs:
+            for k, v in attrs.items():
+                cmd.extend(["--attr", f"{k}={v}"])
+        cmd.extend([str(src), s3_path])
+        _run(cmd, cmd, f"PUBLISH {remote_path}")
 
 
 def _run(

--- a/bootstrap/remote/resource_manager.py
+++ b/bootstrap/remote/resource_manager.py
@@ -97,7 +97,11 @@ class ResourceManager:
                 self._stats.existing += 1
                 self._stats.uploaded += 1
         else:
-            self._pub._upload_file(local_path, remote_path)
+            self._pub._upload_file(
+                local_path,
+                remote_path,
+                attrs={"Cache-Control": "immutable, max-age=31536000"},
+            )
             with self._lock:
                 self._stats.uploaded += 1
         self._tick()

--- a/bootstrap/tests/test_resource_manager.py
+++ b/bootstrap/tests/test_resource_manager.py
@@ -236,7 +236,7 @@ class TestResourceManager:
         def fake_remote_exists(remote_path: str) -> bool:
             return remote_path in existing
 
-        def fake_upload_file(src: Path, remote_path: str) -> None:
+        def fake_upload_file(src: Path, remote_path: str, **kwargs: object) -> None:
             nonlocal put_count
             with put_lock:
                 put_count += 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uploaded remote objects can now include custom S3/MinIO metadata attributes.
  * Newly uploaded assets are marked for long-term browser and CDN caching.

* **Bug Fixes**
  * Improved upload compatibility when additional upload options are provided.
  * Updated parallel upload handling to accept extended upload parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->