### PR TITLE
fix(repo): rebuild stale native dir after storage relocation

### DIFF
--- a/lib/storage/repo/native_dir.dart
+++ b/lib/storage/repo/native_dir.dart
@@ -21,6 +21,10 @@ class NativeDirResolver {
 
   final AssetStore assetStore;
 
+  /// Name of the marker file recording the blob root the native directory was
+  /// materialized against. Stored inside each native directory.
+  static const _markerFileName = ".efa_blob_root";
+
   /// Computes the expected native directory path for [snapshotHash]
   /// without I/O.
   ///
@@ -31,11 +35,19 @@ class NativeDirResolver {
 
   /// Creates a temporary native directory populated with all files referenced by
   /// [resourceIndex], and returns the root path of the native directory.
+  ///
+  /// A native directory is only reused when its marker file matches the current
+  /// blob root. Directories materialized before a storage relocation (e.g. the
+  /// documents → application support migration) contain absolute symlinks into
+  /// the old blob root and are rebuilt instead.
   Future<String> prepareNativeDir(String snapshotHash, ResourceIndex resourceIndex) async {
     final nativeRoot = resolvePathFromSnapshot(snapshotHash);
     final dir = Directory(nativeRoot);
 
-    if (dir.existsSync()) return nativeRoot;
+    if (dir.existsSync()) {
+      if (!_isStale(nativeRoot)) return nativeRoot;
+      dir.deleteSync(recursive: true);
+    }
 
     dir.createSync(recursive: true);
 
@@ -60,10 +72,23 @@ class NativeDirResolver {
         _linkOrCopy(blobPath, targetPath);
       }
 
+      File(p.join(nativeRoot, _markerFileName)).writeAsStringSync(RepoPaths.assetsPath);
       return nativeRoot;
     } on FileSystemException {
       dir.deleteSync(recursive: true);
       rethrow;
+    }
+  }
+
+  /// Returns `true` when the native directory at [nativeRoot] was materialized
+  /// against a different blob root than the current one (or has no marker,
+  /// e.g. it predates the marker mechanism).
+  static bool _isStale(String nativeRoot) {
+    final marker = File(p.join(nativeRoot, _markerFileName));
+    try {
+      return marker.readAsStringSync() != RepoPaths.assetsPath;
+    } on FileSystemException {
+      return true;
     }
   }
 

--- a/lib/storage/repo/native_dir.dart
+++ b/lib/storage/repo/native_dir.dart
@@ -21,9 +21,13 @@ class NativeDirResolver {
 
   final AssetStore assetStore;
 
-  /// Name of the marker file recording the blob root the native directory was
-  /// materialized against. Stored inside each native directory.
-  static const _markerFileName = ".efa_blob_root";
+  /// Suffix of the marker file recording the blob root a native directory was
+  /// materialized against. The marker is stored as a sibling of the native
+  /// directory (`<nativeRoot>.efa_blob_root`), never inside the materialized
+  /// tree, so it cannot collide with a resource index entry.
+  static const _markerFileSuffix = "efa_blob_root";
+
+  static String _markerPath(String nativeRoot) => "$nativeRoot.$_markerFileSuffix";
 
   /// Computes the expected native directory path for [snapshotHash]
   /// without I/O.
@@ -72,7 +76,7 @@ class NativeDirResolver {
         _linkOrCopy(blobPath, targetPath);
       }
 
-      File(p.join(nativeRoot, _markerFileName)).writeAsStringSync(RepoPaths.assetsPath);
+      File(_markerPath(nativeRoot)).writeAsStringSync(RepoPaths.assetsPath);
       return nativeRoot;
     } on FileSystemException {
       dir.deleteSync(recursive: true);
@@ -84,7 +88,7 @@ class NativeDirResolver {
   /// against a different blob root than the current one (or has no marker,
   /// e.g. it predates the marker mechanism).
   static bool _isStale(String nativeRoot) {
-    final marker = File(p.join(nativeRoot, _markerFileName));
+    final marker = File(_markerPath(nativeRoot));
     try {
       return marker.readAsStringSync() != RepoPaths.assetsPath;
     } on FileSystemException {
@@ -135,7 +139,8 @@ class NativeDirResolver {
     }
   }
 
-  /// Removes native directories for snapshots not in [activeSnapshotHashes].
+  /// Removes native directories for snapshots not in [activeSnapshotHashes],
+  /// along with their marker files.
   void cleanup(Iterable<String> activeSnapshotHashes) {
     final nativeBase = p.join(PathProvider.tempPath, "efa", "native");
     final baseDir = Directory(nativeBase);
@@ -143,16 +148,21 @@ class NativeDirResolver {
 
     final activeSet = activeSnapshotHashes.toSet();
 
-    for (final entity in baseDir.listSync().whereType<Directory>()) {
-      if (!activeSet.contains(p.basename(entity.path))) {
-        try {
-          entity.deleteSync(recursive: true);
-        } on FileSystemException catch (e, stackTrace) {
-          warning(
-            "Failed to remove stale native directory: ${entity.path}",
-            stackTrace: stackTrace,
-          );
-        }
+    for (final entity in baseDir.listSync()) {
+      final name = p.basename(entity.path);
+      final isOrphan =
+          entity is Directory && !activeSet.contains(name) ||
+          entity is File &&
+              name.endsWith(".$_markerFileSuffix") &&
+              !activeSet.contains(name.substring(0, name.length - _markerFileSuffix.length - 1));
+      if (!isOrphan) continue;
+      try {
+        entity.deleteSync(recursive: true);
+      } on FileSystemException catch (e, stackTrace) {
+        warning(
+          "Failed to remove stale native directory artifact: ${entity.path}",
+          stackTrace: stackTrace,
+        );
       }
     }
   }

--- a/test/storage/repo/native_dir_test.dart
+++ b/test/storage/repo/native_dir_test.dart
@@ -104,6 +104,8 @@ void main() {
   test("rebuilds when the blob root moved (documents -> support migration)", () async {
     final index = writeIconBlob();
     final nativeRoot = await resolver.prepareNativeDir("snapshot_a", index);
+    final sentinel = File(p.join(nativeRoot, "sentinel"));
+    await sentinel.writeAsString("stale");
 
     // Simulate StoragePathMigrator: resources are renamed to the new root.
     await Directory(
@@ -111,15 +113,10 @@ void main() {
     ).rename(p.join(newStorageRoot, "resources"));
     PathProvider.appSupportPath = newStorageRoot;
 
-    expect(
-      File(iconPath(nativeRoot)).existsSync(),
-      isFalse,
-      reason: "precondition: migration leaves dangling symlinks behind",
-    );
-
     final rebuilt = await resolver.prepareNativeDir("snapshot_a", index);
 
     expect(rebuilt, nativeRoot);
+    expect(sentinel.existsSync(), isFalse, reason: "stale native dir must be rebuilt recursively");
     expect(await File(iconPath(rebuilt)).readAsBytes(), iconContent);
     expect(File(markerPath(rebuilt)).readAsStringSync(), RepoPaths.assetsPath);
   });
@@ -127,15 +124,15 @@ void main() {
   test("rebuilds when the marker is missing (install predating the fix)", () async {
     final index = writeIconBlob();
     final nativeRoot = await resolver.prepareNativeDir("snapshot_a", index);
+    final sentinel = File(p.join(nativeRoot, "sentinel"));
+    await sentinel.writeAsString("stale");
 
-    await Directory(
-      p.join(oldStorageRoot, "resources"),
-    ).rename(p.join(newStorageRoot, "resources"));
-    PathProvider.appSupportPath = newStorageRoot;
     await File(markerPath(nativeRoot)).delete();
 
     final rebuilt = await resolver.prepareNativeDir("snapshot_a", index);
 
+    expect(rebuilt, nativeRoot);
+    expect(sentinel.existsSync(), isFalse, reason: "unmarked native dir must be rebuilt");
     expect(await File(iconPath(rebuilt)).readAsBytes(), iconContent);
   });
 

--- a/test/storage/repo/native_dir_test.dart
+++ b/test/storage/repo/native_dir_test.dart
@@ -1,0 +1,106 @@
+import "dart:io";
+import "dart:typed_data";
+
+import "package:eve_fit_assistant/config/paths.dart";
+import "package:eve_fit_assistant/data/proto/resource_index.pb.dart";
+import "package:eve_fit_assistant/storage/repo/assets.dart";
+import "package:eve_fit_assistant/storage/repo/hash.dart";
+import "package:eve_fit_assistant/storage/repo/native_dir.dart";
+import "package:eve_fit_assistant/storage/repo/paths.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:path/path.dart" as p;
+
+void main() {
+  const iconIdent = "resource://static/images/icons/123.png";
+  final iconContent = Uint8List.fromList(List.generate(16, (i) => i));
+
+  late Directory tempRoot;
+  late String oldStorageRoot;
+  late String newStorageRoot;
+  late NativeDirResolver resolver;
+
+  ResourceIndex writeIconBlob() {
+    final written = const AssetStore().writeBlobSync(RepoHash.hashIdent(iconIdent), iconContent);
+    return ResourceIndex(
+      entries: [ResourceIndex_Entry(resourceId: iconIdent, contentHash: written.contentHash)],
+    );
+  }
+
+  String iconPath(String nativeRoot) => p.join(nativeRoot, "static", "images", "icons", "123.png");
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp("efa_native_dir_test_");
+    oldStorageRoot = p.join(tempRoot.path, "documents");
+    newStorageRoot = p.join(tempRoot.path, "support");
+    await Directory(oldStorageRoot).create(recursive: true);
+    await Directory(newStorageRoot).create(recursive: true);
+    PathProvider.appSupportPath = oldStorageRoot;
+    PathProvider.tempPath = p.join(tempRoot.path, "temp");
+    resolver = const NativeDirResolver(assetStore: AssetStore());
+  });
+
+  tearDown(() async {
+    if (tempRoot.existsSync()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  test("materializes entries and records the blob root marker", () async {
+    final index = writeIconBlob();
+
+    final nativeRoot = await resolver.prepareNativeDir("snapshot_a", index);
+
+    expect(await File(iconPath(nativeRoot)).readAsBytes(), iconContent);
+    expect(File(p.join(nativeRoot, ".efa_blob_root")).readAsStringSync(), RepoPaths.assetsPath);
+  });
+
+  test("reuses a fresh native directory without rebuilding", () async {
+    final index = writeIconBlob();
+    final nativeRoot = await resolver.prepareNativeDir("snapshot_a", index);
+    final sentinel = File(p.join(nativeRoot, "sentinel"));
+    await sentinel.writeAsString("keep");
+
+    final again = await resolver.prepareNativeDir("snapshot_a", index);
+
+    expect(again, nativeRoot);
+    expect(sentinel.existsSync(), isTrue, reason: "fresh native dir must not be rebuilt");
+  });
+
+  test("rebuilds when the blob root moved (documents -> support migration)", () async {
+    final index = writeIconBlob();
+    final nativeRoot = await resolver.prepareNativeDir("snapshot_a", index);
+
+    // Simulate StoragePathMigrator: resources are renamed to the new root.
+    await Directory(
+      p.join(oldStorageRoot, "resources"),
+    ).rename(p.join(newStorageRoot, "resources"));
+    PathProvider.appSupportPath = newStorageRoot;
+
+    expect(
+      File(iconPath(nativeRoot)).existsSync(),
+      isFalse,
+      reason: "precondition: migration leaves dangling symlinks behind",
+    );
+
+    final rebuilt = await resolver.prepareNativeDir("snapshot_a", index);
+
+    expect(rebuilt, nativeRoot);
+    expect(await File(iconPath(rebuilt)).readAsBytes(), iconContent);
+    expect(File(p.join(rebuilt, ".efa_blob_root")).readAsStringSync(), RepoPaths.assetsPath);
+  });
+
+  test("rebuilds when the marker is missing (install predating the fix)", () async {
+    final index = writeIconBlob();
+    final nativeRoot = await resolver.prepareNativeDir("snapshot_a", index);
+
+    await Directory(
+      p.join(oldStorageRoot, "resources"),
+    ).rename(p.join(newStorageRoot, "resources"));
+    PathProvider.appSupportPath = newStorageRoot;
+    await File(p.join(nativeRoot, ".efa_blob_root")).delete();
+
+    final rebuilt = await resolver.prepareNativeDir("snapshot_a", index);
+
+    expect(await File(iconPath(rebuilt)).readAsBytes(), iconContent);
+  });
+}

--- a/test/storage/repo/native_dir_test.dart
+++ b/test/storage/repo/native_dir_test.dart
@@ -28,6 +28,8 @@ void main() {
 
   String iconPath(String nativeRoot) => p.join(nativeRoot, "static", "images", "icons", "123.png");
 
+  String markerPath(String nativeRoot) => "$nativeRoot.efa_blob_root";
+
   setUp(() async {
     tempRoot = await Directory.systemTemp.createTemp("efa_native_dir_test_");
     oldStorageRoot = p.join(tempRoot.path, "documents");
@@ -51,7 +53,40 @@ void main() {
     final nativeRoot = await resolver.prepareNativeDir("snapshot_a", index);
 
     expect(await File(iconPath(nativeRoot)).readAsBytes(), iconContent);
-    expect(File(p.join(nativeRoot, ".efa_blob_root")).readAsStringSync(), RepoPaths.assetsPath);
+    expect(File(markerPath(nativeRoot)).readAsStringSync(), RepoPaths.assetsPath);
+    expect(
+      File(p.join(nativeRoot, ".efa_blob_root")).existsSync(),
+      isFalse,
+      reason: "marker must live outside the materialized tree",
+    );
+  });
+
+  test("materializes a resource whose name collides with the marker", () async {
+    const collidingIdent = "resource://.efa_blob_root";
+    final collidingContent = Uint8List.fromList([1, 2, 3]);
+    final written = const AssetStore().writeBlobSync(
+      RepoHash.hashIdent(collidingIdent),
+      collidingContent,
+    );
+    final index = ResourceIndex(
+      entries: [ResourceIndex_Entry(resourceId: collidingIdent, contentHash: written.contentHash)],
+    );
+
+    final nativeRoot = await resolver.prepareNativeDir("snapshot_a", index);
+
+    expect(
+      await File(p.join(nativeRoot, ".efa_blob_root")).readAsBytes(),
+      collidingContent,
+      reason: "the resource must not be overwritten by the marker",
+    );
+    expect(File(markerPath(nativeRoot)).readAsStringSync(), RepoPaths.assetsPath);
+
+    final again = await resolver.prepareNativeDir("snapshot_a", index);
+    expect(
+      File(p.join(again, ".efa_blob_root")).readAsBytesSync(),
+      collidingContent,
+      reason: "the directory must be reused, not treated as stale",
+    );
   });
 
   test("reuses a fresh native directory without rebuilding", () async {
@@ -86,7 +121,7 @@ void main() {
 
     expect(rebuilt, nativeRoot);
     expect(await File(iconPath(rebuilt)).readAsBytes(), iconContent);
-    expect(File(p.join(rebuilt, ".efa_blob_root")).readAsStringSync(), RepoPaths.assetsPath);
+    expect(File(markerPath(rebuilt)).readAsStringSync(), RepoPaths.assetsPath);
   });
 
   test("rebuilds when the marker is missing (install predating the fix)", () async {
@@ -97,10 +132,23 @@ void main() {
       p.join(oldStorageRoot, "resources"),
     ).rename(p.join(newStorageRoot, "resources"));
     PathProvider.appSupportPath = newStorageRoot;
-    await File(p.join(nativeRoot, ".efa_blob_root")).delete();
+    await File(markerPath(nativeRoot)).delete();
 
     final rebuilt = await resolver.prepareNativeDir("snapshot_a", index);
 
     expect(await File(iconPath(rebuilt)).readAsBytes(), iconContent);
+  });
+
+  test("cleanup removes inactive native directories and their markers", () async {
+    final index = writeIconBlob();
+    final activeRoot = await resolver.prepareNativeDir("snapshot_active", index);
+    final staleRoot = await resolver.prepareNativeDir("snapshot_stale", index);
+
+    resolver.cleanup(["snapshot_active"]);
+
+    expect(Directory(activeRoot).existsSync(), isTrue);
+    expect(File(markerPath(activeRoot)).existsSync(), isTrue);
+    expect(Directory(staleRoot).existsSync(), isFalse);
+    expect(File(markerPath(staleRoot)).existsSync(), isFalse);
   });
 }


### PR DESCRIPTION
The documents -> application support migration moves the blob store, but native dirs under temp/ keep absolute symlinks into the old root and were reused blindly, leaving icons unresolvable. Record the blob root in a marker file inside each native dir and rebuild when it no longer matches (or is missing, for installs predating the marker).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native asset directories now detect outdated or missing storage markers and rebuild automatically.
  * Assets are correctly restored after app storage migrations.
  * Existing up-to-date directories continue to be reused without unnecessary rebuilding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->