### PR TITLE
feat(worker,release): serve APK downloads with proper filename

### DIFF
--- a/pkgs/worker/release/README.md
+++ b/pkgs/worker/release/README.md
@@ -55,7 +55,7 @@ Streams the APK blob for the given channel and variant (`general`, `armv7`,
 `arm64`, `x64`) directly from R2. The response carries a proper download name
 via `Content-Disposition`, e.g.:
 
-```
+```text
 Content-Type: application/vnd.android.package-archive
 Content-Disposition: attachment; filename="eve-fit-assistant-0.1.0-arm64.apk"
 Content-Length: 12345678

--- a/pkgs/worker/release/README.md
+++ b/pkgs/worker/release/README.md
@@ -24,7 +24,7 @@ No query parameters — the worker reads all channels from `efa/v2/channels/head
           "identifier": "com.evefitassistant…",
           "content_hash": "sha256…",
           "size": 12345678,
-          "download_url": "https://…/efa/v2/assets/blobs/…"
+          "download_url": "https://api.efa-tech.dev/releases/download/testing/general"
         },
         "armv7":  { … },
         "arm64":  { … },
@@ -47,7 +47,23 @@ No query parameters — the worker reads all channels from `efa/v2/channels/head
 }
 ```
 
-The worker does not use HTTP status codes for errors; always check the `ok` field.
+The artifacts endpoint does not use HTTP status codes for errors; always check the `ok` field.
+
+### `GET /releases/download/{channel}/{variant}`
+
+Streams the APK blob for the given channel and variant (`general`, `armv7`,
+`arm64`, `x64`) directly from R2. The response carries a proper download name
+via `Content-Disposition`, e.g.:
+
+```
+Content-Type: application/vnd.android.package-archive
+Content-Disposition: attachment; filename="eve-fit-assistant-0.1.0-arm64.apk"
+Content-Length: 12345678
+Cache-Control: public, max-age=31536000, immutable
+```
+
+Returns `404` when the channel, variant, or blob does not exist. Blobs are
+content-addressed, so responses are marked immutable.
 
 ## Architecture
 
@@ -55,4 +71,4 @@ The worker does not use HTTP status codes for errors; always check the `ok` fiel
 2. Resolves the channel head to a **generation hash** via `efa/v2/channels/heads/{channel}/metadata.json`.
 3. Fetches the **`GenerationPointer`** protobuf at `efa/v2/channels/refs/{hash}/releases.pb2` to get the snapshot hash.
 4. Fetches the **`ReleaseIndex`** protobuf at `efa/v2/assets/releases/{snapshot}/releases.pb2`.
-5. Builds signed download URLs pointing to `{origin}/efa/v2/assets/blobs/{prefix}/{hash}/{blob}`.
+5. Exposes per-variant download URLs under `/releases/download/{channel}/{variant}`, which stream the blob at `efa/v2/assets/blobs/{prefix}/{hash}/{blob}` with a `Content-Disposition` filename.

--- a/pkgs/worker/release/README.md
+++ b/pkgs/worker/release/README.md
@@ -24,7 +24,7 @@ No query parameters — the worker reads all channels from `efa/v2/channels/head
           "identifier": "com.evefitassistant…",
           "content_hash": "sha256…",
           "size": 12345678,
-          "download_url": "https://api.efa-tech.dev/releases/download/testing/general"
+          "download_url": "https://api.efa-tech.dev/releases/download/testing/general/sha256…"
         },
         "armv7":  { … },
         "arm64":  { … },
@@ -49,11 +49,12 @@ No query parameters — the worker reads all channels from `efa/v2/channels/head
 
 The artifacts endpoint does not use HTTP status codes for errors; always check the `ok` field.
 
-### `GET /releases/download/{channel}/{variant}`
+### `GET /releases/download/{channel}/{variant}/{hash}`
 
 Streams the APK blob for the given channel and variant (`general`, `armv7`,
-`arm64`, `x64`) directly from R2. The response carries a proper download name
-via `Content-Disposition`, e.g.:
+`arm64`, `x64`) directly from R2. The `{hash}` path segment must equal the
+variant's current `content_hash`, making the URL content-addressed. The
+response carries a proper download name via `Content-Disposition`, e.g.:
 
 ```text
 Content-Type: application/vnd.android.package-archive
@@ -62,8 +63,12 @@ Content-Length: 12345678
 Cache-Control: public, max-age=31536000, immutable
 ```
 
-Returns `404` when the channel, variant, or blob does not exist. Blobs are
-content-addressed, so responses are marked immutable.
+Returns `404` when the channel, variant, or blob does not exist, or when
+`{hash}` does not match the channel's current release (a stale URL after a
+channel update); hash-mismatch responses are sent with `Cache-Control:
+no-cache`. Because the URL embeds the blob's content hash, successful
+responses are safe to cache immutably — a channel update always produces a
+new URL.
 
 ## Architecture
 
@@ -71,4 +76,4 @@ content-addressed, so responses are marked immutable.
 2. Resolves the channel head to a **generation hash** via `efa/v2/channels/heads/{channel}/metadata.json`.
 3. Fetches the **`GenerationPointer`** protobuf at `efa/v2/channels/refs/{hash}/releases.pb2` to get the snapshot hash.
 4. Fetches the **`ReleaseIndex`** protobuf at `efa/v2/assets/releases/{snapshot}/releases.pb2`.
-5. Exposes per-variant download URLs under `/releases/download/{channel}/{variant}`, which stream the blob at `efa/v2/assets/blobs/{prefix}/{hash}/{blob}` with a `Content-Disposition` filename.
+5. Exposes per-variant download URLs under `/releases/download/{channel}/{variant}/{hash}`, where `{hash}` is the variant's content hash, which stream the blob at `efa/v2/assets/blobs/{prefix}/{hash}/{blob}` with a `Content-Disposition` filename.

--- a/pkgs/worker/release/build.rs
+++ b/pkgs/worker/release/build.rs
@@ -9,8 +9,14 @@ fn workspace_root() -> PathBuf {
 fn main() -> anyhow::Result<()> {
     let schema_dir = workspace_root().join("data/schema");
 
-    println!("cargo::rerun-if-changed={}", schema_dir.join("release_index.proto").display());
-    println!("cargo::rerun-if-changed={}", schema_dir.join("generation_pointer.proto").display());
+    println!(
+        "cargo::rerun-if-changed={}",
+        schema_dir.join("release_index.proto").display()
+    );
+    println!(
+        "cargo::rerun-if-changed={}",
+        schema_dir.join("generation_pointer.proto").display()
+    );
 
     prost_build::Config::new().compile_protos(
         &["release_index.proto", "generation_pointer.proto"],

--- a/pkgs/worker/release/src/lib.rs
+++ b/pkgs/worker/release/src/lib.rs
@@ -86,27 +86,34 @@ fn sanitize_filename_part(part: &str) -> String {
         .collect()
 }
 
-async fn read_bucket_bytes(bucket: &Bucket, path: &str) -> Result<Vec<u8>> {
-    let object = bucket
-        .get(path)
-        .execute()
-        .await?
-        .ok_or_else(|| Error::RustError(format!("object not found: {}", path)))?;
+async fn read_bucket_bytes(bucket: &Bucket, path: &str) -> Result<Option<Vec<u8>>> {
+    let object = match bucket.get(path).execute().await? {
+        Some(o) => o,
+        None => return Ok(None),
+    };
     let body = object
         .body()
         .ok_or_else(|| Error::RustError(format!("object has no body: {}", path)))?;
-    body.bytes().await
+    body.bytes().await.map(Some)
 }
 
-async fn read_bucket_json(bucket: &Bucket, path: &str) -> Result<serde_json::Value> {
-    let bytes = read_bucket_bytes(bucket, path).await?;
+async fn read_bucket_json(bucket: &Bucket, path: &str) -> Result<Option<serde_json::Value>> {
+    let bytes = match read_bucket_bytes(bucket, path).await? {
+        Some(b) => b,
+        None => return Ok(None),
+    };
     serde_json::from_slice(&bytes)
+        .map(Some)
         .map_err(|e| Error::RustError(format!("JSON parse error for {}: {}", path, e)))
 }
 
-async fn read_bucket_proto<T: Message + Default>(bucket: &Bucket, path: &str) -> Result<T> {
-    let bytes = read_bucket_bytes(bucket, path).await?;
+async fn read_bucket_proto<T: Message + Default>(bucket: &Bucket, path: &str) -> Result<Option<T>> {
+    let bytes = match read_bucket_bytes(bucket, path).await? {
+        Some(b) => b,
+        None => return Ok(None),
+    };
     T::decode(&*bytes)
+        .map(Some)
         .map_err(|e| Error::RustError(format!("protobuf decode error for {}: {}", path, e)))
 }
 
@@ -123,41 +130,50 @@ async fn fetch_channel_artifact(bucket: &Bucket, channel: &str) -> Result<Option
         bucket,
         &format!("{}/channels/heads/{}/metadata.json", RESOURCE_ROOT, channel),
     )
-    .await
+    .await?
     {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
-    };
-
-    let gen_hash = match head_meta["generationHash"].as_str() {
-        Some(h) => h.to_string(),
+        Some(v) => v,
         None => return Ok(None),
     };
 
-    let pointer: GenerationPointer = match read_bucket_proto(
+    let gen_hash = head_meta["generationHash"]
+        .as_str()
+        .ok_or_else(|| {
+            Error::RustError(format!(
+                "channel metadata missing generationHash: {}",
+                channel
+            ))
+        })?
+        .to_string();
+
+    let pointer: GenerationPointer = read_bucket_proto(
         bucket,
         &format!("{}/channels/refs/{}/releases.pb2", RESOURCE_ROOT, gen_hash),
     )
-    .await
-    {
-        Ok(p) => p,
-        Err(_) => return Ok(None),
-    };
+    .await?
+    .ok_or_else(|| {
+        Error::RustError(format!(
+            "release pointer not found for generation: {}",
+            gen_hash
+        ))
+    })?;
 
     let snapshot_hash = pointer.snapshot_hash;
 
-    let index: ReleaseIndex = match read_bucket_proto(
+    let index: ReleaseIndex = read_bucket_proto(
         bucket,
         &format!(
             "{}/assets/releases/{}/releases.pb2",
             RESOURCE_ROOT, snapshot_hash
         ),
     )
-    .await
-    {
-        Ok(idx) => idx,
-        Err(_) => return Ok(None),
-    };
+    .await?
+    .ok_or_else(|| {
+        Error::RustError(format!(
+            "release index not found for snapshot: {}",
+            snapshot_hash
+        ))
+    })?;
 
     let android = index.android.map(|arts| {
         let mut variants = HashMap::new();
@@ -232,13 +248,21 @@ async fn handle_artifacts(req: Request, env: Env) -> Result<Response> {
     )
     .await
     {
-        Ok(v) => v,
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            return Response::from_json(&ArtifactResponse {
+                ok: false,
+                artifacts: None,
+                channels: vec![],
+                error: Some("channel registry not found".to_string()),
+            });
+        }
         Err(e) => {
             return Response::from_json(&ArtifactResponse {
                 ok: false,
                 artifacts: None,
                 channels: vec![],
-                error: Some(format!("channel registry not found: {}", e)),
+                error: Some(format!("failed to read channel registry: {}", e)),
             });
         }
     };

--- a/pkgs/worker/release/src/lib.rs
+++ b/pkgs/worker/release/src/lib.rs
@@ -214,11 +214,12 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
             handle_artifacts(req, ctx.env).await
         })
         .get_async(
-            "/releases/download/:channel/:variant",
+            "/releases/download/:channel/:variant/:hash",
             |req, ctx| async move {
                 let channel = ctx.param("channel").cloned().unwrap_or_default();
                 let variant = ctx.param("variant").cloned().unwrap_or_default();
-                handle_download(req, ctx.env, &channel, &variant).await
+                let hash = ctx.param("hash").cloned().unwrap_or_default();
+                handle_download(req, ctx.env, &channel, &variant, &hash).await
             },
         )
         .run(req, env)
@@ -279,11 +280,15 @@ async fn handle_artifacts(req: Request, env: Env) -> Result<Response> {
                 variants
                     .into_iter()
                     .map(|(name, v)| {
+                        let download_url = format!(
+                            "{}/releases/download/{}/{}/{}",
+                            origin, ch, name, v.content_hash
+                        );
                         let info = VariantInfo {
                             identifier: v.identifier,
                             content_hash: v.content_hash,
                             size: v.size,
-                            download_url: format!("{}/releases/download/{}/{}", origin, ch, name),
+                            download_url,
                         };
                         (name, info)
                     })
@@ -315,6 +320,7 @@ async fn handle_download(
     env: Env,
     channel: &str,
     variant: &str,
+    hash: &str,
 ) -> Result<Response> {
     let bucket = env
         .bucket("RELEASE_BUCKET")
@@ -333,6 +339,18 @@ async fn handle_download(
         Some(v) => v,
         None => return Response::error(format!("variant not found: {}/{}", channel, variant), 404),
     };
+
+    if info.content_hash != hash {
+        let mut res = Response::error(
+            format!(
+                "stale content hash for {}/{}: {} (current: {})",
+                channel, variant, hash, info.content_hash
+            ),
+            404,
+        )?;
+        res.headers_mut().set("Cache-Control", "no-cache")?;
+        return Ok(res);
+    }
 
     let path = blob_path(&info.identifier, &info.content_hash);
     let object = match bucket.get(&path).execute().await? {

--- a/pkgs/worker/release/src/lib.rs
+++ b/pkgs/worker/release/src/lib.rs
@@ -125,6 +125,16 @@ fn add_cors(res: &mut Response) -> Result<()> {
     Ok(())
 }
 
+fn artifact_error_response(msg: &str, status: u16) -> Result<Response> {
+    let res = Response::from_json(&ArtifactResponse {
+        ok: false,
+        artifacts: None,
+        channels: vec![],
+        error: Some(msg.to_string()),
+    })?;
+    Ok(res.with_status(status))
+}
+
 async fn fetch_channel_artifact(bucket: &Bucket, channel: &str) -> Result<Option<RawArtifactInfo>> {
     let head_meta: serde_json::Value = match read_bucket_json(
         bucket,
@@ -209,7 +219,7 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         add_cors(&mut res)?;
         return Ok(res);
     }
-    let mut res = Router::new()
+    let mut res = match Router::new()
         .get_async("/releases/artifacts", |req, ctx| async move {
             handle_artifacts(req, ctx.env).await
         })
@@ -223,7 +233,11 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
             },
         )
         .run(req, env)
-        .await?;
+        .await
+    {
+        Ok(res) => res,
+        Err(e) => Response::error(e.to_string(), 500)?,
+    };
     add_cors(&mut res)?;
     Ok(res)
 }
@@ -232,12 +246,10 @@ async fn handle_artifacts(req: Request, env: Env) -> Result<Response> {
     let bucket = match env.bucket("RELEASE_BUCKET") {
         Ok(b) => b,
         Err(e) => {
-            return Response::from_json(&ArtifactResponse {
-                ok: false,
-                artifacts: None,
-                channels: vec![],
-                error: Some(format!("RELEASE_BUCKET binding not configured: {}", e)),
-            });
+            return artifact_error_response(
+                &format!("RELEASE_BUCKET binding not configured: {}", e),
+                500,
+            );
         }
     };
 
@@ -251,20 +263,13 @@ async fn handle_artifacts(req: Request, env: Env) -> Result<Response> {
     {
         Ok(Some(v)) => v,
         Ok(None) => {
-            return Response::from_json(&ArtifactResponse {
-                ok: false,
-                artifacts: None,
-                channels: vec![],
-                error: Some("channel registry not found".to_string()),
-            });
+            return artifact_error_response("channel registry not found", 404);
         }
         Err(e) => {
-            return Response::from_json(&ArtifactResponse {
-                ok: false,
-                artifacts: None,
-                channels: vec![],
-                error: Some(format!("failed to read channel registry: {}", e)),
-            });
+            return artifact_error_response(
+                &format!("failed to read channel registry: {}", e),
+                500,
+            );
         }
     };
 
@@ -275,34 +280,36 @@ async fn handle_artifacts(req: Request, env: Env) -> Result<Response> {
 
     let mut artifacts = HashMap::new();
     for ch in &channels {
-        if let Ok(Some(raw)) = fetch_channel_artifact(&bucket, ch).await {
-            let android = raw.android.map(|variants| {
-                variants
-                    .into_iter()
-                    .map(|(name, v)| {
-                        let download_url = format!(
-                            "{}/releases/download/{}/{}/{}",
-                            origin, ch, name, v.content_hash
-                        );
-                        let info = VariantInfo {
-                            identifier: v.identifier,
-                            content_hash: v.content_hash,
-                            size: v.size,
-                            download_url,
-                        };
-                        (name, info)
-                    })
-                    .collect()
-            });
-            artifacts.insert(
-                ch.clone(),
-                ArtifactInfo {
-                    id: raw.id,
-                    version: raw.version,
-                    android,
-                },
-            );
-        }
+        let raw = match fetch_channel_artifact(&bucket, ch).await? {
+            Some(raw) => raw,
+            None => continue,
+        };
+        let android = raw.android.map(|variants| {
+            variants
+                .into_iter()
+                .map(|(name, v)| {
+                    let download_url = format!(
+                        "{}/releases/download/{}/{}/{}",
+                        origin, ch, name, v.content_hash
+                    );
+                    let info = VariantInfo {
+                        identifier: v.identifier,
+                        content_hash: v.content_hash,
+                        size: v.size,
+                        download_url,
+                    };
+                    (name, info)
+                })
+                .collect()
+        });
+        artifacts.insert(
+            ch.clone(),
+            ArtifactInfo {
+                id: raw.id,
+                version: raw.version,
+                android,
+            },
+        );
     }
 
     let body = serde_json::to_string(&ArtifactResponse {

--- a/pkgs/worker/release/src/lib.rs
+++ b/pkgs/worker/release/src/lib.rs
@@ -365,7 +365,6 @@ async fn handle_download(
         None => return Response::error(format!("blob not found: {}", path), 404),
     };
 
-    let size = object.size();
     let body = object
         .body()
         .ok_or_else(|| Error::RustError(format!("object has no body: {}", path)))?;
@@ -383,7 +382,6 @@ async fn handle_download(
         "Content-Disposition",
         &format!("attachment; filename=\"{}\"", filename),
     )?;
-    headers.set("Content-Length", &size.to_string())?;
     headers.set("Cache-Control", "public, max-age=31536000, immutable")?;
     Ok(res)
 }

--- a/pkgs/worker/release/src/lib.rs
+++ b/pkgs/worker/release/src/lib.rs
@@ -12,7 +12,7 @@ use proto::GenerationPointer;
 use proto::ReleaseIndex;
 
 const RESOURCE_ROOT: &str = "efa/v2";
-const DEFAULT_ORIGIN: &str = "https://prod.storage.efa-tech.dev";
+const APK_CONTENT_TYPE: &str = "application/vnd.android.package-archive";
 
 #[derive(Serialize)]
 struct ArtifactResponse {
@@ -40,6 +40,18 @@ struct VariantInfo {
     download_url: String,
 }
 
+struct RawVariantInfo {
+    identifier: String,
+    content_hash: String,
+    size: i64,
+}
+
+struct RawArtifactInfo {
+    id: String,
+    version: String,
+    android: Option<HashMap<String, RawVariantInfo>>,
+}
+
 fn sha256_hex(input: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());
@@ -49,6 +61,29 @@ fn sha256_hex(input: &str) -> String {
 
 fn hex_prefix_2(hash: &str) -> &str {
     &hash[..2]
+}
+
+fn blob_path(identifier: &str, content_hash: &str) -> String {
+    let ident_hash = sha256_hex(identifier);
+    format!(
+        "{}/assets/blobs/{}/{}/{}",
+        RESOURCE_ROOT,
+        hex_prefix_2(&ident_hash),
+        ident_hash,
+        content_hash
+    )
+}
+
+fn sanitize_filename_part(part: &str) -> String {
+    part.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
 }
 
 async fn read_bucket_bytes(bucket: &Bucket, path: &str) -> Result<Vec<u8>> {
@@ -69,10 +104,7 @@ async fn read_bucket_json(bucket: &Bucket, path: &str) -> Result<serde_json::Val
         .map_err(|e| Error::RustError(format!("JSON parse error for {}: {}", path, e)))
 }
 
-async fn read_bucket_proto<T: Message + Default>(
-    bucket: &Bucket,
-    path: &str,
-) -> Result<T> {
+async fn read_bucket_proto<T: Message + Default>(bucket: &Bucket, path: &str) -> Result<T> {
     let bytes = read_bucket_bytes(bucket, path).await?;
     T::decode(&*bytes)
         .map_err(|e| Error::RustError(format!("protobuf decode error for {}: {}", path, e)))
@@ -86,11 +118,7 @@ fn add_cors(res: &mut Response) -> Result<()> {
     Ok(())
 }
 
-async fn fetch_channel_artifact(
-    bucket: &Bucket,
-    origin: &str,
-    channel: &str,
-) -> Result<Option<ArtifactInfo>> {
+async fn fetch_channel_artifact(bucket: &Bucket, channel: &str) -> Result<Option<RawArtifactInfo>> {
     let head_meta: serde_json::Value = match read_bucket_json(
         bucket,
         &format!("{}/channels/heads/{}/metadata.json", RESOURCE_ROOT, channel),
@@ -138,22 +166,12 @@ async fn fetch_channel_artifact(
             [Some(arts.general), arts.armv7, arts.arm64, arts.x64];
         for (i, field) in fields.iter().enumerate() {
             if let Some(v) = field {
-                let ident_hash = sha256_hex(&v.identifier);
-                let download_url = format!(
-                    "{}/{}/assets/blobs/{}/{}/{}",
-                    origin,
-                    RESOURCE_ROOT,
-                    hex_prefix_2(&ident_hash),
-                    ident_hash,
-                    v.content_hash
-                );
                 variants.insert(
                     names[i].to_string(),
-                    VariantInfo {
+                    RawVariantInfo {
                         identifier: v.identifier.clone(),
                         content_hash: v.content_hash.clone(),
                         size: v.size,
-                        download_url,
                     },
                 );
             }
@@ -161,7 +179,7 @@ async fn fetch_channel_artifact(
         variants
     });
 
-    Ok(Some(ArtifactInfo {
+    Ok(Some(RawArtifactInfo {
         id: index.id,
         version: index.version,
         android,
@@ -179,21 +197,21 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .get_async("/releases/artifacts", |req, ctx| async move {
             handle_artifacts(req, ctx.env).await
         })
+        .get_async(
+            "/releases/download/:channel/:variant",
+            |req, ctx| async move {
+                let channel = ctx.param("channel").cloned().unwrap_or_default();
+                let variant = ctx.param("variant").cloned().unwrap_or_default();
+                handle_download(req, ctx.env, &channel, &variant).await
+            },
+        )
         .run(req, env)
         .await?;
     add_cors(&mut res)?;
     Ok(res)
 }
 
-fn origin_from_env(env: &Env) -> String {
-    env.var("BLOB_ORIGIN")
-        .ok()
-        .and_then(|v| v.to_string().into())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_ORIGIN.to_string())
-}
-
-async fn handle_artifacts(_req: Request, env: Env) -> Result<Response> {
+async fn handle_artifacts(req: Request, env: Env) -> Result<Response> {
     let bucket = match env.bucket("RELEASE_BUCKET") {
         Ok(b) => b,
         Err(e) => {
@@ -206,21 +224,24 @@ async fn handle_artifacts(_req: Request, env: Env) -> Result<Response> {
         }
     };
 
-    let origin = origin_from_env(&env);
+    let origin = req.url()?.origin().ascii_serialization();
 
-    let registry: serde_json::Value =
-        match read_bucket_json(&bucket, &format!("{}/channels/heads/channels.json", RESOURCE_ROOT)).await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                return Response::from_json(&ArtifactResponse {
-                    ok: false,
-                    artifacts: None,
-                    channels: vec![],
-                    error: Some(format!("channel registry not found: {}", e)),
-                });
-            }
-        };
+    let registry: serde_json::Value = match read_bucket_json(
+        &bucket,
+        &format!("{}/channels/heads/channels.json", RESOURCE_ROOT),
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            return Response::from_json(&ArtifactResponse {
+                ok: false,
+                artifacts: None,
+                channels: vec![],
+                error: Some(format!("channel registry not found: {}", e)),
+            });
+        }
+    };
 
     let channels: Vec<String> = registry["channels"]
         .as_object()
@@ -229,8 +250,29 @@ async fn handle_artifacts(_req: Request, env: Env) -> Result<Response> {
 
     let mut artifacts = HashMap::new();
     for ch in &channels {
-        if let Ok(Some(artifact)) = fetch_channel_artifact(&bucket, &origin, ch).await {
-            artifacts.insert(ch.clone(), artifact);
+        if let Ok(Some(raw)) = fetch_channel_artifact(&bucket, ch).await {
+            let android = raw.android.map(|variants| {
+                variants
+                    .into_iter()
+                    .map(|(name, v)| {
+                        let info = VariantInfo {
+                            identifier: v.identifier,
+                            content_hash: v.content_hash,
+                            size: v.size,
+                            download_url: format!("{}/releases/download/{}/{}", origin, ch, name),
+                        };
+                        (name, info)
+                    })
+                    .collect()
+            });
+            artifacts.insert(
+                ch.clone(),
+                ArtifactInfo {
+                    id: raw.id,
+                    version: raw.version,
+                    android,
+                },
+            );
         }
     }
 
@@ -242,4 +284,57 @@ async fn handle_artifacts(_req: Request, env: Env) -> Result<Response> {
     })
     .map_err(|e| Error::RustError(format!("serialization error: {}", e)))?;
     Response::ok(body)
+}
+
+async fn handle_download(
+    _req: Request,
+    env: Env,
+    channel: &str,
+    variant: &str,
+) -> Result<Response> {
+    let bucket = env
+        .bucket("RELEASE_BUCKET")
+        .map_err(|e| Error::RustError(format!("RELEASE_BUCKET binding not configured: {}", e)))?;
+
+    let artifact = match fetch_channel_artifact(&bucket, channel).await? {
+        Some(a) => a,
+        None => return Response::error(format!("channel not found: {}", channel), 404),
+    };
+
+    let info = match artifact
+        .android
+        .as_ref()
+        .and_then(|variants| variants.get(variant))
+    {
+        Some(v) => v,
+        None => return Response::error(format!("variant not found: {}/{}", channel, variant), 404),
+    };
+
+    let path = blob_path(&info.identifier, &info.content_hash);
+    let object = match bucket.get(&path).execute().await? {
+        Some(o) => o,
+        None => return Response::error(format!("blob not found: {}", path), 404),
+    };
+
+    let size = object.size();
+    let body = object
+        .body()
+        .ok_or_else(|| Error::RustError(format!("object has no body: {}", path)))?;
+
+    let filename = format!(
+        "eve-fit-assistant-{}-{}.apk",
+        sanitize_filename_part(&artifact.version),
+        sanitize_filename_part(variant)
+    );
+
+    let mut res = Response::from_body(body.response_body()?)?;
+    let headers = res.headers_mut();
+    headers.set("Content-Type", APK_CONTENT_TYPE)?;
+    headers.set(
+        "Content-Disposition",
+        &format!("attachment; filename=\"{}\"", filename),
+    )?;
+    headers.set("Content-Length", &size.to_string())?;
+    headers.set("Cache-Control", "public, max-age=31536000, immutable")?;
+    Ok(res)
 }

--- a/pkgs/worker/release/wrangler.toml
+++ b/pkgs/worker/release/wrangler.toml
@@ -13,9 +13,6 @@ remote = true
 # Till 2026.07 cloudflare does not offer cargo environment barely.
 command = "export PATH=\"$HOME/.cargo/bin:$HOME/.local/bin:$PATH\" && worker-build --release"
 
-[vars]
-BLOB_ORIGIN = "https://prod.storage.efa-tech.dev"
-
 [[routes]]
 pattern = "api.efa-tech.dev/releases/*"
 zone_name = "efa-tech.dev"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated release download endpoint to retrieve APKs by channel, variant, and content hash.
  * APK downloads now return appropriate headers (content type, content length, content-disposition filename) and immutable caching.
  * Artifact listings now link to the new download endpoint.
  * Missing channel/variant/blob or hash mismatches return clear `404` responses (with `no-cache` on stale hash).

* **Documentation**
  * Updated the release API examples and architecture docs to reflect the new download flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->