### PR TITLE
feat: enhance implant set UI with family grouping and localized names

### DIFF
--- a/bootstrap/data/workspace/generate/static/__init__.py
+++ b/bootstrap/data/workspace/generate/static/__init__.py
@@ -15,6 +15,7 @@ from . import dogma_units
 from . import dynamic
 from . import fit
 from . import groups
+from . import implant_sets
 from . import market_groups
 from . import meta_groups
 from . import type_materials
@@ -42,6 +43,7 @@ async def generate(data: GeneratorDatasource) -> collections_pb2.Collection:
             dogma_attributes,
             dynamic,
             fit,
+            implant_sets,
         ]
     )
     await asyncio.gather(*tasks)

--- a/bootstrap/data/workspace/generate/static/implant_sets.py
+++ b/bootstrap/data/workspace/generate/static/implant_sets.py
@@ -1,0 +1,287 @@
+"""Implant set (e.g. "High-grade Crystal Alpha..Omega") metadata generator.
+
+Set identity is derived from dogma, never from type names: all members of a
+set share a setBonus/implantSet dogma effect and carry the corresponding
+implantSet attribute. Type names are used only to produce baked per-locale
+display names via longest-common-prefix within each grade cluster.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+from typing import NamedTuple
+
+from pydantic import BaseModel
+from pydantic import Field
+
+import bootstrap.config
+
+from bootstrap.constant import IMPLANT_SLOT_ATTR_ID
+from bootstrap.data.schema import fit_pb2
+from bootstrap.localization import to_native_localization
+from bootstrap.log import error
+from bootstrap.log import info
+from bootstrap.log import warning
+
+
+if TYPE_CHECKING:
+    from bootstrap.data.workspace.generate import GeneratorDatasource
+    from bootstrap.localization import LocalizationType
+
+
+_IMPLANT_CATEGORY_ID = 20
+# FSD naming is inconsistent: "implantSetGuristas", "ImplantSetNirvana",
+# "setBonusMimesis", ...
+_IMPLANT_SET_ATTR_PREFIXES = ("implantset", "setbonus")
+
+
+class DogmaAttributeItem(BaseModel):
+    attributeID: int
+    value: float
+
+
+class DogmaEffectItem(BaseModel):
+    effectID: int
+
+
+class TypeDogmaDef(BaseModel):
+    dogmaAttributes: list[DogmaAttributeItem] = Field(default_factory=list)
+    dogmaEffects: list[DogmaEffectItem] = Field(default_factory=list)
+
+
+class TypeDef(BaseModel):
+    typeID: int
+    groupID: int
+    published: bool
+    typeNameID: int
+
+
+class GroupDef(BaseModel):
+    groupID: int
+    categoryID: int
+
+
+class ModifierInfoDef(BaseModel):
+    modifyingAttributeID: int | None = Field(default=None)
+
+
+class EffectDef(BaseModel):
+    effectName: str = ""
+    modifierInfo: list[ModifierInfoDef] = Field(default_factory=list)
+
+
+class AttributeDef(BaseModel):
+    name: str = ""
+
+
+class SetMember(NamedTuple):
+    type_id: int
+    slot: int
+    set_value: float
+
+
+def find_set_effects(dogma_effects: dict, dogma_attributes: dict) -> dict[int, int]:
+    """Map set effect IDs to their implantSet attribute ID.
+
+    FSD effect naming is inconsistent ("setBonusGuristas", "haloSetBonus",
+    "federationsetbonus3", "imperialsetLGbonus", "implantSetWarpSpeed"), so
+    instead of matching effect names, an effect is a set effect iff it
+    modifies by an attribute named implantSet*/setBonus* (case-insensitive).
+    """
+    set_attribute_ids: set[int] = set()
+    for attribute_id, raw in dogma_attributes.items():
+        try:
+            attribute = AttributeDef.model_validate(raw)
+        except Exception as e:
+            error(f"Failed to validate dogma attribute {attribute_id} for implant sets: {e}")
+            continue
+        if attribute.name.lower().startswith(_IMPLANT_SET_ATTR_PREFIXES):
+            set_attribute_ids.add(int(attribute_id))
+
+    set_effects: dict[int, int] = {}
+    for effect_id, raw in dogma_effects.items():
+        try:
+            effect = EffectDef.model_validate(raw)
+        except Exception as e:
+            error(f"Failed to validate dogma effect {effect_id} for implant sets: {e}")
+            continue
+        for modifier in effect.modifierInfo:
+            if modifier.modifyingAttributeID in set_attribute_ids:
+                set_effects[int(effect_id)] = modifier.modifyingAttributeID
+                break
+    return set_effects
+
+
+def base_name(name: str) -> str:
+    """Strip the trailing slot discriminator token ("... Alpha", "... CA-1")."""
+    base, sep, _ = name.rpartition(" ")
+    return base if sep else name
+
+
+def set_display_name(names: list[str]) -> str:
+    """Longest common prefix of member names, trimmed to a clean word boundary."""
+    if not names:
+        return ""
+    prefix = os.path.commonprefix(names).strip()
+    if prefix and not prefix[-1].isalnum() and " " in prefix:
+        prefix = prefix[: prefix.rindex(" ")].strip()
+    return prefix
+
+
+def cluster_members(members: list[SetMember], name_of) -> list[list[SetMember]]:
+    """Split an effect family into grades by the members' base names."""
+    clusters: dict[str, list[SetMember]] = defaultdict(list)
+    for member in members:
+        clusters[base_name(name_of(member.type_id))].append(member)
+    return list(clusters.values())
+
+
+def merge_set_clusters(
+    members_by_effect: dict[int, list[SetMember]], set_effects: dict[int, int], name_of
+) -> list[tuple[int, int, list[SetMember]]]:
+    """Merge per-effect clusters into sets keyed by display name.
+
+    A single set family can be spread over multiple setBonus effects (e.g.
+    Talisman uses one effect for Alpha-Epsilon and another including Omega;
+    Genolution has one effect per bonus attribute). Returns a list of
+    (set_id, effect_id, members) with deterministic set IDs.
+    """
+    merged: dict[str, dict] = {}
+    for effect_id in sorted(set_effects):
+        members = members_by_effect.get(effect_id, [])
+        for cluster in cluster_members(members, name_of):
+            if len(cluster) < 2:
+                continue
+            display = set_display_name([name_of(m.type_id) for m in cluster])
+            if not display:
+                continue
+            entry = merged.setdefault(display, {"effects": defaultdict(int), "slots": {}})
+            for member in cluster:
+                entry["effects"][effect_id] += 1
+                entry["slots"].setdefault(member.slot, member)
+
+    sets_by_effect: dict[int, list[dict]] = defaultdict(list)
+    for entry in merged.values():
+        primary_effect = max(entry["effects"].items(), key=lambda kv: (kv[1], -kv[0]))[0]
+        sets_by_effect[primary_effect].append(entry)
+
+    sets: list[tuple[int, int, list[SetMember]]] = []
+    for effect_id, entries in sorted(sets_by_effect.items()):
+        entries.sort(
+            key=lambda entry: (
+                sum(m.set_value for m in entry["slots"].values()) / len(entry["slots"])
+            )
+        )
+        for rank, entry in enumerate(entries):
+            members = sorted(entry["slots"].values(), key=lambda m: (m.slot, m.type_id))
+            sets.append((effect_id * 100 + rank, effect_id, members))
+    return sets
+
+
+async def _load_localized_names(
+    data: GeneratorDatasource, lang: LocalizationType
+) -> dict[int, str]:
+    resource = data.resources.res.get_resource(
+        f"res:/localizationfsd/localization_fsd_{to_native_localization(lang)}.pickle"
+    )
+    async with resource.open() as f:
+        _lang_code, loc = pickle.loads(await f.read())
+    return {int(key): value[0] for key, value in loc.items()}
+
+
+async def generate(data: GeneratorDatasource, collection):
+    info("Generating implant sets...")
+
+    type_dogma = await data.resources.fsd.get("typedogma")
+    types = await data.resources.fsd.get("types")
+    groups = await data.resources.fsd.get("groups")
+    dogma_effects = await data.resources.fsd.get("dogmaeffects")
+    dogma_attributes = await data.resources.fsd.get("dogmaattributes")
+
+    set_effects = find_set_effects(dogma_effects, dogma_attributes)
+    if not set_effects:
+        warning("No implant set effects found in dogma effects")
+        return
+
+    implant_group_ids: set[int] = set()
+    for group_id, raw in groups.items():
+        try:
+            group = GroupDef.model_validate(raw)
+        except Exception as e:
+            error(f"Failed to validate group {group_id} for implant sets: {e}")
+            continue
+        if group.categoryID == _IMPLANT_CATEGORY_ID:
+            implant_group_ids.add(group.groupID)
+
+    type_name_ids: dict[int, int] = {}
+    for type_id, raw in types.items():
+        try:
+            type_def = TypeDef.model_validate(raw)
+        except Exception as e:
+            error(f"Failed to validate type {type_id} for implant sets: {e}")
+            continue
+        if type_def.published and type_def.groupID in implant_group_ids:
+            type_name_ids[type_def.typeID] = type_def.typeNameID
+
+    members_by_effect: dict[int, list[SetMember]] = defaultdict(list)
+    for type_id, raw in type_dogma.items():
+        type_id = int(type_id)
+        if type_id not in type_name_ids:
+            continue
+        try:
+            dogma = TypeDogmaDef.model_validate(raw)
+        except Exception as e:
+            error(f"Failed to validate type dogma {type_id} for implant sets: {e}")
+            continue
+
+        attributes = {attr.attributeID: attr.value for attr in dogma.dogmaAttributes}
+        slot = attributes.get(IMPLANT_SLOT_ATTR_ID)
+        if slot is None:
+            continue
+
+        for effect in dogma.dogmaEffects:
+            set_attr = set_effects.get(effect.effectID)
+            if set_attr is not None and set_attr in attributes:
+                members_by_effect[effect.effectID].append(
+                    SetMember(type_id=type_id, slot=int(slot), set_value=attributes[set_attr])
+                )
+
+    locales: list[LocalizationType] = bootstrap.config.CONFIGURATION.localizations.supported
+    names_by_locale = {lang: await _load_localized_names(data, lang) for lang in locales}
+    cluster_lang: LocalizationType = "en" if "en" in locales else locales[0]
+
+    def name_of(lang: LocalizationType, type_id: int) -> str:
+        name_id = type_name_ids.get(type_id)
+        if name_id is None:
+            return str(type_id)
+        return names_by_locale[lang].get(name_id, str(type_id))
+
+    count = 0
+    sets = merge_set_clusters(
+        members_by_effect, set_effects, lambda tid: name_of(cluster_lang, tid)
+    )
+    for set_id, effect_id, members in sets:
+        pb = fit_pb2.ImplantSet()
+        pb.set_id = set_id
+        pb.effect_id = effect_id
+        pb.member_type_ids.extend(member.type_id for member in members)
+
+        for lang in locales:
+            display = set_display_name([name_of(lang, m.type_id) for m in members])
+            if not display and lang != cluster_lang:
+                display = set_display_name([name_of(cluster_lang, m.type_id) for m in members])
+            if display:
+                pb.names[lang] = display
+
+        if not pb.names:
+            warning(f"Implant set for effect {effect_id} has no display name, skipped")
+            continue
+
+        collection.implant_sets[pb.set_id].CopyFrom(pb)
+        count += 1
+
+    info(f"Generated {count} implant sets")

--- a/bootstrap/data/workspace/generate/static/implant_sets.py
+++ b/bootstrap/data/workspace/generate/static/implant_sets.py
@@ -37,6 +37,9 @@ _IMPLANT_CATEGORY_ID = 20
 # FSD naming is inconsistent: "implantSetGuristas", "ImplantSetNirvana",
 # "setBonusMimesis", ...
 _IMPLANT_SET_ATTR_PREFIXES = ("implantset", "setbonus")
+# Separators between the set name and the slot discriminator in localized type
+# names ("High-grade Crystal Alpha", "高级水晶—阿尔法型", "低级辟邪 - 阿尔法型").
+_SEPARATOR_CHARS = " \t-\N{EN DASH}\N{EM DASH}"
 
 
 class DogmaAttributeItem(BaseModel):
@@ -129,7 +132,52 @@ def set_display_name(names: list[str]) -> str:
     prefix = os.path.commonprefix(names).strip()
     if prefix and not prefix[-1].isalnum() and " " in prefix:
         prefix = prefix[: prefix.rindex(" ")].strip()
-    return prefix
+    stripped = prefix.rstrip(_SEPARATOR_CHARS)
+    return stripped or prefix
+
+
+# Closed grade vocabulary used to derive family names from set display names.
+# Only affects display strings; membership/mechanics never depend on it.
+_GRADE_PREFIXES: dict[str, tuple[str, ...]] = {
+    "en": ("low-grade ", "mid-grade ", "high-grade "),
+    "zh": ("低级", "中级", "高级"),
+}
+
+
+def family_display_name(displays: list[str], lang: str) -> str:
+    """Family name from the per-grade display names of one family.
+
+    Strips the grade prefix from each display; requires all sets of the
+    family to agree on the remainder. Falls back to the longest common
+    suffix when the grade structure is not recognized.
+    """
+    if not displays:
+        return ""
+    if len(displays) == 1:
+        return displays[0]
+
+    grades = _GRADE_PREFIXES.get(lang, ())
+    families = set()
+    for display in displays:
+        lowered = display.lower()
+        for grade in grades:
+            if lowered.startswith(grade):
+                families.add(display[len(grade) :])
+                break
+    if len(families) == 1:
+        return families.pop()
+
+    # Fallback: longest common suffix, trimmed to a clean token boundary.
+    lcs = os.path.commonprefix([display[::-1] for display in displays])[::-1]
+    starts_mid_token = any(
+        len(display) > len(lcs) and display[-len(lcs) - 1] != " " for display in displays
+    )
+    if starts_mid_token:
+        _head, sep, tail = lcs.partition(" ")
+        if sep:
+            lcs = tail
+    stripped = lcs.strip(_SEPARATOR_CHARS)
+    return stripped or lcs.strip()
 
 
 def cluster_members(members: list[SetMember], name_of) -> list[list[SetMember]]:
@@ -140,15 +188,21 @@ def cluster_members(members: list[SetMember], name_of) -> list[list[SetMember]]:
     return list(clusters.values())
 
 
+class MergedSet(NamedTuple):
+    effect_id: int
+    display: str
+    members: list[SetMember]
+
+
 def merge_set_clusters(
     members_by_effect: dict[int, list[SetMember]], set_effects: dict[int, int], name_of
-) -> list[tuple[int, int, list[SetMember]]]:
+) -> list[MergedSet]:
     """Merge per-effect clusters into sets keyed by display name.
 
     A single set family can be spread over multiple setBonus effects (e.g.
     Talisman uses one effect for Alpha-Epsilon and another including Omega;
-    Genolution has one effect per bonus attribute). Returns a list of
-    (set_id, effect_id, members) with deterministic set IDs.
+    Genolution has one effect per bonus attribute). Returns one MergedSet per
+    (family, grade) with the cluster-locale display name.
     """
     merged: dict[str, dict] = {}
     for effect_id in sorted(set_effects):
@@ -164,22 +218,43 @@ def merge_set_clusters(
                 entry["effects"][effect_id] += 1
                 entry["slots"].setdefault(member.slot, member)
 
-    sets_by_effect: dict[int, list[dict]] = defaultdict(list)
-    for entry in merged.values():
+    sets: list[MergedSet] = []
+    for display, entry in merged.items():
         primary_effect = max(entry["effects"].items(), key=lambda kv: (kv[1], -kv[0]))[0]
-        sets_by_effect[primary_effect].append(entry)
-
-    sets: list[tuple[int, int, list[SetMember]]] = []
-    for effect_id, entries in sorted(sets_by_effect.items()):
-        entries.sort(
-            key=lambda entry: (
-                sum(m.set_value for m in entry["slots"].values()) / len(entry["slots"])
-            )
-        )
-        for rank, entry in enumerate(entries):
-            members = sorted(entry["slots"].values(), key=lambda m: (m.slot, m.type_id))
-            sets.append((effect_id * 100 + rank, effect_id, members))
+        members = sorted(entry["slots"].values(), key=lambda m: (m.slot, m.type_id))
+        sets.append(MergedSet(effect_id=primary_effect, display=display, members=members))
     return sets
+
+
+def family_key(display: str) -> str:
+    """Family key from a display name: drop a leading grade token if present."""
+    first, sep, rest = display.partition(" ")
+    if sep and rest and first.lower().endswith("-grade"):
+        return rest
+    return display
+
+
+def assign_set_ids(sets: list[MergedSet]) -> list[tuple[int, MergedSet]]:
+    """Group sets into families and assign deterministic set IDs.
+
+    set_id = family_index * 100 + grade_rank, so sets of one family share
+    set_id // 100 and grade ranks ascend with set strength (low < mid < high).
+    Families group grades across different effects (e.g. Low-grade and
+    High-grade Grail use different set effects).
+    """
+    families: dict[str, list[MergedSet]] = defaultdict(list)
+    for merged_set in sets:
+        families[family_key(merged_set.display)].append(merged_set)
+
+    assigned: list[tuple[int, MergedSet]] = []
+    for family_index, key in enumerate(sorted(families)):
+        entries = sorted(
+            families[key],
+            key=lambda s: sum(m.set_value for m in s.members) / len(s.members),
+        )
+        for rank, merged_set in enumerate(entries):
+            assigned.append((family_index * 100 + rank, merged_set))
+    return assigned
 
 
 async def _load_localized_names(
@@ -260,28 +335,68 @@ async def generate(data: GeneratorDatasource, collection):
             return str(type_id)
         return names_by_locale[lang].get(name_id, str(type_id))
 
-    count = 0
-    sets = merge_set_clusters(
+    merged = merge_set_clusters(
         members_by_effect, set_effects, lambda tid: name_of(cluster_lang, tid)
     )
-    for set_id, effect_id, members in sets:
+    assigned = assign_set_ids(merged)
+
+    # Family display name per locale from the family's per-grade display
+    # names ("低级水晶"/"高级水晶" -> "水晶").
+    family_sets: dict[int, list[MergedSet]] = defaultdict(list)
+    for set_id, merged_set in assigned:
+        family_sets[set_id // 100].append(merged_set)
+
+    family_names: dict[int, dict[str, str]] = {}
+    for family_id, sets_in_family in family_sets.items():
+        names: dict[str, str] = {}
+        for lang in locales:
+            displays = [
+                display
+                for s in sets_in_family
+                if (display := set_display_name([name_of(lang, m.type_id) for m in s.members]))
+            ]
+            family = family_display_name(displays, lang)
+            if not family and lang != cluster_lang:
+                family = family_display_name(
+                    [
+                        display
+                        for s in sets_in_family
+                        if (
+                            display := set_display_name(
+                                [name_of(cluster_lang, m.type_id) for m in s.members]
+                            )
+                        )
+                    ],
+                    cluster_lang,
+                )
+            if family:
+                names[lang] = family
+        family_names[family_id] = names
+
+    count = 0
+    for set_id, merged_set in assigned:
         pb = fit_pb2.ImplantSet()
         pb.set_id = set_id
-        pb.effect_id = effect_id
-        pb.member_type_ids.extend(member.type_id for member in members)
+        pb.effect_id = merged_set.effect_id
+        pb.member_type_ids.extend(member.type_id for member in merged_set.members)
 
         for lang in locales:
-            display = set_display_name([name_of(lang, m.type_id) for m in members])
+            display = set_display_name([name_of(lang, m.type_id) for m in merged_set.members])
             if not display and lang != cluster_lang:
-                display = set_display_name([name_of(cluster_lang, m.type_id) for m in members])
+                display = set_display_name(
+                    [name_of(cluster_lang, m.type_id) for m in merged_set.members]
+                )
             if display:
                 pb.names[lang] = display
 
+        for lang, family in family_names.get(set_id // 100, {}).items():
+            pb.family_names[lang] = family
+
         if not pb.names:
-            warning(f"Implant set for effect {effect_id} has no display name, skipped")
+            warning(f"Implant set for effect {merged_set.effect_id} has no display name, skipped")
             continue
 
         collection.implant_sets[pb.set_id].CopyFrom(pb)
         count += 1
 
-    info(f"Generated {count} implant sets")
+    info(f"Generated {count} implant sets in {len(family_sets)} families")

--- a/bootstrap/data/workspace/generate/static/implant_sets.py
+++ b/bootstrap/data/workspace/generate/static/implant_sets.py
@@ -17,10 +17,12 @@ from typing import NamedTuple
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import ValidationError
 
 import bootstrap.config
 
 from bootstrap.constant import IMPLANT_SLOT_ATTR_ID
+from bootstrap.data.schema import collections_pb2
 from bootstrap.data.schema import fit_pb2
 from bootstrap.localization import to_native_localization
 from bootstrap.log import error
@@ -99,7 +101,7 @@ def find_set_effects(dogma_effects: dict, dogma_attributes: dict) -> dict[int, i
     for attribute_id, raw in dogma_attributes.items():
         try:
             attribute = AttributeDef.model_validate(raw)
-        except Exception as e:
+        except ValidationError as e:
             error(f"Failed to validate dogma attribute {attribute_id} for implant sets: {e}")
             continue
         if attribute.name.lower().startswith(_IMPLANT_SET_ATTR_PREFIXES):
@@ -109,7 +111,7 @@ def find_set_effects(dogma_effects: dict, dogma_attributes: dict) -> dict[int, i
     for effect_id, raw in dogma_effects.items():
         try:
             effect = EffectDef.model_validate(raw)
-        except Exception as e:
+        except ValidationError as e:
             error(f"Failed to validate dogma effect {effect_id} for implant sets: {e}")
             continue
         for modifier in effect.modifierInfo:
@@ -268,7 +270,7 @@ async def _load_localized_names(
     return {int(key): value[0] for key, value in loc.items()}
 
 
-async def generate(data: GeneratorDatasource, collection):
+async def generate(data: GeneratorDatasource, collection: collections_pb2.Collection):
     info("Generating implant sets...")
 
     type_dogma = await data.resources.fsd.get("typedogma")
@@ -286,7 +288,7 @@ async def generate(data: GeneratorDatasource, collection):
     for group_id, raw in groups.items():
         try:
             group = GroupDef.model_validate(raw)
-        except Exception as e:
+        except ValidationError as e:
             error(f"Failed to validate group {group_id} for implant sets: {e}")
             continue
         if group.categoryID == _IMPLANT_CATEGORY_ID:
@@ -296,7 +298,7 @@ async def generate(data: GeneratorDatasource, collection):
     for type_id, raw in types.items():
         try:
             type_def = TypeDef.model_validate(raw)
-        except Exception as e:
+        except ValidationError as e:
             error(f"Failed to validate type {type_id} for implant sets: {e}")
             continue
         if type_def.published and type_def.groupID in implant_group_ids:
@@ -309,7 +311,7 @@ async def generate(data: GeneratorDatasource, collection):
             continue
         try:
             dogma = TypeDogmaDef.model_validate(raw)
-        except Exception as e:
+        except ValidationError as e:
             error(f"Failed to validate type dogma {type_id} for implant sets: {e}")
             continue
 

--- a/bootstrap/tests/test_implant_sets.py
+++ b/bootstrap/tests/test_implant_sets.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from bootstrap.data.workspace.generate.static.implant_sets import MergedSet
 from bootstrap.data.workspace.generate.static.implant_sets import SetMember
+from bootstrap.data.workspace.generate.static.implant_sets import assign_set_ids
 from bootstrap.data.workspace.generate.static.implant_sets import base_name
 from bootstrap.data.workspace.generate.static.implant_sets import cluster_members
+from bootstrap.data.workspace.generate.static.implant_sets import family_display_name
+from bootstrap.data.workspace.generate.static.implant_sets import family_key
 from bootstrap.data.workspace.generate.static.implant_sets import find_set_effects
 from bootstrap.data.workspace.generate.static.implant_sets import merge_set_clusters
 from bootstrap.data.workspace.generate.static.implant_sets import set_display_name
@@ -89,8 +93,38 @@ def test_set_display_name_keeps_cjk_prefix():
     assert set_display_name(names) == "高级水晶体"
 
 
+def test_set_display_name_strips_trailing_cjk_separator():
+    # Real zh names: "高级水晶—阿尔法型", "低级辟邪 - 阿尔法型"
+    assert set_display_name(["高级水晶—阿尔法型", "高级水晶—欧米伽型"]) == "高级水晶"
+    assert set_display_name(["低级辟邪 - 阿尔法型", "低级辟邪 - 欧米伽型"]) == "低级辟邪"
+
+
 def test_set_display_name_empty():
     assert set_display_name([]) == ""
+
+
+def test_family_display_name():
+    assert (
+        family_display_name(["Low-grade Crystal", "Mid-grade Crystal", "High-grade Crystal"], "en")
+        == "Crystal"
+    )
+    assert family_display_name(["低级水晶", "中级水晶", "高级水晶"], "zh") == "水晶"
+    assert family_display_name(["低级辟邪", "高级辟邪"], "zh") == "辟邪"
+    assert family_display_name(["Genolution Core Augmentation"], "en") == (
+        "Genolution Core Augmentation"
+    )
+    assert family_display_name([], "en") == ""
+
+
+def test_family_display_name_fallback_for_unknown_language():
+    # No grade table: falls back to the longest common suffix at a token boundary.
+    assert family_display_name(["Low-grade Crystal", "High-grade Crystal"], "fr") == "Crystal"
+
+
+def test_family_key_strips_grade_token():
+    assert family_key("High-grade Crystal") == "Crystal"
+    assert family_key("Low-grade Grail") == "Grail"
+    assert family_key("Genolution Core Augmentation") == "Genolution Core Augmentation"
 
 
 def test_cluster_members_splits_grades():
@@ -134,16 +168,53 @@ def test_merge_set_clusters_merges_effects_of_same_family():
     sets = merge_set_clusters(members_by_effect, {100: 800, 200: 801}, names.get)
 
     assert len(sets) == 3
-    for _set_id, effect_id, members in sets:
-        assert effect_id == 100
-        assert len(members) == 6
-        assert [m.slot for m in members] == [1, 2, 3, 4, 5, 6]
-    # deterministic grade order: low < mid < high by ascending set value
-    assert [s[0] for s in sets] == [10000, 10001, 10002]
-    assert sets[0][2][0].set_value == 1.025
-    assert sets[2][2][0].set_value == 1.15
+    for merged_set in sets:
+        assert merged_set.effect_id == 100
+        assert len(merged_set.members) == 6
+        assert [m.slot for m in merged_set.members] == [1, 2, 3, 4, 5, 6]
+    assert {s.display for s in sets} == {
+        "Low-grade Talisman",
+        "Mid-grade Talisman",
+        "High-grade Talisman",
+    }
 
 
 def test_merge_set_clusters_drops_singletons():
     members_by_effect = {100: [SetMember(1, 1, 1.15)]}
     assert merge_set_clusters(members_by_effect, {100: 800}, lambda _: "Solo Implant") == []
+
+
+def test_assign_set_ids_groups_families_and_ranks_grades():
+    def make_set(effect_id, display, value):
+        return MergedSet(
+            effect_id=effect_id,
+            display=display,
+            members=[SetMember(type_id=1, slot=1, set_value=value)],
+        )
+
+    sets = [
+        # Crystal family: one effect, three grades (given out of order).
+        make_set(1397, "High-grade Crystal", 1.15),
+        make_set(1397, "Low-grade Crystal", 1.025),
+        make_set(1397, "Mid-grade Crystal", 1.1),
+        # Navy family: grades spread over two different effects.
+        make_set(4457, "High-grade Grail", 1.15),
+        make_set(4460, "Low-grade Grail", 1.025),
+        # Single-set family without a grade token.
+        make_set(4867, "Genolution Core Augmentation", 1.5),
+    ]
+
+    assigned = assign_set_ids(sets)
+    by_display = {s.display: set_id for set_id, s in assigned}
+
+    crystal_ids = {by_display[d] // 100 for d in by_display if "Crystal" in d}
+    assert len(crystal_ids) == 1
+    grail_ids = {by_display[d] // 100 for d in by_display if "Grail" in d}
+    assert len(grail_ids) == 1
+
+    # Grade ranks ascend with set strength within each family.
+    assert by_display["Low-grade Crystal"] % 100 == 0
+    assert by_display["Mid-grade Crystal"] % 100 == 1
+    assert by_display["High-grade Crystal"] % 100 == 2
+    assert by_display["Low-grade Grail"] % 100 == 0
+    assert by_display["High-grade Grail"] % 100 == 1

--- a/bootstrap/tests/test_implant_sets.py
+++ b/bootstrap/tests/test_implant_sets.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from bootstrap.data.workspace.generate.static.implant_sets import SetMember
+from bootstrap.data.workspace.generate.static.implant_sets import base_name
+from bootstrap.data.workspace.generate.static.implant_sets import cluster_members
+from bootstrap.data.workspace.generate.static.implant_sets import find_set_effects
+from bootstrap.data.workspace.generate.static.implant_sets import merge_set_clusters
+from bootstrap.data.workspace.generate.static.implant_sets import set_display_name
+
+
+def test_find_set_effects_picks_up_set_bonus_and_implant_set():
+    dogma_attributes = {
+        66: {"name": "durationBonus"},
+        838: {"name": "implantSetGuristas"},
+        863: {"name": "implantSetHalo"},
+        1932: {"name": "implantSetWarpSpeed"},
+        3017: {"name": "ImplantSetNirvana"},
+    }
+    dogma_effects = {
+        1397: {
+            "effectName": "setBonusGuristas",
+            "modifierInfo": [{"modifyingAttributeID": 838}],
+        },
+        5717: {
+            "effectName": "implantSetWarpSpeed",
+            "modifierInfo": [{"modifyingAttributeID": 1932}],
+        },
+        1577: {
+            "effectName": "haloSetBonus",
+            "modifierInfo": [{"modifyingAttributeID": 863}],
+        },
+        8013: {
+            "effectName": "setBonusNirvana",
+            "modifierInfo": [{"modifyingAttributeID": 3017}],
+        },
+        1256: {
+            # Not a set-membership effect: modifies by a non-implantSet attribute.
+            "effectName": "setBonusBloodraiderNosferatu",
+            "modifierInfo": [{"modifyingAttributeID": 66}],
+        },
+        11: {
+            "effectName": "shieldBoosting",
+            "modifierInfo": [{"modifyingAttributeID": 100}],
+        },
+        9999: {
+            "effectName": "setBonusNoModifier",
+            "modifierInfo": [{}],
+        },
+    }
+
+    assert find_set_effects(dogma_effects, dogma_attributes) == {
+        1397: 838,
+        5717: 1932,
+        1577: 863,
+        8013: 3017,
+    }
+
+
+def test_find_set_effects_handles_missing_fields():
+    assert find_set_effects({1: {}}, {}) == {}
+    assert find_set_effects({2: {"effectName": "setBonusX"}}, {3: {}}) == {}
+
+
+def test_base_name_strips_slot_discriminator():
+    assert base_name("High-grade Crystal Alpha") == "High-grade Crystal"
+    assert base_name("Genolution Core Augmentation CA-1") == "Genolution Core Augmentation"
+    assert base_name("SingleWord") == "SingleWord"
+
+
+def test_set_display_name_common_prefix():
+    names = [
+        "High-grade Crystal Alpha",
+        "High-grade Crystal Beta",
+        "High-grade Crystal Omega",
+    ]
+    assert set_display_name(names) == "High-grade Crystal"
+
+
+def test_set_display_name_trims_trailing_partial_token():
+    names = [
+        "Genolution Core Augmentation CA-1",
+        "Genolution Core Augmentation CA-2",
+    ]
+    assert set_display_name(names) == "Genolution Core Augmentation"
+
+
+def test_set_display_name_keeps_cjk_prefix():
+    names = ["高级水晶体阿尔法", "高级水晶体欧米伽"]
+    assert set_display_name(names) == "高级水晶体"
+
+
+def test_set_display_name_empty():
+    assert set_display_name([]) == ""
+
+
+def test_cluster_members_splits_grades():
+    members = [
+        SetMember(type_id=1, slot=1, set_value=1.15),
+        SetMember(type_id=2, slot=2, set_value=1.15),
+        SetMember(type_id=3, slot=1, set_value=1.025),
+        SetMember(type_id=4, slot=2, set_value=1.025),
+    ]
+    names = {
+        1: "High-grade Crystal Alpha",
+        2: "High-grade Crystal Beta",
+        3: "Low-grade Crystal Alpha",
+        4: "Low-grade Crystal Beta",
+    }
+
+    clusters = cluster_members(members, names.get)
+    cluster_type_ids = sorted(sorted(m.type_id for m in cluster) for cluster in clusters)
+    assert cluster_type_ids == [[1, 2], [3, 4]]
+
+
+def _talisman_like_members() -> tuple[dict[int, list[SetMember]], dict[int, str]]:
+    """Mirror Talisman: one effect covering Alpha-Omega, another Alpha-Epsilon."""
+    names = {}
+    members_by_effect: dict[int, list[SetMember]] = {100: [], 200: []}
+    grades = [("Low-grade", 1.025), ("Mid-grade", 1.1), ("High-grade", 1.15)]
+    type_id = 0
+    for grade, value in grades:
+        for slot, greek in enumerate(["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Omega"], 1):
+            type_id += 1
+            names[type_id] = f"{grade} Talisman {greek}"
+            members_by_effect[100].append(SetMember(type_id, slot, value))
+            if slot <= 5:
+                members_by_effect[200].append(SetMember(type_id, slot, value))
+    return members_by_effect, names
+
+
+def test_merge_set_clusters_merges_effects_of_same_family():
+    members_by_effect, names = _talisman_like_members()
+
+    sets = merge_set_clusters(members_by_effect, {100: 800, 200: 801}, names.get)
+
+    assert len(sets) == 3
+    for _set_id, effect_id, members in sets:
+        assert effect_id == 100
+        assert len(members) == 6
+        assert [m.slot for m in members] == [1, 2, 3, 4, 5, 6]
+    # deterministic grade order: low < mid < high by ascending set value
+    assert [s[0] for s in sets] == [10000, 10001, 10002]
+    assert sets[0][2][0].set_value == 1.025
+    assert sets[2][2][0].set_value == 1.15
+
+
+def test_merge_set_clusters_drops_singletons():
+    members_by_effect = {100: [SetMember(1, 1, 1.15)]}
+    assert merge_set_clusters(members_by_effect, {100: 800}, lambda _: "Solo Implant") == []

--- a/data/schema/collections.proto
+++ b/data/schema/collections.proto
@@ -33,4 +33,7 @@ message Collection {
   map<uint32, dynamic.DynamicMutator> dynamic_mutators = 12;
   map<uint32, dynamic.DynamicTypeOptions> dynamic_type_options = 13;
   map<string, SkillProfile> skill_profiles = 14;
+
+  // Optional: absent in older bundles; feature-gate UI on emptiness.
+  map<uint32, fit.ImplantSet> implant_sets = 15;
 }

--- a/data/schema/fit.proto
+++ b/data/schema/fit.proto
@@ -57,6 +57,25 @@ message TacticalMode {
   required TacticalModeVariant variant = 3;
 }
 
+/// A named group of implants forming a set (e.g. "High-grade Crystal").
+///
+/// Membership is derived at data-build time from dogma: all members share the
+/// same setBonus effect and carry the corresponding implantSet attribute.
+/// Display names are baked per locale; the app never parses type names.
+message ImplantSet {
+  /// Deterministic ID: effect_id * 100 + grade rank within the effect family.
+  required uint32 set_id = 1;
+
+  /// The shared setBonus dogma effect ID (mechanics key, stable across versions).
+  required uint32 effect_id = 2;
+
+  /// Display name per locale (e.g. "en" -> "High-grade Crystal").
+  map<string, string> names = 3;
+
+  /// Member implant type IDs, sorted by implant slot (dogma attribute 331).
+  repeated uint32 member_type_ids = 4;
+}
+
 message Slots {
   enum SlotState {
     PASSIVE = 0;

--- a/data/schema/fit.proto
+++ b/data/schema/fit.proto
@@ -63,7 +63,9 @@ message TacticalMode {
 /// same setBonus effect and carry the corresponding implantSet attribute.
 /// Display names are baked per locale; the app never parses type names.
 message ImplantSet {
-  /// Deterministic ID: effect_id * 100 + grade rank within the effect family.
+  /// Deterministic ID: family_index * 100 + grade rank within the family.
+  /// Sets of one family (e.g. Low/Mid/High-grade Crystal) share set_id / 100;
+  /// grade ranks ascend with set strength.
   required uint32 set_id = 1;
 
   /// The shared setBonus dogma effect ID (mechanics key, stable across versions).
@@ -74,6 +76,9 @@ message ImplantSet {
 
   /// Member implant type IDs, sorted by implant slot (dogma attribute 331).
   repeated uint32 member_type_ids = 4;
+
+  /// Family display name per locale (e.g. "en" -> "Crystal", "zh" -> "水晶").
+  map<string, string> family_names = 5;
 }
 
 message Slots {

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -185,6 +185,7 @@
   "fitSkillPolicyUnsupportedDescription": "Fits are simulated without character skill modifiers. Implants and boosters still apply.",
   "fitAddItemDialogTitle": "Add Item: {slotName}",
   "fitAddItemDialogTitleWithIndex": "Add Item: {slotName} #{index}",
+  "fitImplantSetDialogTitle": "Apply Implant Set",
   "fitSlotEmpty": "{slotName} (Empty)",
   "fitActionFill": "Fill",
   "fitActionSet": "Set",

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -495,6 +495,7 @@
       }
     }
   },
+  "fitImplantSetDialogTitle": "应用植入体套装",
   "fitSlotEmpty": "{slotName}（空）",
   "@fitSlotEmpty": {
     "placeholders": {

--- a/lib/pages/fit/tabs/character.dart
+++ b/lib/pages/fit/tabs/character.dart
@@ -192,6 +192,9 @@ class _CharacterImplantTab extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final fit = fitContext.fit;
     final implantAssignments = _buildImplantAssignments(fit, ref);
+    final hasImplantSets = ref.watch(
+      repoCollectionProvider.select((c) => (c?.getAllImplantSets().length ?? 0) > 0),
+    );
 
     return Column(
       children: [
@@ -199,6 +202,11 @@ class _CharacterImplantTab extends ConsumerWidget {
           title: context.l10n.implantSlot,
           issues: _collectFitIssuesForSection(context, ref, fitContext, _FitIssueSection.implant),
           actions: [
+            if (interactionOptions.allowMutations && hasImplantSets)
+              InkWell(
+                onTap: () => _handleApplyImplantSet(context, ref),
+                child: const Icon(Icons.auto_awesome),
+              ),
             if (interactionOptions.allowMutations)
               InkWell(onTap: () => _handleAddImplant(context, ref), child: const Icon(Icons.add)),
             if (interactionOptions.allowMutations)
@@ -248,6 +256,62 @@ class _CharacterImplantTab extends ConsumerWidget {
     final storageIndex = slotId == null ? null : slotId - 1;
     if (storageIndex == null || storageIndex < 0 || storageIndex >= _maxImplantSlots) return;
     await fitContext.fitWrapper.equipSlot(SlotIdentifier.implant(index: storageIndex), typeId, ref);
+  }
+
+  Future<void> _handleApplyImplantSet(BuildContext context, WidgetRef ref) async {
+    final collection = ref.read(repoCollectionProvider);
+    if (collection == null) return;
+    final sets = collection.getAllImplantSets();
+    if (sets.isEmpty) return;
+
+    final setId = await showDialog<int>(
+      context: context,
+      builder: (context) => _ImplantSetDialog(sets: sets),
+    );
+    if (setId == null) return;
+    final implantSet = collection.getImplantSet(setId);
+    if (implantSet == null) return;
+    await fitContext.fitWrapper.applyImplantSet(implantSet.memberTypeIds, ref);
+  }
+}
+
+class _ImplantSetDialog extends ConsumerWidget {
+  const _ImplantSetDialog({required this.sets});
+
+  final IList<ImplantSet> sets;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(localeProvider).name;
+    final sorted = sets.toList()
+      ..sort((left, right) {
+        final family = left.effectId.compareTo(right.effectId);
+        return family != 0 ? family : left.setId.compareTo(right.setId);
+      });
+
+    String nameOf(ImplantSet set) {
+      final names = set.names;
+      final name = names[locale] ?? names["en"];
+      if (name != null && name.isNotEmpty) return name;
+      return names.values.isEmpty ? "${set.setId}" : names.values.first;
+    }
+
+    return AppDialog(
+      title: context.l10n.fitImplantSetDialogTitle,
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final set in sorted)
+              ListTile(
+                title: Text(nameOf(set)),
+                trailing: Text("×${set.memberTypeIds.length}"),
+                onTap: () => Navigator.of(context).pop(set.setId),
+              ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/pages/fit/tabs/character.dart
+++ b/lib/pages/fit/tabs/character.dart
@@ -203,9 +203,12 @@ class _CharacterImplantTab extends ConsumerWidget {
           issues: _collectFitIssuesForSection(context, ref, fitContext, _FitIssueSection.implant),
           actions: [
             if (interactionOptions.allowMutations && hasImplantSets)
-              InkWell(
-                onTap: () => _handleApplyImplantSet(context, ref),
-                child: const Icon(Icons.dashboard_customize),
+              Tooltip(
+                message: context.l10n.fitImplantSetDialogTitle,
+                child: InkWell(
+                  onTap: () => _handleApplyImplantSet(context, ref),
+                  child: const Icon(Icons.dashboard_customize),
+                ),
               ),
             if (interactionOptions.allowMutations)
               InkWell(onTap: () => _handleAddImplant(context, ref), child: const Icon(Icons.add)),

--- a/lib/pages/fit/tabs/character.dart
+++ b/lib/pages/fit/tabs/character.dart
@@ -205,7 +205,7 @@ class _CharacterImplantTab extends ConsumerWidget {
             if (interactionOptions.allowMutations && hasImplantSets)
               InkWell(
                 onTap: () => _handleApplyImplantSet(context, ref),
-                child: const Icon(Icons.auto_awesome),
+                child: const Icon(Icons.dashboard_customize),
               ),
             if (interactionOptions.allowMutations)
               InkWell(onTap: () => _handleAddImplant(context, ref), child: const Icon(Icons.add)),

--- a/lib/pages/fit/tabs/character.dart
+++ b/lib/pages/fit/tabs/character.dart
@@ -283,18 +283,20 @@ class _ImplantSetDialog extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = ref.watch(localeProvider).name;
-    final sorted = sets.toList()
-      ..sort((left, right) {
-        final family = left.effectId.compareTo(right.effectId);
-        return family != 0 ? family : left.setId.compareTo(right.setId);
-      });
 
-    String nameOf(ImplantSet set) {
-      final names = set.names;
-      final name = names[locale] ?? names["en"];
-      if (name != null && name.isNotEmpty) return name;
-      return names.values.isEmpty ? "${set.setId}" : names.values.first;
+    String nameOf(ImplantSet set) => _localized(set.names, locale, "${set.setId}");
+    String familyOf(ImplantSet set) => _localized(set.familyNames, locale, nameOf(set));
+
+    // Sets of one family share setId ~/ 100; grade ranks ascend with strength.
+    final families = <int, List<ImplantSet>>{};
+    for (final set in sets) {
+      families.putIfAbsent(set.setId ~/ 100, () => []).add(set);
     }
+    for (final members in families.values) {
+      members.sort((left, right) => left.setId.compareTo(right.setId));
+    }
+    final sortedFamilies = families.values.toList()
+      ..sort((left, right) => familyOf(left.first).compareTo(familyOf(right.first)));
 
     return AppDialog(
       title: context.l10n.fitImplantSetDialogTitle,
@@ -302,17 +304,41 @@ class _ImplantSetDialog extends ConsumerWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            for (final set in sorted)
-              ListTile(
-                title: Text(nameOf(set)),
-                trailing: Text("×${set.memberTypeIds.length}"),
-                onTap: () => Navigator.of(context).pop(set.setId),
-              ),
+            for (final members in sortedFamilies)
+              if (members.length == 1)
+                _ImplantSetTile(set: members.single, title: nameOf(members.single))
+              else
+                ExpansionTile(
+                  title: Text(familyOf(members.first)),
+                  children: [
+                    for (final set in members) _ImplantSetTile(set: set, title: nameOf(set)),
+                  ],
+                ),
           ],
         ),
       ),
     );
   }
+
+  static String _localized(Map<String, String> names, String locale, String fallback) {
+    final name = names[locale] ?? names["en"];
+    if (name != null && name.isNotEmpty) return name;
+    return names.values.isEmpty ? fallback : names.values.first;
+  }
+}
+
+class _ImplantSetTile extends StatelessWidget {
+  const _ImplantSetTile({required this.set, required this.title});
+
+  final ImplantSet set;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) => ListTile(
+    title: Text(title),
+    trailing: Text("×${set.memberTypeIds.length}"),
+    onTap: () => Navigator.of(context).pop(set.setId),
+  );
 }
 
 class _CharacterBoosterTab extends ConsumerWidget {

--- a/lib/pages/fit/wrapper.dart
+++ b/lib/pages/fit/wrapper.dart
@@ -291,6 +291,39 @@ class FitWrapper {
     return fit.copyWith(body: fit.body.copyWith(implants: implants.toIList()));
   });
 
+  // Applies a whole implant set in a single update: set members replace any
+  // implant occupying one of the set's slots; implants in other slots are kept.
+  Future<void> applyImplantSet(Iterable<int> memberTypeIds, WidgetRef ref) => wrapped.update((fit) {
+    final slotsInfo = ref.read(repoCollectionProvider.select((c) => c?.slots));
+    if (slotsInfo == null) return fit;
+
+    final setSlots = <int>{};
+    final members = <FitImplantItem>[];
+    for (final typeId in memberTypeIds) {
+      final slotIndex = slotsInfo.implantSlots[typeId]?.slotIndex;
+      if (slotIndex == null || slotIndex < 1) continue;
+      setSlots.add(slotIndex);
+      members.add(
+        FitImplantItem(
+          itemId: FitStorageItemId.item(id: typeId),
+          state: FitItemState.online,
+        ),
+      );
+    }
+    if (members.isEmpty) return fit;
+
+    final kept = fit.body.implants.where((implant) {
+      final typeId = switch (implant.itemId) {
+        FitStorageItemIdItem(:final id) => id,
+        _ => null,
+      };
+      final slotIndex = typeId == null ? null : slotsInfo.implantSlots[typeId]?.slotIndex;
+      return slotIndex == null || !setSlots.contains(slotIndex);
+    });
+
+    return fit.copyWith(body: fit.body.copyWith(implants: IList([...kept, ...members])));
+  });
+
   Future<void> toggleImplantForSlot(int slotId, WidgetRef ref) => wrapped.update((fit) {
     final existingIndex = findImplantStorageIndex(fit, slotId, ref);
     if (existingIndex == null) return fit;

--- a/lib/storage/repo/collection.dart
+++ b/lib/storage/repo/collection.dart
@@ -77,6 +77,8 @@ class RepoCollectionService {
     required IMap<int, pb_materials.TypeMaterial> typeMaterials,
     required IMap<int, pb_dynamic.DynamicMutator> dynamicMutators,
     required IMap<int, pb_dynamic.DynamicTypeOptions> dynamicTypeOptions,
+    required IMap<int, ImplantSet> implantSets,
+    required IMap<int, int> implantTypeToSet,
   }) : _collection = collection,
        _localizedNames = localizedNames,
        _ships = ships,
@@ -92,7 +94,9 @@ class RepoCollectionService {
        _subsystems = subsystems,
        _typeMaterials = typeMaterials,
        _dynamicMutators = dynamicMutators,
-       _dynamicTypeOptions = dynamicTypeOptions;
+       _dynamicTypeOptions = dynamicTypeOptions,
+       _implantSets = implantSets,
+       _implantTypeToSet = implantTypeToSet;
 
   /// Builds a [RepoCollectionService] from a [Collection] protobuf for testing.
   ///
@@ -129,6 +133,8 @@ class RepoCollectionService {
       typeMaterials: const IMap.empty(),
       dynamicMutators: const IMap.empty(),
       dynamicTypeOptions: const IMap.empty(),
+      implantSets: const IMap.empty(),
+      implantTypeToSet: const IMap.empty(),
     );
   }
 
@@ -190,6 +196,13 @@ class RepoCollectionService {
     final dynamicTypeOptions = IMap.fromEntries(
       collection.dynamicTypeOptions.entries.map((e) => MapEntry(e.key, e.value)),
     );
+    final implantSets = IMap.fromEntries(
+      collection.implantSets.entries.map((e) => MapEntry(e.key, e.value)),
+    );
+    final implantTypeToSet = IMap.fromEntries([
+      for (final set in implantSets.values)
+        for (final typeId in set.memberTypeIds) MapEntry(typeId, set.setId),
+    ]);
 
     // Derive skill type IDs
     final skillGroupIds = collection.groups.values
@@ -243,6 +256,8 @@ class RepoCollectionService {
       typeMaterials: typeMaterials,
       dynamicMutators: dynamicMutators,
       dynamicTypeOptions: dynamicTypeOptions,
+      implantSets: implantSets,
+      implantTypeToSet: implantTypeToSet,
     );
   }
 
@@ -265,6 +280,8 @@ class RepoCollectionService {
   final IMap<int, pb_materials.TypeMaterial> _typeMaterials;
   final IMap<int, pb_dynamic.DynamicMutator> _dynamicMutators;
   final IMap<int, pb_dynamic.DynamicTypeOptions> _dynamicTypeOptions;
+  final IMap<int, ImplantSet> _implantSets;
+  final IMap<int, int> _implantTypeToSet;
 
   // ── Query surface ──
 
@@ -285,6 +302,19 @@ class RepoCollectionService {
   pb_materials.TypeMaterial? getTypeMaterial(int typeId) => _typeMaterials[typeId];
   pb_dynamic.DynamicMutator? getDynamicMutator(int mutatorId) => _dynamicMutators[mutatorId];
   pb_dynamic.DynamicTypeOptions? getDynamicTypeOptions(int typeId) => _dynamicTypeOptions[typeId];
+
+  /// Returns the implant set with the given [setId], or `null` when absent
+  /// (e.g. older bundles without implant set metadata).
+  ImplantSet? getImplantSet(int setId) => _implantSets[setId];
+
+  /// Returns the implant set containing the implant [typeId], or `null` when
+  /// the type belongs to no set or set metadata is unavailable.
+  ImplantSet? getImplantSetForType(int typeId) {
+    final setId = _implantTypeToSet[typeId];
+    return setId == null ? null : _implantSets[setId];
+  }
+
+  IList<ImplantSet> getAllImplantSets() => _implantSets.values.toIList();
 
   IList<pb_categories.Category> getAllCategories() => _categories.values.toIList();
   IList<pb_groups.Group> getAllGroups() => _groups.values.toIList();


### PR DESCRIPTION
Closes #233 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added implant-set metadata with localized names and membership details.
  * Added an “Apply Implant Set” action to fitting workflows.
  * Users can browse implant sets by family, view member counts, and apply a selected set to a fit.
  * Added English and Chinese localization for the implant-set dialog.

* **Bug Fixes**
  * Applying a set now replaces implants in matching slots while preserving others.

* **Tests**
  * Added coverage for implant-set detection, grouping, naming, ranking, and identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->