### PR TITLE
feat(fit): display damage per hit in weapon and fighter stats

### DIFF
--- a/lib/pages/fit/components/attribute/weapon.dart
+++ b/lib/pages/fit/components/attribute/weapon.dart
@@ -58,7 +58,7 @@ List<Text> _getWeaponTextGroup(native.Ship ship) {
 
   final dpsWithReload = hull.getAttribute(EveConstExtendedAttrID.damagePerSecondWithReload);
   texts
-    ..add(Text("${dpsWithReload.toStringAsFixed(1)}/s"))
+    ..add(Text("${(dpsWithReload + fighterDps).toStringAsFixed(1)}/s"))
     ..add(const Text(" | "));
 
   final alpha = hull.getAttribute(EveConstExtendedAttrID.damageAlpha) + _fighterVolleySum(ship);

--- a/lib/pages/fit/components/attribute/weapon.dart
+++ b/lib/pages/fit/components/attribute/weapon.dart
@@ -13,10 +13,7 @@ class Weapon extends StatelessWidget {
         leading: const Image(image: ImageAssets.attrDamageAlpha, height: 28),
         title: DefaultTextStyle(
           style: const TextStyle(fontSize: 16),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: _getWeaponTextGroup(ship.hull),
-          ),
+          child: Row(mainAxisAlignment: MainAxisAlignment.end, children: _getWeaponTextGroup(ship)),
         ),
       ),
       ListTile(
@@ -45,7 +42,12 @@ class Weapon extends StatelessWidget {
   );
 }
 
-List<Text> _getWeaponTextGroup(native.Item hull) {
+double _fighterVolleySum(native.Ship ship) => ship.modules
+    .where((item) => item.slot.slotType is native.OutSlotType_Fighter)
+    .fold(0, (sum, item) => sum + _fighterVolley(item));
+
+List<Text> _getWeaponTextGroup(native.Ship ship) {
+  final hull = ship.hull;
   final List<Text> texts = [];
 
   final fighterDps = hull.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond);
@@ -55,7 +57,12 @@ List<Text> _getWeaponTextGroup(native.Item hull) {
     ..add(const Text(" | "));
 
   final dpsWithReload = hull.getAttribute(EveConstExtendedAttrID.damagePerSecondWithReload);
-  texts.add(Text("${dpsWithReload.toStringAsFixed(1)}/s"));
+  texts
+    ..add(Text("${dpsWithReload.toStringAsFixed(1)}/s"))
+    ..add(const Text(" | "));
+
+  final alpha = hull.getAttribute(EveConstExtendedAttrID.damageAlpha) + _fighterVolleySum(ship);
+  texts.add(Text(alpha.toStringAsFixed(1)));
 
   return texts;
 }
@@ -72,7 +79,13 @@ List<Text> _getWeaponWithoutDroneTextGroup(native.Item hull) {
     ..add(const Text(" | "));
 
   final dpsWithReload = hull.getAttribute(EveConstExtendedAttrID.damagePerSecondWithReload);
-  texts.add(Text("${(dpsWithReload - drone).toStringAsFixed(1)}/s"));
+  texts
+    ..add(Text("${(dpsWithReload - drone).toStringAsFixed(1)}/s"))
+    ..add(const Text(" | "));
+
+  // damageAlpha only aggregates weapon modules; drones and fighters are excluded.
+  final alpha = hull.getAttribute(EveConstExtendedAttrID.damageAlpha);
+  texts.add(Text(alpha.toStringAsFixed(1)));
 
   return texts;
 }

--- a/lib/pages/fit/components/equipment/slot_row/fighter_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/fighter_slot.dart
@@ -155,13 +155,17 @@ class _FighterSlotRow extends ConsumerWidget {
         padding: .zero,
       ),
     ];
-    final dpsText = representative == null
+    final dps = representative?.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond);
+    final volley = representative == null ? null : _fighterVolley(representative);
+    final dpsText = dps == null || volley == null
         ? null
         : Text(
             "${storedFighter.quantity} x "
-            "${representative.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond).toStringAsFixed(1)}/s = "
-            "${(representative.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond) * storedFighter.quantity).toStringAsFixed(1)}/s | "
-            "${_fighterVolley(representative).toStringAsFixed(1)}",
+            "${dps.toStringAsFixed(1)}/s = "
+            "${(dps * storedFighter.quantity).toStringAsFixed(1)}/s\n"
+            "${storedFighter.quantity} x "
+            "${volley.toStringAsFixed(1)} = "
+            "${(volley * storedFighter.quantity).toStringAsFixed(1)}",
           );
 
     final content = ListTile(

--- a/lib/pages/fit/components/equipment/slot_row/fighter_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/fighter_slot.dart
@@ -158,7 +158,10 @@ class _FighterSlotRow extends ConsumerWidget {
     final dpsText = representative == null
         ? null
         : Text(
-            "${storedFighter.quantity} x ${representative.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond).toStringAsFixed(1)}/s = ${(representative.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond) * storedFighter.quantity).toStringAsFixed(1)}/s",
+            "${storedFighter.quantity} x "
+            "${representative.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond).toStringAsFixed(1)}/s = "
+            "${(representative.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond) * storedFighter.quantity).toStringAsFixed(1)}/s | "
+            "${_fighterVolley(representative).toStringAsFixed(1)}",
           );
 
     final content = ListTile(
@@ -249,6 +252,11 @@ class _FighterSlotRow extends ConsumerWidget {
     );
   }
 }
+
+double _fighterVolley(native.Item fighter) =>
+    fighter.getAttribute(EveConstExtendedAttrID.fighterDamageMissiles) +
+    fighter.getAttribute(EveConstExtendedAttrID.fighterDamageAttackTurret) +
+    fighter.getAttribute(EveConstExtendedAttrID.fighterDamageAttackMissile);
 
 class _FighterCountText extends StatelessWidget {
   const _FighterCountText({required this.count, required this.total});


### PR DESCRIPTION
Closes #182 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weapon details now include fighter contributions in displayed alpha damage.
  * Fighter equipment slots now show an additional volley damage value alongside DPS.
* **Bug Fixes**
  * Improved weapon damage calculations to more accurately account for fighter-based attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->