### PR TITLE
refactor(storage): relocate app data from documents to application support

### DIFF
--- a/lib/config/paths.dart
+++ b/lib/config/paths.dart
@@ -10,18 +10,23 @@ class PathProvider {
   static late String? downloadsPath;
   static late String cachesPath;
 
-  static String get resourcesPath => p.join(documentsPath, "resources");
-  static String get settingsPath => p.join(documentsPath, "settings");
+  static String get resourcesPath => p.join(appSupportPath, "resources");
+  static String get settingsPath => p.join(appSupportPath, "settings");
 
   static String get oldFittingsPath => p.join(documentsPath, "fittings");
   static String get oldCharactersPath => p.join(documentsPath, "characters");
 
-  static String get runtimePath => p.join(documentsPath, "runtime", "v2");
+  static String get runtimePath => p.join(appSupportPath, "runtime", "v2");
   static String get fittingsPath => p.join(runtimePath, "fittings");
   static String get charactersPath => p.join(runtimePath, "characters");
 
-  static String get logsPath => p.join(documentsPath, "logs");
+  static String get logsPath => p.join(appSupportPath, "logs");
   static String get cacheResourcesPath => p.join(cachesPath, "resources");
+
+  static String get legacyResourcesPath => p.join(documentsPath, "resources");
+  static String get legacySettingsPath => p.join(documentsPath, "settings");
+  static String get legacyRuntimePath => p.join(documentsPath, "runtime");
+  static String get legacyLogsPath => p.join(documentsPath, "logs");
   static Future<void> init() async {
     documentsPath = (await getApplicationDocumentsDirectory()).path;
     tempPath = (await getTemporaryDirectory()).path;

--- a/lib/init.dart
+++ b/lib/init.dart
@@ -16,6 +16,7 @@ import "package:eve_fit_assistant/features/remote_content/cache_manager.dart";
 import "package:eve_fit_assistant/native/frb_generated.dart";
 import "package:eve_fit_assistant/storage/fit/manager.dart";
 import "package:eve_fit_assistant/storage/fit/service.dart";
+import "package:eve_fit_assistant/storage/path_migration.dart";
 import "package:eve_fit_assistant/storage/persistence/startup_repair.dart";
 import "package:eve_fit_assistant/storage/setting/setting.dart";
 import "package:flutter/material.dart";
@@ -40,6 +41,7 @@ Future<InitializedStores> initSingletons() async {
   WidgetsFlutterBinding.ensureInitialized();
   await RustLib.init();
   await PathProvider.init();
+  await const StoragePathMigrator().migrateIfNeeded();
   AppSettingService.init();
 
   final announcementStateStore = AnnouncementStateStore(settingsPath: PathProvider.settingsPath);

--- a/lib/storage/path_migration.dart
+++ b/lib/storage/path_migration.dart
@@ -51,7 +51,7 @@ class StoragePathMigrator {
 
   Future<void> _copyRecursively(Directory source, Directory target) async {
     await target.create(recursive: true);
-    await for (final entity in source.list()) {
+    await for (final entity in source.list(followLinks: false)) {
       final targetPath = p.join(target.path, p.basename(entity.path));
       if (entity is Directory) {
         await _copyRecursively(entity, Directory(targetPath));

--- a/lib/storage/path_migration.dart
+++ b/lib/storage/path_migration.dart
@@ -1,0 +1,73 @@
+import "dart:io";
+
+import "package:eve_fit_assistant/config/paths.dart";
+import "package:flutter/foundation.dart";
+import "package:path/path.dart" as p;
+
+typedef DirectoryRename = Future<Directory> Function(Directory dir, String newPath);
+
+class StoragePathMigrator {
+  const StoragePathMigrator({DirectoryRename? rename}) : _rename = rename ?? _defaultRename;
+
+  final DirectoryRename _rename;
+
+  static Future<Directory> _defaultRename(Directory dir, String newPath) => dir.rename(newPath);
+
+  static const _migratedDirs = ["settings", "resources", "runtime", "logs"];
+
+  Future<void> migrateIfNeeded() async {
+    for (final name in _migratedDirs) {
+      await _migrateDir(name);
+    }
+  }
+
+  Future<void> _migrateDir(String name) async {
+    final target = Directory(p.join(PathProvider.appSupportPath, name));
+    final legacy = Directory(p.join(PathProvider.documentsPath, name));
+    if (target.path == legacy.path || target.existsSync() || !legacy.existsSync()) return;
+
+    final staging = Directory(p.join(PathProvider.appSupportPath, ".$name.migrating"));
+    try {
+      await _deleteQuietly(staging);
+      await target.parent.create(recursive: true);
+
+      try {
+        await _rename(legacy, target.path);
+        debugPrint("StoragePathMigrator: moved '$name' to application support");
+        return;
+      } on FileSystemException {
+        debugPrint("StoragePathMigrator: rename of '$name' failed, falling back to copy");
+      }
+
+      await _copyRecursively(legacy, staging);
+      await staging.rename(target.path);
+      await _deleteQuietly(legacy);
+      debugPrint("StoragePathMigrator: copied '$name' to application support");
+    } on FileSystemException catch (e) {
+      debugPrint("StoragePathMigrator: failed to migrate '$name': $e");
+      await _deleteQuietly(staging);
+    }
+  }
+
+  Future<void> _copyRecursively(Directory source, Directory target) async {
+    await target.create(recursive: true);
+    await for (final entity in source.list()) {
+      final targetPath = p.join(target.path, p.basename(entity.path));
+      if (entity is Directory) {
+        await _copyRecursively(entity, Directory(targetPath));
+      } else if (entity is File) {
+        await entity.copy(targetPath);
+      } else if (entity is Link) {
+        await Link(targetPath).create(await entity.target());
+      }
+    }
+  }
+
+  Future<void> _deleteQuietly(Directory dir) async {
+    try {
+      if (dir.existsSync()) await dir.delete(recursive: true);
+    } on FileSystemException {
+      // Best-effort cleanup; leftovers are retried on the next launch.
+    }
+  }
+}

--- a/lib/storage/setting/reset_service.dart
+++ b/lib/storage/setting/reset_service.dart
@@ -27,6 +27,10 @@ class ResetStorageService {
       // Legacy paths, cleaned up if present.
       PathProvider.oldFittingsPath,
       PathProvider.oldCharactersPath,
+      PathProvider.legacySettingsPath,
+      PathProvider.legacyResourcesPath,
+      PathProvider.legacyRuntimePath,
+      PathProvider.legacyLogsPath,
     ];
 
     for (final path in dirs) {

--- a/test/features/schema_guard/migration_gate_test.dart
+++ b/test/features/schema_guard/migration_gate_test.dart
@@ -87,6 +87,7 @@ void main() {
     setUp(() {
       tempDir = Directory.systemTemp.createTempSync("efa_mig_gate_test_").path;
       PathProvider.documentsPath = tempDir;
+      PathProvider.appSupportPath = tempDir;
     });
 
     tearDown(() {

--- a/test/features/schema_guard/migration_gate_test.dart
+++ b/test/features/schema_guard/migration_gate_test.dart
@@ -82,17 +82,21 @@ void main() {
   });
 
   group("MigrationGate fast-path", () {
-    late String tempDir;
+    late String legacyDir;
+    late String appSupportDir;
 
     setUp(() {
-      tempDir = Directory.systemTemp.createTempSync("efa_mig_gate_test_").path;
-      PathProvider.documentsPath = tempDir;
-      PathProvider.appSupportPath = tempDir;
+      legacyDir = Directory.systemTemp.createTempSync("efa_mig_gate_legacy_").path;
+      appSupportDir = Directory.systemTemp.createTempSync("efa_mig_gate_support_").path;
+      PathProvider.documentsPath = legacyDir;
+      PathProvider.appSupportPath = appSupportDir;
     });
 
     tearDown(() {
-      final dir = Directory(tempDir);
-      if (dir.existsSync()) dir.deleteSync(recursive: true);
+      for (final path in [legacyDir, appSupportDir]) {
+        final dir = Directory(path);
+        if (dir.existsSync()) dir.deleteSync(recursive: true);
+      }
     });
 
     testWidgets("skips scan and calls onMigrationComplete when schema_version.json exists", (
@@ -125,7 +129,7 @@ void main() {
     });
 
     testWidgets("shows migration prompt when legacy fits exist", (tester) async {
-      _writeLegacyFits(tempDir);
+      _writeLegacyFits(legacyDir);
       var completed = false;
 
       await tester.pumpWidget(
@@ -142,7 +146,7 @@ void main() {
     });
 
     testWidgets("shows migration prompt when legacy characters exist", (tester) async {
-      _writeLegacyCharacters(tempDir);
+      _writeLegacyCharacters(legacyDir);
       var completed = false;
 
       await tester.pumpWidget(
@@ -158,7 +162,7 @@ void main() {
 
     testWidgets("fast-path overrides legacy data detection — schema_version wins", (tester) async {
       _ensureSchemaVersion();
-      _writeLegacyFits(tempDir);
+      _writeLegacyFits(legacyDir);
       var completed = false;
 
       await tester.pumpWidget(

--- a/test/pages/setting/data/checkout_management_test.dart
+++ b/test/pages/setting/data/checkout_management_test.dart
@@ -64,6 +64,7 @@ void main() {
     registerFallbackValue("");
     tempDir = Directory.systemTemp.createTempSync("efa_checkout_mgmt_test_");
     PathProvider.documentsPath = tempDir.path;
+    PathProvider.appSupportPath = tempDir.path;
 
     mockAssetStore = MockAssetStore();
     when(() => mockAssetStore.readResourceIndexSync(any())).thenReturn(const None());

--- a/test/storage/fit/compatibility_test.dart
+++ b/test/storage/fit/compatibility_test.dart
@@ -62,6 +62,7 @@ void main() {
   setUp(() {
     _tempDir = Directory.systemTemp.createTempSync("efa_compat_test_").path;
     PathProvider.documentsPath = _tempDir;
+    PathProvider.appSupportPath = _tempDir;
   });
 
   tearDown(() {

--- a/test/storage/fit/manager_test.dart
+++ b/test/storage/fit/manager_test.dart
@@ -84,6 +84,7 @@ void main() {
   setUp(() {
     _tempDir = Directory.systemTemp.createTempSync("efa_mgr_test_").path;
     PathProvider.documentsPath = _tempDir;
+    PathProvider.appSupportPath = _tempDir;
   });
 
   tearDown(() {

--- a/test/storage/fit/native_fit_engine_service_test.dart
+++ b/test/storage/fit/native_fit_engine_service_test.dart
@@ -180,6 +180,7 @@ void main() {
   setUp(() {
     _tempDir = Directory.systemTemp.createTempSync("efa_engine_test_").path;
     PathProvider.documentsPath = _tempDir;
+    PathProvider.appSupportPath = _tempDir;
     _snapshotHash = _writeTestResourceSnapshot();
   });
 

--- a/test/storage/path_migration_test.dart
+++ b/test/storage/path_migration_test.dart
@@ -1,0 +1,196 @@
+import "dart:io";
+
+import "package:eve_fit_assistant/config/paths.dart";
+import "package:eve_fit_assistant/storage/path_migration.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:path/path.dart" as p;
+
+void main() {
+  late Directory tempRoot;
+  late String documentsDir;
+  late String supportDir;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp("efa_path_migration_test_");
+    documentsDir = p.join(tempRoot.path, "documents");
+    supportDir = p.join(tempRoot.path, "support");
+    await Directory(documentsDir).create(recursive: true);
+    await Directory(supportDir).create(recursive: true);
+    PathProvider.documentsPath = documentsDir;
+    PathProvider.appSupportPath = supportDir;
+  });
+
+  tearDown(() async {
+    if (tempRoot.existsSync()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  Future<File> createLegacyFile(String dirName, String relativePath, String content) async {
+    final file = File(p.join(documentsDir, dirName, relativePath));
+    await file.parent.create(recursive: true);
+    await file.writeAsString(content);
+    return file;
+  }
+
+  group("fresh install", () {
+    test("is a no-op when no legacy directories exist", () async {
+      await const StoragePathMigrator().migrateIfNeeded();
+
+      for (final name in ["settings", "resources", "runtime", "logs"]) {
+        expect(Directory(p.join(supportDir, name)).existsSync(), isFalse, reason: name);
+      }
+    });
+
+    test("is a no-op when documents and support resolve to the same root", () async {
+      PathProvider.appSupportPath = documentsDir;
+      await createLegacyFile("settings", "settings.json", "{}");
+
+      await const StoragePathMigrator().migrateIfNeeded();
+
+      expect(File(p.join(documentsDir, "settings", "settings.json")).existsSync(), isTrue);
+    });
+  });
+
+  group("migration", () {
+    test("moves all legacy directories with contents intact", () async {
+      await createLegacyFile("settings", "settings.json", "settings-content");
+      await createLegacyFile("resources", "v2/schema_version.json", "schema-content");
+      await createLegacyFile("resources", "v2/assets/blobs/ab/hash", "blob-content");
+      await createLegacyFile("runtime", "v2/fittings/fit.json", "fit-content");
+      await createLegacyFile("runtime", "v2/characters/char.json", "char-content");
+      await createLegacyFile("logs", "app.log", "log-content");
+
+      await const StoragePathMigrator().migrateIfNeeded();
+
+      final expected = <String, String>{
+        p.join(supportDir, "settings", "settings.json"): "settings-content",
+        p.join(supportDir, "resources", "v2", "schema_version.json"): "schema-content",
+        p.join(supportDir, "resources", "v2", "assets", "blobs", "ab", "hash"): "blob-content",
+        p.join(supportDir, "runtime", "v2", "fittings", "fit.json"): "fit-content",
+        p.join(supportDir, "runtime", "v2", "characters", "char.json"): "char-content",
+        p.join(supportDir, "logs", "app.log"): "log-content",
+      };
+      for (final entry in expected.entries) {
+        final file = File(entry.key);
+        expect(file.existsSync(), isTrue, reason: entry.key);
+        expect(await file.readAsString(), entry.value, reason: entry.key);
+      }
+
+      for (final name in ["settings", "resources", "runtime", "logs"]) {
+        expect(
+          Directory(p.join(documentsDir, name)).existsSync(),
+          isFalse,
+          reason: "legacy $name should be removed",
+        );
+      }
+    });
+
+    test("migrates only the directories that exist", () async {
+      await createLegacyFile("settings", "settings.json", "settings-content");
+
+      await const StoragePathMigrator().migrateIfNeeded();
+
+      expect(File(p.join(supportDir, "settings", "settings.json")).existsSync(), isTrue);
+      expect(Directory(p.join(supportDir, "resources")).existsSync(), isFalse);
+      expect(Directory(p.join(supportDir, "runtime")).existsSync(), isFalse);
+      expect(Directory(p.join(supportDir, "logs")).existsSync(), isFalse);
+    });
+
+    test("skips directories that already exist at the target", () async {
+      await createLegacyFile("settings", "settings.json", "legacy-content");
+      final existing = File(p.join(supportDir, "settings", "settings.json"));
+      await existing.parent.create(recursive: true);
+      await existing.writeAsString("current-content");
+
+      await const StoragePathMigrator().migrateIfNeeded();
+
+      expect(await existing.readAsString(), "current-content");
+      expect(
+        File(p.join(documentsDir, "settings", "settings.json")).existsSync(),
+        isTrue,
+        reason: "legacy copy is preserved when the target already exists",
+      );
+    });
+
+    test("is idempotent across runs", () async {
+      await createLegacyFile("settings", "settings.json", "settings-content");
+
+      await const StoragePathMigrator().migrateIfNeeded();
+      await const StoragePathMigrator().migrateIfNeeded();
+
+      expect(
+        await File(p.join(supportDir, "settings", "settings.json")).readAsString(),
+        "settings-content",
+      );
+    });
+
+    test("cleans up a stale staging directory from a crashed run", () async {
+      await createLegacyFile("settings", "settings.json", "settings-content");
+      final staleFile = File(p.join(supportDir, ".settings.migrating", "partial.json"));
+      await staleFile.parent.create(recursive: true);
+      await staleFile.writeAsString("partial");
+
+      await const StoragePathMigrator().migrateIfNeeded();
+
+      expect(
+        await File(p.join(supportDir, "settings", "settings.json")).readAsString(),
+        "settings-content",
+      );
+      expect(File(p.join(supportDir, "settings", "partial.json")).existsSync(), isFalse);
+      expect(Directory(p.join(supportDir, ".settings.migrating")).existsSync(), isFalse);
+    });
+  });
+
+  group("copy fallback", () {
+    Future<Directory> failingRename(Directory dir, String newPath) =>
+        throw const FileSystemException("cross-device link");
+
+    test("copies via staging when rename fails", () async {
+      await createLegacyFile("resources", "v2/assets/blobs/ab/hash", "blob-content");
+      await createLegacyFile("resources", "v2/schema_version.json", "schema-content");
+
+      await StoragePathMigrator(rename: failingRename).migrateIfNeeded();
+
+      expect(
+        await File(
+          p.join(supportDir, "resources", "v2", "assets", "blobs", "ab", "hash"),
+        ).readAsString(),
+        "blob-content",
+      );
+      expect(
+        await File(p.join(supportDir, "resources", "v2", "schema_version.json")).readAsString(),
+        "schema-content",
+      );
+      expect(Directory(p.join(documentsDir, "resources")).existsSync(), isFalse);
+      expect(Directory(p.join(supportDir, ".resources.migrating")).existsSync(), isFalse);
+    });
+
+    test("uses rename for directories before the failure point and copy after", () async {
+      await createLegacyFile("settings", "settings.json", "settings-content");
+      await createLegacyFile("resources", "v2/schema_version.json", "schema-content");
+
+      await StoragePathMigrator(rename: failingRename).migrateIfNeeded();
+
+      expect(File(p.join(supportDir, "settings", "settings.json")).existsSync(), isTrue);
+      expect(
+        File(p.join(supportDir, "resources", "v2", "schema_version.json")).existsSync(),
+        isTrue,
+      );
+    });
+
+    test("keeps legacy data when the copy fallback also fails", () async {
+      await createLegacyFile("settings", "settings.json", "settings-content");
+      await Directory(supportDir).delete(recursive: true);
+      final blockingFile = File(supportDir);
+      await blockingFile.writeAsString("not a directory");
+
+      await StoragePathMigrator(rename: failingRename).migrateIfNeeded();
+
+      expect(
+        await File(p.join(documentsDir, "settings", "settings.json")).readAsString(),
+        "settings-content",
+      );
+    });
+  });
+}

--- a/test/storage/path_migration_test.dart
+++ b/test/storage/path_migration_test.dart
@@ -166,6 +166,26 @@ void main() {
       expect(Directory(p.join(supportDir, ".resources.migrating")).existsSync(), isFalse);
     });
 
+    test("preserves directory symlinks instead of traversing them", () async {
+      await createLegacyFile("resources", "v2/schema_version.json", "schema-content");
+      final external = Directory(p.join(tempRoot.path, "external_blobs"));
+      await external.create();
+      await File(p.join(external.path, "hash")).writeAsString("blob-content");
+      final linked = Link(p.join(documentsDir, "resources", "v2", "blobs"));
+      await linked.parent.create(recursive: true);
+      await linked.create(external.path);
+
+      await StoragePathMigrator(rename: failingRename).migrateIfNeeded();
+
+      final migratedLink = Link(p.join(supportDir, "resources", "v2", "blobs"));
+      expect(
+        FileSystemEntity.typeSync(migratedLink.path, followLinks: false),
+        FileSystemEntityType.link,
+      );
+      expect(await migratedLink.target(), external.path);
+      expect(Directory(p.join(documentsDir, "resources")).existsSync(), isFalse);
+    });
+
     test("uses rename for directories before the failure point and copy after", () async {
       await createLegacyFile("settings", "settings.json", "settings-content");
       await createLegacyFile("resources", "v2/schema_version.json", "schema-content");

--- a/test/storage/repo/assets_recover_test.dart
+++ b/test/storage/repo/assets_recover_test.dart
@@ -21,6 +21,7 @@ void main() {
   setUp(() {
     fs = MemoryFileSystem();
     PathProvider.documentsPath = "/";
+    PathProvider.appSupportPath = "/";
   });
 
   test("recoverSync deletes orphaned .tmp files but keeps real blobs", () {

--- a/test/storage/repo/channel_service_test.dart
+++ b/test/storage/repo/channel_service_test.dart
@@ -73,6 +73,7 @@ void main() {
   setUp(() {
     tempDir = Directory.systemTemp.createTempSync("efa_channel_service_test_").path;
     PathProvider.documentsPath = tempDir;
+    PathProvider.appSupportPath = tempDir;
     assetStore = const AssetStore();
   });
 

--- a/test/storage/repo/checkout_provisioner_test.dart
+++ b/test/storage/repo/checkout_provisioner_test.dart
@@ -209,6 +209,7 @@ void main() {
     // dir so the Code doesn't crash even though no files are actually read.
     tempDir = Directory.systemTemp.createTempSync("efa_provisioner_test_").path;
     PathProvider.documentsPath = tempDir;
+    PathProvider.appSupportPath = tempDir;
 
     mockRemoteCatalog = MockRemoteCatalogService();
     fakeAssetStore = _FakeAssetStore();

--- a/test/storage/repo/checkout_service_test.dart
+++ b/test/storage/repo/checkout_service_test.dart
@@ -116,6 +116,7 @@ void main() {
   setUp(() {
     tempDir = Directory.systemTemp.createTempSync("efa_checkout_service_test_").path;
     PathProvider.documentsPath = tempDir;
+    PathProvider.appSupportPath = tempDir;
     PathProvider.cachesPath = tempDir;
     assetStore = const AssetStore();
     checkoutRegistry = CheckoutRegistryService();

--- a/test/storage/repo/migration/migrate_service_test.dart
+++ b/test/storage/repo/migration/migrate_service_test.dart
@@ -75,28 +75,34 @@ void main() {
   });
 
   group("MigrateService", () {
-    late String tempDir;
+    late String legacyDir;
+    late String appSupportDir;
 
     setUp(() async {
-      tempDir = Directory.systemTemp.createTempSync("efa_mig_service_test_").path;
-      PathProvider.documentsPath = tempDir;
-      PathProvider.appSupportPath = tempDir;
+      legacyDir = Directory.systemTemp.createTempSync("efa_mig_service_legacy_").path;
+      appSupportDir = Directory.systemTemp.createTempSync("efa_mig_service_support_").path;
+      PathProvider.documentsPath = legacyDir;
+      PathProvider.appSupportPath = appSupportDir;
       // Clean up any stale checkpoint from prior runs.
-      final checkpoint = File(p.join(tempDir, "resources", "v2", ".migration_progress.json"));
+      final checkpoint = File(p.join(RepoPaths.schemaResourcesPath, ".migration_progress.json"));
       if (checkpoint.existsSync()) checkpoint.deleteSync();
-      final schemaFile = File(p.join(tempDir, "resources", "v2", "schema_version.json"));
+      final schemaFile = File(RepoPaths.schemaVersionPath);
       if (schemaFile.existsSync()) schemaFile.deleteSync();
     });
 
     tearDown(() {
-      final dir = Directory(tempDir);
-      if (dir.existsSync()) dir.deleteSync(recursive: true);
+      for (final path in [legacyDir, appSupportDir]) {
+        final dir = Directory(path);
+        if (dir.existsSync()) dir.deleteSync(recursive: true);
+      }
     });
 
     test("fresh migration — migrates files to runtime/v2/, deletes old dirs", () async {
       // Create legacy data in old paths
       final oldFittingsPath = PathProvider.oldFittingsPath;
       final oldCharactersPath = PathProvider.oldCharactersPath;
+      expect(oldFittingsPath, startsWith(legacyDir));
+      expect(oldCharactersPath, startsWith(legacyDir));
       Directory(oldFittingsPath).createSync(recursive: true);
       Directory(oldCharactersPath).createSync(recursive: true);
 
@@ -122,6 +128,8 @@ void main() {
       // Files written to new runtime/v2/ paths
       final newFittingsPath = PathProvider.fittingsPath;
       final newCharactersPath = PathProvider.charactersPath;
+      expect(newFittingsPath, startsWith(appSupportDir));
+      expect(newCharactersPath, startsWith(appSupportDir));
       expect(File(p.join(newFittingsPath, "fit-1.json")).existsSync(), isTrue);
       expect(File(p.join(newCharactersPath, "char-1.json")).existsSync(), isTrue);
 
@@ -130,7 +138,7 @@ void main() {
       expect(Directory(oldCharactersPath).existsSync(), isFalse);
 
       // Schema version written
-      final schemaFile = File(p.join(tempDir, "resources", "v2", "schema_version.json"));
+      final schemaFile = File(RepoPaths.schemaVersionPath);
       expect(schemaFile.existsSync(), isTrue);
     });
 
@@ -244,7 +252,7 @@ void main() {
       expect(progress.fitsResult!.migrated, 1);
       expect(progress.charactersResult!.migrated, 2);
 
-      final schemaFile = File(p.join(tempDir, "resources", "v2", "schema_version.json"));
+      final schemaFile = File(RepoPaths.schemaVersionPath);
       expect(schemaFile.existsSync(), isTrue);
     });
 

--- a/test/storage/repo/migration/migrate_service_test.dart
+++ b/test/storage/repo/migration/migrate_service_test.dart
@@ -80,6 +80,7 @@ void main() {
     setUp(() async {
       tempDir = Directory.systemTemp.createTempSync("efa_mig_service_test_").path;
       PathProvider.documentsPath = tempDir;
+      PathProvider.appSupportPath = tempDir;
       // Clean up any stale checkpoint from prior runs.
       final checkpoint = File(p.join(tempDir, "resources", "v2", ".migration_progress.json"));
       if (checkpoint.existsSync()) checkpoint.deleteSync();

--- a/test/storage/repo/migration/progress_test.dart
+++ b/test/storage/repo/migration/progress_test.dart
@@ -1,4 +1,3 @@
-import "dart:convert";
 import "dart:io";
 
 import "package:eve_fit_assistant/config/paths.dart";
@@ -114,17 +113,21 @@ void main() {
   });
 
   group("MigrateProgressStore", () {
-    late String tempDir;
+    late String documentsDir;
+    late String appSupportDir;
 
     setUp(() {
-      tempDir = Directory.systemTemp.createTempSync("efa_mig_progress_test_").path;
-      PathProvider.documentsPath = tempDir;
-      PathProvider.appSupportPath = tempDir;
+      documentsDir = Directory.systemTemp.createTempSync("efa_mig_progress_docs_").path;
+      appSupportDir = Directory.systemTemp.createTempSync("efa_mig_progress_support_").path;
+      PathProvider.documentsPath = documentsDir;
+      PathProvider.appSupportPath = appSupportDir;
     });
 
     tearDown(() {
-      final dir = Directory(tempDir);
-      if (dir.existsSync()) dir.deleteSync(recursive: true);
+      for (final path in [documentsDir, appSupportDir]) {
+        final dir = Directory(path);
+        if (dir.existsSync()) dir.deleteSync(recursive: true);
+      }
     });
 
     test("load returns default when checkpoint file does not exist", () async {
@@ -174,7 +177,7 @@ void main() {
 
     test("load returns default on corrupt JSON without throwing", () async {
       const store = MigrateProgressStore();
-      final v2Dir = p.join(PathProvider.documentsPath, "resources", "v2");
+      final v2Dir = RepoPaths.schemaResourcesPath;
       Directory(v2Dir).createSync(recursive: true);
       final checkpointFile = File(p.join(v2Dir, ".migration_progress.json"));
       checkpointFile.writeAsStringSync("not valid json");
@@ -186,7 +189,8 @@ void main() {
 
     test("save creates parent directories", () async {
       const store = MigrateProgressStore();
-      final v2Dir = p.join(PathProvider.documentsPath, "resources", "v2");
+      final v2Dir = RepoPaths.schemaResourcesPath;
+      expect(v2Dir, startsWith(appSupportDir));
       expect(Directory(v2Dir).existsSync(), isFalse);
 
       const progress = MigrateProgress();
@@ -194,13 +198,14 @@ void main() {
 
       expect(Directory(v2Dir).existsSync(), isTrue);
       expect(File(p.join(v2Dir, ".migration_progress.json")).existsSync(), isTrue);
+      expect(Directory(p.join(documentsDir, "resources")).existsSync(), isFalse);
     });
 
     test("atomic write does not leave tmp file", () async {
       const store = MigrateProgressStore();
       await store.save(const MigrateProgress());
 
-      final v2Dir = p.join(PathProvider.documentsPath, "resources", "v2");
+      final v2Dir = RepoPaths.schemaResourcesPath;
       final tmpFile = File(p.join(v2Dir, ".migration_progress.json.tmp"));
       expect(tmpFile.existsSync(), isFalse);
 
@@ -223,7 +228,7 @@ void main() {
 
     test("startedAt timestamp is set on fresh load", () async {
       const store = MigrateProgressStore();
-      final v2Dir = p.join(PathProvider.documentsPath, "resources", "v2");
+      final v2Dir = RepoPaths.schemaResourcesPath;
       final checkpointFile = File(p.join(v2Dir, ".migration_progress.json"));
       if (checkpointFile.existsSync()) checkpointFile.deleteSync();
 

--- a/test/storage/repo/migration/progress_test.dart
+++ b/test/storage/repo/migration/progress_test.dart
@@ -119,6 +119,7 @@ void main() {
     setUp(() {
       tempDir = Directory.systemTemp.createTempSync("efa_mig_progress_test_").path;
       PathProvider.documentsPath = tempDir;
+      PathProvider.appSupportPath = tempDir;
     });
 
     tearDown(() {

--- a/test/storage/repo/schema_version_service_test.dart
+++ b/test/storage/repo/schema_version_service_test.dart
@@ -20,6 +20,7 @@ void main() {
   setUp(() {
     tempDir = Directory.systemTemp.createTempSync("efa_schema_version_test_").path;
     PathProvider.documentsPath = tempDir;
+    PathProvider.appSupportPath = tempDir;
     service = const SchemaVersionService();
   });
 

--- a/test/storage/repo/verification_test.dart
+++ b/test/storage/repo/verification_test.dart
@@ -40,6 +40,7 @@ void main() {
   setUp(() {
     tempDir = Directory.systemTemp.createTempSync("efa_verification_test_").path;
     PathProvider.documentsPath = tempDir;
+    PathProvider.appSupportPath = tempDir;
     checkoutId = "test-checkout-001";
   });
 

--- a/test/storage/setting/reset_service_test.dart
+++ b/test/storage/setting/reset_service_test.dart
@@ -36,6 +36,10 @@ void main() {
       p.join(PathProvider.tempPath, "efa", "native", "foo"),
       p.join(PathProvider.oldFittingsPath, "fit.json"),
       p.join(PathProvider.oldCharactersPath, "char.json"),
+      p.join(PathProvider.legacySettingsPath, "settings.json"),
+      p.join(PathProvider.legacyResourcesPath, "v2", "schema_version.json"),
+      p.join(PathProvider.legacyRuntimePath, "v2", "fittings", "fit.json"),
+      p.join(PathProvider.legacyLogsPath, "app.log"),
     ];
 
     for (final filePath in files) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - App data, settings, runtime files, resources, and logs now use the application support location.
  - Existing data is automatically migrated from the previous storage location on startup.
  - Migration preserves legacy data when conflicts or filesystem errors occur.

- **Bug Fixes**
  - Resetting storage now also removes data from legacy storage locations.

- **Tests**
  - Added/expanded migration and storage recovery coverage, including conflict handling, retries, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->