### PR TITLE
fix(ci): prevent partial generation publish on missing channel head

### DIFF
--- a/.github/workflows/_release-data.yml
+++ b/.github/workflows/_release-data.yml
@@ -143,7 +143,8 @@ jobs:
               --dev-env remote.s3.secret_key="${REMOTE_SECRET_KEY}" \
               remote sync \
               --target s3 \
-              --channel testing'
+              --channel testing \
+              --schema-root cache/remote'
 
       - name: Publish to testing channel
         if: inputs.test_mode == false
@@ -165,6 +166,15 @@ jobs:
               --schema-root cache/remote \
               --target s3'
 
+      - name: Sync remote channel head (MinIO mock)
+        if: inputs.test_mode
+        run: |
+          nix develop .#python --command bash -c \
+            'uv run x.py remote sync \
+              --target minio \
+              --channel testing \
+              --schema-root cache/remote'
+
       - name: Publish to testing channel (MinIO mock)
         if: inputs.test_mode
         run: |
@@ -172,7 +182,8 @@ jobs:
             'uv run x.py ci release-data publish testing \
               --hashes snapshot-hashes.json \
               --schema-root cache/remote \
-              --target minio'
+              --target minio \
+              --allow-missing-head'
 
       - name: Upload diagnostics
         if: failure()

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -367,6 +367,12 @@ def register_ci_commands(cli_group: click.Group) -> None:
         default=True,
         help="Include unchanged server snapshots from the current channel head (default: true).",
     )
+    @click.option(
+        "--allow-missing-head",
+        is_flag=True,
+        default=False,
+        help="Allow publishing without a local channel head (first publish to a channel).",
+    )
     @click.pass_context
     def release_data_publish(
         ctx: click.Context,
@@ -383,6 +389,7 @@ def register_ci_commands(cli_group: click.Group) -> None:
         workers: int,
         sync_depth: int,
         merge: bool,
+        allow_missing_head: bool,
     ):
         """Publish resource snapshots to a remote channel."""
         from bootstrap.remote import SessionManager
@@ -413,6 +420,14 @@ def register_ci_commands(cli_group: click.Group) -> None:
                             f"Carried forward {entry.server_id} snapshot: "
                             f"{entry.snapshot_hash[:16]}..."
                         )
+            elif not allow_missing_head:
+                raise click.ClickException(
+                    f"No local channel head found for '{resolved_channel}' under "
+                    f"{resolved_root}; refusing to publish a partial generation. "
+                    "Run `remote sync` for this channel into the same schema root first, "
+                    "or pass --allow-missing-head if this is the first publish "
+                    "to the channel."
+                )
 
         init_cmd = _lookup_command(ctx, "remote", "session", "init")
         add_cmd = _lookup_command(ctx, "remote", "session", "add")

--- a/bootstrap/tests/test_ci_release_data_publish.py
+++ b/bootstrap/tests/test_ci_release_data_publish.py
@@ -1,0 +1,105 @@
+"""Regression tests for `ci release-data publish` missing-head handling.
+
+Covers the fail-loud guard added to prevent partial generations: when
+--merge is on (the default) but no local channel head exists under the
+schema root, the publish must abort unless --allow-missing-head is given.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+
+from pathlib import Path
+
+import click
+import click.testing
+import pytest
+
+from bootstrap.cli import register_all_commands
+from bootstrap.tests.test_session_cli import _make_resource_snapshot
+
+
+@pytest.fixture
+def tmp_project() -> Path:
+    d = tempfile.mkdtemp(prefix="efa-release-data-publish-")
+    yield Path(d)
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _make_cli() -> click.Group:
+    @click.group()
+    def cli() -> None:
+        pass
+
+    register_all_commands(cli)
+    return cli
+
+
+def _write_hashes(tmp_project: Path, hashes: dict[str, str]) -> Path:
+    hashes_path = tmp_project / "snapshot-hashes.json"
+    hashes_path.write_text(json.dumps(hashes), encoding="utf-8")
+    return hashes_path
+
+
+class TestMissingHeadGuard:
+    def test_rejects_missing_head_by_default(
+        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("bootstrap.ci.commands.PROJECT_ROOT", tmp_project)
+        hashes_path = _write_hashes(tmp_project, {"tranquility": "ab" * 32})
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(
+            _make_cli(),
+            [
+                "ci",
+                "release-data",
+                "publish",
+                "testing",
+                "--hashes",
+                str(hashes_path),
+                "--schema-root",
+                "cache/remote",
+                "--test-mode",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "No local channel head found for 'testing'" in result.output
+        assert "refusing to publish a partial generation" in result.output
+        assert "Staged" not in result.output
+
+    def test_proceeds_with_allow_missing_head(
+        self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("bootstrap.ci.commands.PROJECT_ROOT", tmp_project)
+        schema_root = tmp_project / "cache" / "remote"
+        schema_root.mkdir(parents=True)
+        snap_hash = _make_resource_snapshot(schema_root, server_id="tranquility")
+        hashes_path = _write_hashes(tmp_project, {"tranquility": snap_hash})
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(
+            _make_cli(),
+            [
+                "ci",
+                "release-data",
+                "publish",
+                "testing",
+                "--hashes",
+                str(hashes_path),
+                "--schema-root",
+                "cache/remote",
+                "--test-mode",
+                "--allow-missing-head",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Staged tranquility snapshot" in result.output
+        assert "Test mode: skipped publish/sync/verify." in result.output
+        refs_dir = schema_root / "channels" / "refs"
+        generations = [p for p in refs_dir.iterdir() if p.is_dir() and not p.name.startswith("tmp")]
+        assert len(generations) == 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--allow-missing-head` option to permit `release-data publish` when no prior channel generation head exists.
* **Bug Fixes**
  * Publishing now blocks partial merged generations by default if the local channel head is missing.
* **Workflow / Release Improvements**
  * Improved testing-channel publishing for S3/MinIO by syncing remote head (including cache schema root) and allowing missing heads for MinIO mock publishing.
* **Tests**
  * Added regression coverage for missing-head behavior (default rejection vs. allowed success).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->