### PR TITLE
feat(fit): version native fit payload with v1 migration and v2 emit format

### DIFF
--- a/lib/features/fit_io/text_export.dart
+++ b/lib/features/fit_io/text_export.dart
@@ -1,6 +1,7 @@
 import "dart:convert";
 
 import "package:archive/archive.dart";
+import "package:eve_fit_assistant/storage/fit/persistence.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/storage/repo/collection.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -28,9 +29,9 @@ class FitTextExporter {
   };
 
   String _exportNativeFit(FitStorage fit) {
-    final payload = jsonEncode({"version": 1, "fit": fit.toJson()});
+    final payload = jsonEncode(encodeNativeFitPayload(fit));
     final compressed = const GZipEncoder().encodeBytes(utf8.encode(payload), level: 9);
-    return "EFA:${base64Encode(compressed)}";
+    return "EFA2:${base64Encode(compressed)}";
   }
 
   Future<String> _exportEft(FitStorage fit) async {

--- a/lib/features/fit_io/text_import.dart
+++ b/lib/features/fit_io/text_import.dart
@@ -40,6 +40,7 @@ class FitTextImporter {
 
   static final _nativePrefixPattern = RegExp(r"^EFA(?:(\d+))?:");
   static const _legacyNativePrefixVersion = 1;
+  static const _currentNativePrefixVersion = 2;
 
   final WidgetRef ref;
 
@@ -76,7 +77,12 @@ class FitTextImporter {
         throw const FitTextImportException(FitTextImportErrorCode.unsupportedNativeVersion);
       }
       final explicitVersion = prefixMatch.group(1);
-      if (explicitVersion != null && int.tryParse(explicitVersion) != _legacyNativePrefixVersion) {
+      final prefixVersion = explicitVersion == null
+          ? _legacyNativePrefixVersion
+          : int.tryParse(explicitVersion);
+      if (prefixVersion == null ||
+          prefixVersion < _legacyNativePrefixVersion ||
+          prefixVersion > _currentNativePrefixVersion) {
         throw const FitTextImportException(FitTextImportErrorCode.unsupportedNativeVersion);
       }
 
@@ -85,7 +91,7 @@ class FitTextImporter {
       final jsonText = utf8.decode(const GZipDecoder().decodeBytes(compressed));
       final payload = jsonDecode(jsonText) as Map<String, dynamic>;
       try {
-        return decodeNativeFitPayload(payload);
+        return decodeNativeFitPayload(payload).fit;
       } on FitPersistenceException catch (error) {
         if (error.code == FitPersistenceErrorCode.unsupportedVersion) {
           throw const FitTextImportException(FitTextImportErrorCode.unsupportedNativeVersion);

--- a/lib/storage/fit/migrations.dart
+++ b/lib/storage/fit/migrations.dart
@@ -1,0 +1,37 @@
+import "package:eve_fit_assistant/storage/repo/migration/action/legacy_utils.dart";
+
+/// Upgrades a legacy (pre-checkout) fit metadata JSON map to the current shape.
+///
+/// Legacy metadata carries `bundleId` and `bundleSnapshot` instead of
+/// `checkoutRef`. The bundle snapshot may be a plain checkout id string or an
+/// object describing the bundle; only the string form yields a checkout id.
+///
+/// The upgrade is idempotent: metadata that already has `checkoutRef` is
+/// returned unchanged.
+Map<String, dynamic> upgradeLegacyFitMetadataJson(Map<String, dynamic> metadata) {
+  if (metadata["checkoutRef"] != null) {
+    return metadata;
+  }
+
+  final bundleSnapshot = metadata["bundleSnapshot"];
+  final bundleId = metadata["bundleId"];
+  final checkoutRef = <String, dynamic>{
+    "checkoutId": bundleSnapshot is String ? bundleSnapshot : "",
+    "serverId": bundleId is String ? serverIdFromBundleId(bundleId) : "",
+  };
+
+  return Map<String, dynamic>.from(metadata)
+    ..["checkoutRef"] = checkoutRef
+    ..remove("bundleId")
+    ..remove("bundleSnapshot");
+}
+
+/// Upgrades a legacy fit storage JSON map (the inner `fit` payload) to the
+/// current shape by upgrading its metadata.
+Map<String, dynamic> upgradeLegacyFitStorageJson(Map<String, dynamic> fitJson) {
+  final metadata = fitJson["metadata"];
+  if (metadata is! Map<String, dynamic>) {
+    return fitJson;
+  }
+  return Map<String, dynamic>.from(fitJson)..["metadata"] = upgradeLegacyFitMetadataJson(metadata);
+}

--- a/lib/storage/fit/persistence.dart
+++ b/lib/storage/fit/persistence.dart
@@ -1,8 +1,10 @@
+import "package:eve_fit_assistant/storage/fit/migrations.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 
 const currentFitStorageVersion = 2;
 const currentFitRegistryVersion = 2;
-const currentNativeFitPayloadVersion = 1;
+const currentNativeFitPayloadVersion = 2;
+const legacyNativeFitPayloadVersion = 1;
 
 enum FitPersistencePayloadKind { fitStorage, fitRegistry, nativeText }
 
@@ -119,7 +121,12 @@ DecodedFitRegistry decodeFitRegistry(Map<String, dynamic> json) {
   );
 }
 
-FitStorage decodeNativeFitPayload(Map<String, dynamic> json) {
+Map<String, dynamic> encodeNativeFitPayload(FitStorage fit) => <String, dynamic>{
+  "version": currentNativeFitPayloadVersion,
+  "fit": encodeFitStorage(fit),
+};
+
+DecodedFitStorage decodeNativeFitPayload(Map<String, dynamic> json) {
   final version = _readVersion(json, kind: FitPersistencePayloadKind.nativeText);
   if (version == null) {
     throw const FitPersistenceException(
@@ -128,17 +135,28 @@ FitStorage decodeNativeFitPayload(Map<String, dynamic> json) {
       message: "Native fit payload is missing a version.",
     );
   }
-  if (version != currentNativeFitPayloadVersion) {
-    throw FitPersistenceException(
-      kind: FitPersistencePayloadKind.nativeText,
-      code: FitPersistenceErrorCode.unsupportedVersion,
-      message: "Unsupported native fit payload version: $version",
-      version: version,
-    );
+
+  switch (version) {
+    case legacyNativeFitPayloadVersion:
+      return DecodedFitStorage(
+        fit: FitStorage.fromJson(
+          upgradeLegacyFitStorageJson(
+            _readPayloadMap(json, "fit", kind: FitPersistencePayloadKind.nativeText),
+          ),
+        ),
+        didMigrate: true,
+      );
+    case currentNativeFitPayloadVersion:
+      return decodeFitStorage(
+        _readPayloadMap(json, "fit", kind: FitPersistencePayloadKind.nativeText),
+      );
   }
 
-  return FitStorage.fromJson(
-    _readPayloadMap(json, "fit", kind: FitPersistencePayloadKind.nativeText),
+  throw FitPersistenceException(
+    kind: FitPersistencePayloadKind.nativeText,
+    code: FitPersistenceErrorCode.unsupportedVersion,
+    message: "Unsupported native fit payload version: $version",
+    version: version,
   );
 }
 

--- a/lib/storage/repo/migration/action/migrate_fits.dart
+++ b/lib/storage/repo/migration/action/migrate_fits.dart
@@ -1,5 +1,5 @@
 import "package:eve_fit_assistant/config/logger.dart";
-import "package:eve_fit_assistant/storage/repo/migration/action/legacy_utils.dart";
+import "package:eve_fit_assistant/storage/fit/migrations.dart";
 import "package:eve_fit_assistant/storage/repo/migration/action/migrate_runner.dart";
 
 class MigrateFits {
@@ -29,25 +29,10 @@ class MigrateFits {
 
   Map<String, dynamic> _migrateFitRecord(Map<String, dynamic> json) {
     final payload = json["fit"] as Map<String, dynamic>;
-    final metadata = payload["metadata"] as Map<String, dynamic>;
-
-    final bundleSnapshot = metadata["bundleSnapshot"];
-    final checkoutId = bundleSnapshot is String ? bundleSnapshot : "";
-    final bundleId = metadata["bundleId"];
-    final serverId = bundleId is String ? serverIdFromBundleId(bundleId) : "";
-
-    final checkoutRefJson = <String, dynamic>{"checkoutId": checkoutId, "serverId": serverId};
-
-    final updatedMetadata = Map<String, dynamic>.from(metadata)
-      ..["checkoutRef"] = checkoutRefJson
-      ..remove("bundleId")
-      ..remove("bundleSnapshot");
-
-    final updatedPayload = Map<String, dynamic>.from(payload)..["metadata"] = updatedMetadata;
 
     return Map<String, dynamic>.from(json)
       ..["version"] = 2
-      ..["fit"] = updatedPayload;
+      ..["fit"] = upgradeLegacyFitStorageJson(payload);
   }
 }
 

--- a/test/storage/fit/native_payload_test.dart
+++ b/test/storage/fit/native_payload_test.dart
@@ -1,0 +1,188 @@
+import "dart:convert";
+
+import "package:eve_fit_assistant/storage/fit/persistence.dart";
+import "package:eve_fit_assistant/storage/fit/schema.dart";
+import "package:eve_fit_assistant/storage/repo/models/checkout_ref.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:fpdart/fpdart.dart";
+
+FitStorage _makeFitStorage() => const FitStorage(
+  metadata: FitMetadata(
+    fitId: "test-fit-1",
+    shipTypeId: 12017,
+    name: "Test Fit",
+    lastModified: 0,
+    description: "",
+    checkoutRef: CheckoutRef(checkoutId: "checkout-abc", serverId: "Serenity"),
+  ),
+  body: FitStorageBody(
+    shipTypeId: 12017,
+    characterId: "predefined_all_5",
+    damageProfile: FitDamageProfile(em: 0.25, explosive: 0.25, kinetic: 0.25, thermal: 0.25),
+    slots: FitStorageSlots(
+      high: IList.empty(),
+      medium: IList.empty(),
+      low: IList.empty(),
+      rig: IList.empty(),
+      subsystem: IList.empty(),
+      service: IList.empty(),
+      tacticalMode: None(),
+    ),
+    drones: IList.empty(),
+    fighters: IList.empty(),
+    implants: IList.empty(),
+    boosters: IList.empty(),
+  ),
+  dynamicRegistry: FitDynamicRegistry(dynamicItems: IMap.empty()),
+);
+
+Map<String, dynamic> _legacyV1FitJson() => <String, dynamic>{
+  "metadata": <String, dynamic>{
+    "fitId": "b7277b87-c880-4a5e-b474-7b59728d1f18",
+    "shipTypeId": 12017,
+    "name": "500推",
+    "lastModified": 1784685359885,
+    "description": "",
+    "bundleId": "tranquility",
+    "bundleSnapshot": <String, dynamic>{
+      "bundleId": "tranquility",
+      "manifestHash": "fe5818576d58985e7aff57997c1736239974253b8d7055ce1707be75312d2227",
+      "gameBuild": "3409592",
+      "appVersion": "0.1.0-beta.6+6",
+      "generateTimestamp": 1782620853,
+    },
+  },
+  "body": <String, dynamic>{
+    "shipTypeId": 12017,
+    "characterId": "predefined_all_5",
+    "damageProfile": <String, dynamic>{
+      "em": 0.25,
+      "explosive": 0.25,
+      "kinetic": 0.25,
+      "thermal": 0.25,
+    },
+    "slots": <String, dynamic>{
+      "high": <dynamic>[
+        <String, dynamic>{
+          "itemId": <String, dynamic>{"id": 4248, "runtimeType": "item"},
+          "state": "active",
+          "charge": null,
+        },
+        null,
+      ],
+      "medium": <dynamic>[],
+      "low": <dynamic>[],
+      "rig": <dynamic>[],
+      "subsystem": <dynamic>[null, null, null, null],
+      "service": <dynamic>[],
+      "tacticalMode": null,
+    },
+    "drones": <dynamic>[],
+    "fighters": <dynamic>[],
+    "implants": <dynamic>[],
+    "boosters": <dynamic>[],
+  },
+  "dynamicRegistry": <String, dynamic>{"dynamicItems": <String, dynamic>{}},
+};
+
+Map<String, dynamic> _roundTripJson(Map<String, dynamic> json) =>
+    jsonDecode(jsonEncode(json)) as Map<String, dynamic>;
+
+void main() {
+  group("encodeNativeFitPayload", () {
+    test("emits version 2 envelope wrapping the fit storage envelope", () {
+      final encoded = _roundTripJson(encodeNativeFitPayload(_makeFitStorage()));
+
+      expect(encoded["version"], 2);
+      final inner = encoded["fit"] as Map<String, dynamic>;
+      expect(inner["version"], 2);
+      expect(inner["fit"], isA<Map<String, dynamic>>());
+    });
+  });
+
+  group("decodeNativeFitPayload", () {
+    test("round-trips current v2 payloads without migration", () {
+      final fit = _makeFitStorage();
+      final decoded = decodeNativeFitPayload(_roundTripJson(encodeNativeFitPayload(fit)));
+
+      expect(decoded.didMigrate, isFalse);
+      expect(decoded.fit.metadata.fitId, "test-fit-1");
+      expect(decoded.fit.metadata.checkoutRef.checkoutId, "checkout-abc");
+      expect(decoded.fit.body.shipTypeId, 12017);
+    });
+
+    test("migrates legacy v1 payloads with object bundleSnapshot", () {
+      final payload = <String, dynamic>{"version": 1, "fit": _legacyV1FitJson()};
+
+      final decoded = decodeNativeFitPayload(_roundTripJson(payload));
+
+      expect(decoded.didMigrate, isTrue);
+      expect(decoded.fit.metadata.fitId, "b7277b87-c880-4a5e-b474-7b59728d1f18");
+      expect(decoded.fit.metadata.name, "500推");
+      expect(decoded.fit.metadata.checkoutRef.checkoutId, "");
+      expect(decoded.fit.metadata.checkoutRef.serverId, "");
+      expect(decoded.fit.body.shipTypeId, 12017);
+      expect(decoded.fit.body.slots.high.length, 2);
+      expect(decoded.fit.body.slots.subsystem.length, 4);
+    });
+
+    test("migrates legacy v1 payloads with string bundleSnapshot", () {
+      final fitJson = _legacyV1FitJson();
+      final metadata = fitJson["metadata"]! as Map<String, dynamic>;
+      metadata["bundleId"] = "Tranquility-21.06-3409592";
+      metadata["bundleSnapshot"] = "checkout-legacy";
+
+      final payload = <String, dynamic>{"version": 1, "fit": fitJson};
+      final decoded = decodeNativeFitPayload(_roundTripJson(payload));
+
+      expect(decoded.didMigrate, isTrue);
+      expect(decoded.fit.metadata.checkoutRef.checkoutId, "checkout-legacy");
+      expect(decoded.fit.metadata.checkoutRef.serverId, "Tranquility");
+    });
+
+    test("keeps existing checkoutRef when migrating legacy v1 payloads", () {
+      final fitJson = _legacyV1FitJson();
+      final metadata = fitJson["metadata"]! as Map<String, dynamic>;
+      metadata["checkoutRef"] = <String, dynamic>{
+        "checkoutId": "checkout-keep",
+        "serverId": "Serenity",
+      };
+
+      final payload = <String, dynamic>{"version": 1, "fit": fitJson};
+      final decoded = decodeNativeFitPayload(_roundTripJson(payload));
+
+      expect(decoded.fit.metadata.checkoutRef.checkoutId, "checkout-keep");
+    });
+
+    test("throws unsupportedVersion for newer payload versions", () {
+      final payload = <String, dynamic>{"version": 99, "fit": <String, dynamic>{}};
+
+      expect(
+        () => decodeNativeFitPayload(payload),
+        throwsA(
+          isA<FitPersistenceException>().having(
+            (error) => error.code,
+            "code",
+            FitPersistenceErrorCode.unsupportedVersion,
+          ),
+        ),
+      );
+    });
+
+    test("throws invalidPayloadShape when version is missing", () {
+      final payload = <String, dynamic>{"fit": _legacyV1FitJson()};
+
+      expect(
+        () => decodeNativeFitPayload(payload),
+        throwsA(
+          isA<FitPersistenceException>().having(
+            (error) => error.code,
+            "code",
+            FitPersistenceErrorCode.invalidPayloadShape,
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #241 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native FIT exports now use the version 2 payload format.
  * Legacy version 1 FIT payloads are automatically upgraded during import.
  * Added migration support for legacy FIT metadata and storage records.

* **Bug Fixes**
  * Improved validation and error handling for missing or unsupported payload versions.
  * Preserved existing checkout references during legacy data migration.
  * Added compatibility for legacy payloads with different snapshot formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->