### PR TITLE
fix(ci): skip blob check for head-unchanged snapshots in session verify

### DIFF
--- a/bootstrap/cli/remote/session.py
+++ b/bootstrap/cli/remote/session.py
@@ -570,6 +570,8 @@ def _head_resource_snapshot_hashes(root: Path, channel: str) -> set[str]:
         if not head or not head.generation_hash:
             return set()
         gen = GenerationStore(root).load(head.generation_hash)
+    # Broad catch is intentional: any head/generation read failure (missing,
+    # corrupt, or incompatible data) must fall back to requiring all blobs.
     except Exception:
         return set()
     return {entry.snapshot_hash for entry in gen.resources.entries if entry.snapshot_hash}

--- a/bootstrap/cli/remote/session.py
+++ b/bootstrap/cli/remote/session.py
@@ -555,6 +555,26 @@ def _check_duplicate_server_ids(root: Path, session: Session, issues: list) -> N
             seen[meta.server_id] = h
 
 
+def _head_resource_snapshot_hashes(root: Path, channel: str) -> set[str]:
+    """Resource snapshot hashes referenced by the channel head generation.
+
+    Staged snapshots unchanged from the head are already published on the
+    remote; the publisher skips re-uploading them, so their blobs are not
+    required locally (a metadata-only sync never downloads blobs).
+    """
+    from bootstrap.remote.generation import GenerationStore
+    from bootstrap.remote.head import ChannelHeadStore
+
+    try:
+        head = ChannelHeadStore(root)._safe_get_head(channel)
+        if not head or not head.generation_hash:
+            return set()
+        gen = GenerationStore(root).load(head.generation_hash)
+    except Exception:
+        return set()
+    return {entry.snapshot_hash for entry in gen.resources.entries if entry.snapshot_hash}
+
+
 def _verify_staged(root: Path, session: Session) -> list:
     """Validate staged snapshots across all four verification phases."""
     from bootstrap.remote.hash import verify_snapshot_hash as _verify_snapshot_hash
@@ -644,7 +664,10 @@ def _verify_staged(root: Path, session: Session) -> list:
                 )
 
         if snap_type == "resource":
+            head_hashes = _head_resource_snapshot_hashes(root, session.channel)
             for h in staged_hashes:
+                if h in head_hashes:
+                    continue
                 snap_dir = dir_for_type[snap_type](root, h)
                 if snap_dir.is_dir() and (snap_dir / proto_name).is_file():
                     _check_staged_resource_blobs(root, h, issues)

--- a/bootstrap/tests/test_session_cli.py
+++ b/bootstrap/tests/test_session_cli.py
@@ -24,6 +24,8 @@ from bootstrap.cli.remote.session import _add_snapshot_by_file
 from bootstrap.cli.remote.session import _build_generation_data
 from bootstrap.cli.remote.session import _check_duplicate_server_ids
 from bootstrap.cli.remote.session import _compute_diff
+from bootstrap.cli.remote.session import _head_resource_snapshot_hashes
+from bootstrap.cli.remote.session import _verify_staged
 from bootstrap.cli.remote.session import register_remote_session
 from bootstrap.remote import SessionManager
 from bootstrap.remote.generation import utc_timestamp
@@ -613,7 +615,10 @@ def _verify_staged_style(tmp_root: Path, store: SessionStore) -> list[Issue]:
                 )
 
         if snap_type == "resource":
+            head_hashes = _head_resource_snapshot_hashes(tmp_root, session.channel)
             for h in staged_map[snap_type]:
+                if h in head_hashes:
+                    continue
                 snap_dir = dir_for_type[snap_type](tmp_root, h)
                 if snap_dir.is_dir() and (snap_dir / proto_name).is_file():
                     proto_path = snap_dir / proto_name
@@ -794,6 +799,53 @@ class TestSessionVerify:
         issues = _verify_staged_style(tmp_root, store)
         errors = [i for i in issues if i.severity == "error"]
         assert len(errors) == 0
+
+    def test_verify_skips_blobs_for_head_unchanged_snapshot(
+        self, store: SessionStore, tmp_root: Path, mgr: SessionManager
+    ) -> None:
+        _, res_hash = _make_full_generation(mgr, tmp_root)
+
+        from bootstrap.remote.models import ResourceIndex
+        from bootstrap.remote.models import read_pb2 as _read_pb2
+        from bootstrap.remote.paths import resource_snapshot_dir as _rdir
+
+        snap_dir = _rdir(tmp_root, res_hash)
+        index = _read_pb2(snap_dir / "resources.pb2", ResourceIndex)
+        assert index.entries
+        for entry in index.entries:
+            bpath = blob_path(tmp_root, ident_hash(entry.resource_id), entry.content_hash)
+            bpath.unlink()
+
+        _init_session(store)
+        store.add_snapshot("resource", res_hash)
+
+        issues = _verify_staged(tmp_root, store.load())
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_verify_flags_missing_blobs_for_new_snapshot(
+        self, store: SessionStore, tmp_root: Path, mgr: SessionManager
+    ) -> None:
+        _make_full_generation(mgr, tmp_root)
+
+        new_hash = _make_resource_snapshot(tmp_root, server_id="serenity")
+
+        from bootstrap.remote.models import ResourceIndex
+        from bootstrap.remote.models import read_pb2 as _read_pb2
+        from bootstrap.remote.paths import resource_snapshot_dir as _rdir
+
+        snap_dir = _rdir(tmp_root, new_hash)
+        index = _read_pb2(snap_dir / "resources.pb2", ResourceIndex)
+        assert index.entries
+        entry = index.entries[0]
+        blob_path(tmp_root, ident_hash(entry.resource_id), entry.content_hash).unlink()
+
+        _init_session(store)
+        store.add_snapshot("resource", new_hash)
+
+        issues = _verify_staged(tmp_root, store.load())
+        missing_blobs = [i for i in issues if "Missing blob" in i.message]
+        assert len(missing_blobs) >= 1
 
 
 # ===========================================================================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Staged resource snapshots already present in the current channel head are no longer subjected to unnecessary local blob checks.
  * New or changed resource snapshots continue to be validated, including detection of missing blobs.
  * Verification safely falls back to standard checks when the channel head cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->