### PR TITLE
feat(market_price): add fit price breakdown detail page

### DIFF
--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -830,5 +830,11 @@
   "dataUpdateDialogDone": "Done",
   "dataUpdateDialogCancel": "Cancel",
   "dataUpdateDialogClose": "Close",
-  "dataUpdateBannerText": "New game data available"
+  "dataUpdateBannerText": "New game data available",
+  "priceDetailTitle": "[{shipName}] - {fitName}",
+  "priceDetailSell": "Sell",
+  "priceDetailBuy": "Buy",
+  "priceDetailUnavailable": "N/A",
+  "priceDetailLoadFailed": "Failed to load prices",
+  "priceDetailNoData": "No price data available"
 }

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -834,6 +834,8 @@
   "priceDetailTitle": "[{shipName}] - {fitName}",
   "priceDetailSell": "Sell",
   "priceDetailBuy": "Buy",
+  "priceDetailUnit": "Unit",
+  "priceDetailTotal": "Total",
   "priceDetailUnavailable": "N/A",
   "priceDetailLoadFailed": "Failed to load prices",
   "priceDetailNoData": "No price data available"

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -838,5 +838,6 @@
   "priceDetailTotal": "Total",
   "priceDetailUnavailable": "N/A",
   "priceDetailLoadFailed": "Failed to load prices",
-  "priceDetailNoData": "No price data available"
+  "priceDetailNoData": "No price data available",
+  "priceDetailPartial": "{count} price(s) failed to load; totals are incomplete"
 }

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -1828,5 +1828,11 @@
   "priceDetailTotal": "总价",
   "priceDetailUnavailable": "暂无",
   "priceDetailLoadFailed": "价格加载失败",
-  "priceDetailNoData": "暂无价格数据"
+  "priceDetailNoData": "暂无价格数据",
+  "priceDetailPartial": "{count} 项价格获取失败，总价不完整",
+  "@priceDetailPartial": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  }
 }

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -1824,6 +1824,8 @@
   },
   "priceDetailSell": "卖出",
   "priceDetailBuy": "买入",
+  "priceDetailUnit": "单价",
+  "priceDetailTotal": "总价",
   "priceDetailUnavailable": "暂无",
   "priceDetailLoadFailed": "价格加载失败",
   "priceDetailNoData": "暂无价格数据"

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -1813,5 +1813,18 @@
   "dataUpdateDialogDone": "完成",
   "dataUpdateDialogCancel": "取消",
   "dataUpdateDialogClose": "关闭",
-  "dataUpdateBannerText": "有新的游戏数据可用"
+  "dataUpdateBannerText": "有新的游戏数据可用",
+  "@@@_PRICE_DETAIL": {},
+  "priceDetailTitle": "[{shipName}] - {fitName}",
+  "@priceDetailTitle": {
+    "placeholders": {
+      "shipName": { "type": "String" },
+      "fitName": { "type": "String" }
+    }
+  },
+  "priceDetailSell": "卖出",
+  "priceDetailBuy": "买入",
+  "priceDetailUnavailable": "暂无",
+  "priceDetailLoadFailed": "价格加载失败",
+  "priceDetailNoData": "暂无价格数据"
 }

--- a/lib/features/market_price/models/fit_price.dart
+++ b/lib/features/market_price/models/fit_price.dart
@@ -18,3 +18,41 @@ class FitPriceSummary {
   /// Number of distinct types excluded because no price was available.
   final int unpricedTypeCount;
 }
+
+class TypePriceEstimate {
+  const TypePriceEstimate({this.sell, this.buy});
+
+  final double? sell;
+  final double? buy;
+}
+
+class FitPriceLineItem {
+  const FitPriceLineItem({
+    required this.typeId,
+    required this.quantity,
+    required this.unitSell,
+    required this.unitBuy,
+  });
+
+  final int typeId;
+  final int quantity;
+  final double? unitSell;
+  final double? unitBuy;
+
+  double? get totalSell => unitSell != null ? unitSell! * quantity : null;
+  double? get totalBuy => unitBuy != null ? unitBuy! * quantity : null;
+}
+
+/// Aggregated estimated price for a fit, broken down by line item.
+///
+/// The `totalSell` refers to the sum of the sell prices of all the items,
+/// which means if you want to *buy* the fit, you need to pay this amount.
+/// Conversely, the `totalBuy` refers to the sum of the buy prices of all the items,
+/// which means if you want to *sell* the fit, you will receive this amount.
+class FitPriceBreakdown {
+  const FitPriceBreakdown({required this.items, required this.totalSell, required this.totalBuy});
+
+  final List<FitPriceLineItem> items;
+  final double? totalSell;
+  final double? totalBuy;
+}

--- a/lib/features/market_price/models/fit_price.dart
+++ b/lib/features/market_price/models/fit_price.dart
@@ -50,9 +50,21 @@ class FitPriceLineItem {
 /// Conversely, the `totalBuy` refers to the sum of the buy prices of all the items,
 /// which means if you want to *sell* the fit, you will receive this amount.
 class FitPriceBreakdown {
-  const FitPriceBreakdown({required this.items, required this.totalSell, required this.totalBuy});
+  const FitPriceBreakdown({
+    required this.items,
+    required this.totalSell,
+    required this.totalBuy,
+    this.missingTypeCount = 0,
+  });
 
   final List<FitPriceLineItem> items;
   final double? totalSell;
   final double? totalBuy;
+
+  /// Number of requested types whose price lookup failed entirely.
+  ///
+  /// When non-zero the totals are incomplete and the UI should indicate this.
+  final int missingTypeCount;
+
+  bool get isPartial => missingTypeCount > 0;
 }

--- a/lib/features/market_price/models/price_response.dart
+++ b/lib/features/market_price/models/price_response.dart
@@ -14,6 +14,27 @@ double? extractEstimatedPrice(Map<String, dynamic> payload) {
   return _firstPositiveNumber(payload, const ["avg", "average", "median", "price"]);
 }
 
+double? extractSellPrice(Map<String, dynamic> payload) {
+  final sell = payload["sell"];
+  if (sell is Map<String, dynamic>) {
+    final price = _firstPositiveNumber(sell, const ["min", "avg", "average", "median", "max"]);
+    if (price != null) return price;
+  }
+  final all = payload["all"];
+  if (all is Map<String, dynamic>) {
+    return _firstPositiveNumber(all, const ["avg", "average", "median"]);
+  }
+  return null;
+}
+
+double? extractBuyPrice(Map<String, dynamic> payload) {
+  final buy = payload["buy"];
+  if (buy is Map<String, dynamic>) {
+    return _firstPositiveNumber(buy, const ["max", "avg", "average", "median", "min"]);
+  }
+  return null;
+}
+
 double? _firstPositiveNumber(Map<String, dynamic> map, List<String> keys) {
   for (final key in keys) {
     final raw = map[key];

--- a/lib/features/market_price/models/price_response.dart
+++ b/lib/features/market_price/models/price_response.dart
@@ -1,28 +1,27 @@
 /// Extracts an estimated unit price from a ceve-market price response.
 ///
-/// The lowest sell price (`sell.min`) is the preferred estimate. The upstream
-/// API is loosely specified, so parsing is defensive: known section/key
-/// combinations are probed in preference order and the first positive numeric
-/// value wins. Returns `null` when nothing usable is found.
+/// The lowest sell price (`sell.min`) is the preferred estimate. Sections are
+/// probed in preference order and the first positive numeric value wins.
+/// Returns `null` when nothing usable is found.
+///
+/// The API response shape is:
+/// ```json
+/// {"all":{"max":…,"min":…,"volume":…},"buy":{…},"sell":{…}}
+/// ```
 double? extractEstimatedPrice(Map<String, dynamic> payload) {
   for (final section in ["sell", "all", "buy"]) {
     final value = payload[section];
     if (value is! Map<String, dynamic>) continue;
-    final price = _firstPositiveNumber(value, const ["min", "avg", "average", "median", "max"]);
+    final price = _firstPositiveNumber(value, const ["min", "max"]);
     if (price != null) return price;
   }
-  return _firstPositiveNumber(payload, const ["avg", "average", "median", "price"]);
+  return null;
 }
 
 double? extractSellPrice(Map<String, dynamic> payload) {
   final sell = payload["sell"];
   if (sell is Map<String, dynamic>) {
-    final price = _firstPositiveNumber(sell, const ["min", "avg", "average", "median", "max"]);
-    if (price != null) return price;
-  }
-  final all = payload["all"];
-  if (all is Map<String, dynamic>) {
-    return _firstPositiveNumber(all, const ["avg", "average", "median"]);
+    return _firstPositiveNumber(sell, const ["min", "max"]);
   }
   return null;
 }
@@ -30,7 +29,7 @@ double? extractSellPrice(Map<String, dynamic> payload) {
 double? extractBuyPrice(Map<String, dynamic> payload) {
   final buy = payload["buy"];
   if (buy is Map<String, dynamic>) {
-    return _firstPositiveNumber(buy, const ["max", "avg", "average", "median", "min"]);
+    return _firstPositiveNumber(buy, const ["max", "min"]);
   }
   return null;
 }

--- a/lib/features/market_price/remote/market_price_client.dart
+++ b/lib/features/market_price/remote/market_price_client.dart
@@ -41,10 +41,14 @@ class MarketPriceClient {
   /// entry is used as a fallback. Returns `null` on any network, HTTP, or
   /// parse failure — price data is best-effort and individual failures must
   /// never propagate.
-  Future<double?> fetchPrice(int typeId) async {
+  Future<double?> fetchPrice(int typeId) => _fetch(typeId, _parsePrice);
+
+  Future<TypePriceEstimate?> fetchPriceBreakdown(int typeId) => _fetch(typeId, _parseBreakdown);
+
+  Future<T?> _fetch<T>(int typeId, T? Function(Map<String, dynamic>) parse) async {
     final uri = priceUriFor(typeId);
     try {
-      final fresh = await _readFreshCache(uri);
+      final fresh = await _readFreshCache(uri, parse);
       if (fresh != null) return fresh;
 
       final response = await _dio.getUri<String>(
@@ -56,7 +60,7 @@ class MarketPriceClient {
       );
       final data = response.data;
       if (data == null) return null;
-      return _parseBody(data);
+      return _decodeBody(data, parse);
     } on FormatException {
       return null;
     } on Object catch (e, stackTrace) {
@@ -65,36 +69,12 @@ class MarketPriceClient {
     }
   }
 
-  Future<TypePriceEstimate?> fetchPriceBreakdown(int typeId) async {
-    final uri = priceUriFor(typeId);
-    try {
-      final fresh = await _readFreshCacheRaw(uri);
-      if (fresh != null) return fresh;
-
-      final response = await _dio.getUri<String>(
-        uri,
-        options: _cacheOptions
-            .copyWith(policy: CachePolicy.refreshForceCache, hitCacheOnNetworkFailure: true)
-            .toOptions()
-            .copyWith(responseType: ResponseType.plain),
-      );
-      final data = response.data;
-      if (data == null) return null;
-      return _parseBodyBreakdown(data);
-    } on FormatException {
-      return null;
-    } on Object catch (e, stackTrace) {
-      debug("Market price breakdown fetch failed for type $typeId: $e", stackTrace: stackTrace);
-      return null;
-    }
-  }
-
-  /// Returns the cached price for [uri] when the entry is younger than
+  /// Returns the cached value for [uri] when the entry is younger than
   /// [marketPriceMaxStale], or `null` when missing, stale, or unreadable.
   ///
   /// The age is anchored to the entry's fetch time (`responseDate`), so
   /// repeated reads can never extend the freshness window.
-  Future<double?> _readFreshCache(Uri uri) async {
+  Future<T?> _readFreshCache<T>(Uri uri, T? Function(Map<String, dynamic>) parse) async {
     final store = _cacheOptions.store;
     if (store == null) return null;
     try {
@@ -109,7 +89,7 @@ class MarketPriceClient {
         readBody: true,
       )).content;
       if (content == null) return null;
-      return _parseBody(utf8.decode(content));
+      return _decodeBody(utf8.decode(content), parse);
     } on FormatException {
       return null;
     } on Object catch (e, stackTrace) {
@@ -118,46 +98,21 @@ class MarketPriceClient {
     }
   }
 
-  Future<TypePriceEstimate?> _readFreshCacheRaw(Uri uri) async {
-    final store = _cacheOptions.store;
-    if (store == null) return null;
-    try {
-      final key = _cacheOptions.keyBuilder(url: uri);
-      final cached = await store.get(key);
-      if (cached == null) return null;
-      final age = DateTime.now().toUtc().difference(cached.responseDate);
-      if (age >= marketPriceMaxStale) return null;
-      final content = (await cached.readContent(
-        _cacheOptions,
-        readHeaders: false,
-        readBody: true,
-      )).content;
-      if (content == null) return null;
-      return _parseBodyBreakdown(utf8.decode(content));
-    } on FormatException {
-      return null;
-    } on Object catch (e, stackTrace) {
-      debug("Market price cache read failed for $uri: $e", stackTrace: stackTrace);
-      return null;
-    }
-  }
-
-  /// Parses a response body. The upstream API serves HTML error pages (e.g.
-  /// for unknown types) with a 200 status; those are simply "no price", not
-  /// failures.
-  double? _parseBody(String data) {
+  /// Decodes a JSON response body and applies [parse]. The upstream API
+  /// serves HTML error pages (e.g. for unknown types) with a 200 status;
+  /// those are simply "no data", not failures.
+  T? _decodeBody<T>(String data, T? Function(Map<String, dynamic>) parse) {
     if (!data.trimLeft().startsWith("{")) return null;
     final decoded = jsonDecode(data);
     if (decoded is! Map<String, dynamic>) return null;
-    return extractEstimatedPrice(decoded);
+    return parse(decoded);
   }
 
-  TypePriceEstimate? _parseBodyBreakdown(String data) {
-    if (!data.trimLeft().startsWith("{")) return null;
-    final decoded = jsonDecode(data);
-    if (decoded is! Map<String, dynamic>) return null;
-    final sell = extractSellPrice(decoded);
-    final buy = extractBuyPrice(decoded);
+  static double? _parsePrice(Map<String, dynamic> payload) => extractEstimatedPrice(payload);
+
+  static TypePriceEstimate? _parseBreakdown(Map<String, dynamic> payload) {
+    final sell = extractSellPrice(payload);
+    final buy = extractBuyPrice(payload);
     if (sell == null && buy == null) return null;
     return TypePriceEstimate(sell: sell, buy: buy);
   }

--- a/lib/features/market_price/remote/market_price_client.dart
+++ b/lib/features/market_price/remote/market_price_client.dart
@@ -65,6 +65,30 @@ class MarketPriceClient {
     }
   }
 
+  Future<TypePriceEstimate?> fetchPriceBreakdown(int typeId) async {
+    final uri = priceUriFor(typeId);
+    try {
+      final fresh = await _readFreshCacheRaw(uri);
+      if (fresh != null) return fresh;
+
+      final response = await _dio.getUri<String>(
+        uri,
+        options: _cacheOptions
+            .copyWith(policy: CachePolicy.refreshForceCache, hitCacheOnNetworkFailure: true)
+            .toOptions()
+            .copyWith(responseType: ResponseType.plain),
+      );
+      final data = response.data;
+      if (data == null) return null;
+      return _parseBodyBreakdown(data);
+    } on FormatException {
+      return null;
+    } on Object catch (e, stackTrace) {
+      debug("Market price breakdown fetch failed for type $typeId: $e", stackTrace: stackTrace);
+      return null;
+    }
+  }
+
   /// Returns the cached price for [uri] when the entry is younger than
   /// [marketPriceMaxStale], or `null` when missing, stale, or unreadable.
   ///
@@ -94,6 +118,30 @@ class MarketPriceClient {
     }
   }
 
+  Future<TypePriceEstimate?> _readFreshCacheRaw(Uri uri) async {
+    final store = _cacheOptions.store;
+    if (store == null) return null;
+    try {
+      final key = _cacheOptions.keyBuilder(url: uri);
+      final cached = await store.get(key);
+      if (cached == null) return null;
+      final age = DateTime.now().toUtc().difference(cached.responseDate);
+      if (age >= marketPriceMaxStale) return null;
+      final content = (await cached.readContent(
+        _cacheOptions,
+        readHeaders: false,
+        readBody: true,
+      )).content;
+      if (content == null) return null;
+      return _parseBodyBreakdown(utf8.decode(content));
+    } on FormatException {
+      return null;
+    } on Object catch (e, stackTrace) {
+      debug("Market price cache read failed for $uri: $e", stackTrace: stackTrace);
+      return null;
+    }
+  }
+
   /// Parses a response body. The upstream API serves HTML error pages (e.g.
   /// for unknown types) with a 200 status; those are simply "no price", not
   /// failures.
@@ -102,6 +150,16 @@ class MarketPriceClient {
     final decoded = jsonDecode(data);
     if (decoded is! Map<String, dynamic>) return null;
     return extractEstimatedPrice(decoded);
+  }
+
+  TypePriceEstimate? _parseBodyBreakdown(String data) {
+    if (!data.trimLeft().startsWith("{")) return null;
+    final decoded = jsonDecode(data);
+    if (decoded is! Map<String, dynamic>) return null;
+    final sell = extractSellPrice(decoded);
+    final buy = extractBuyPrice(decoded);
+    if (sell == null && buy == null) return null;
+    return TypePriceEstimate(sell: sell, buy: buy);
   }
 
   void dispose() => _dio.close();

--- a/lib/features/market_price/state/market_price_service.dart
+++ b/lib/features/market_price/state/market_price_service.dart
@@ -36,13 +36,23 @@ MarketServer? marketPriceServer(Ref ref) {
 /// Shared worker pool for price fetches, or `null` when the feature is
 /// disabled for the active checkout.
 @riverpodSingleton
-PriceWorkerPool? marketPriceWorkerPool(Ref ref) {
+PriceWorkerPool<double>? marketPriceWorkerPool(Ref ref) {
   final server = ref.watch(marketPriceServerProvider);
   if (server == null) return null;
 
   final client = MarketPriceClient(server: server);
   ref.onDispose(client.dispose);
-  return PriceWorkerPool(fetcher: client.fetchPrice);
+  return PriceWorkerPool<double>(fetcher: client.fetchPrice);
+}
+
+@riverpodSingleton
+PriceWorkerPool<TypePriceEstimate>? marketPriceBreakdownPool(Ref ref) {
+  final server = ref.watch(marketPriceServerProvider);
+  if (server == null) return null;
+
+  final client = MarketPriceClient(server: server);
+  ref.onDispose(client.dispose);
+  return PriceWorkerPool<TypePriceEstimate>(fetcher: client.fetchPriceBreakdown);
 }
 
 /// Enumerates the distinct typeIDs of a fit with their total quantities.
@@ -137,4 +147,40 @@ Future<FitPriceSummary?> fitEstimatedPrice(Ref ref, String fitId) async {
     pricedTypeCount: pricedCount,
     unpricedTypeCount: unpricedCount,
   );
+}
+
+@riverpod
+Future<FitPriceBreakdown?> fitPriceBreakdown(Ref ref, String fitId) async {
+  final pool = ref.watch(marketPriceBreakdownPoolProvider);
+  if (pool == null) return null;
+
+  final fitState = ref.watch(fitProvider(fitId));
+  if (!fitState.isInitialized) return null;
+
+  final quantities = collectFitTypeQuantities(fitState.fit);
+  if (quantities.isEmpty) return null;
+
+  final entries = quantities.entries.toList();
+  final estimates = await Future.wait(entries.map((entry) => pool.request(typeId: entry.key)));
+
+  final items = <FitPriceLineItem>[];
+  double? totalSell;
+  double? totalBuy;
+  for (final (index, estimate) in estimates.indexed) {
+    if (estimate == null) continue;
+    final quantity = entries[index].value;
+    items.add(
+      FitPriceLineItem(
+        typeId: entries[index].key,
+        quantity: quantity,
+        unitSell: estimate.sell,
+        unitBuy: estimate.buy,
+      ),
+    );
+    if (estimate.sell != null) totalSell = (totalSell ?? 0) + estimate.sell! * quantity;
+    if (estimate.buy != null) totalBuy = (totalBuy ?? 0) + estimate.buy! * quantity;
+  }
+  if (items.isEmpty) return null;
+
+  return FitPriceBreakdown(items: items, totalSell: totalSell, totalBuy: totalBuy);
 }

--- a/lib/features/market_price/state/market_price_service.dart
+++ b/lib/features/market_price/state/market_price_service.dart
@@ -33,25 +33,32 @@ MarketServer? marketPriceServer(Ref ref) {
   return MarketServer.parse(ref.watch(appSettingServiceProvider).marketServerFallback);
 }
 
-/// Shared worker pool for price fetches, or `null` when the feature is
-/// disabled for the active checkout.
+/// Shared [MarketPriceClient] for the active market server, or `null` when the
+/// feature is disabled. Both worker pools reuse this single client (and its
+/// underlying Dio connection pool + Hive-backed HTTP cache).
 @riverpodSingleton
-PriceWorkerPool<double>? marketPriceWorkerPool(Ref ref) {
+MarketPriceClient? marketPriceClient(Ref ref) {
   final server = ref.watch(marketPriceServerProvider);
   if (server == null) return null;
 
   final client = MarketPriceClient(server: server);
   ref.onDispose(client.dispose);
+  return client;
+}
+
+/// Shared worker pool for price fetches, or `null` when the feature is
+/// disabled for the active checkout.
+@riverpodSingleton
+PriceWorkerPool<double>? marketPriceWorkerPool(Ref ref) {
+  final client = ref.watch(marketPriceClientProvider);
+  if (client == null) return null;
   return PriceWorkerPool<double>(fetcher: client.fetchPrice);
 }
 
 @riverpodSingleton
 PriceWorkerPool<TypePriceEstimate>? marketPriceBreakdownPool(Ref ref) {
-  final server = ref.watch(marketPriceServerProvider);
-  if (server == null) return null;
-
-  final client = MarketPriceClient(server: server);
-  ref.onDispose(client.dispose);
+  final client = ref.watch(marketPriceClientProvider);
+  if (client == null) return null;
   return PriceWorkerPool<TypePriceEstimate>(fetcher: client.fetchPriceBreakdown);
 }
 

--- a/lib/features/market_price/state/market_price_service.dart
+++ b/lib/features/market_price/state/market_price_service.dart
@@ -173,8 +173,12 @@ Future<FitPriceBreakdown?> fitPriceBreakdown(Ref ref, String fitId) async {
   final items = <FitPriceLineItem>[];
   double? totalSell;
   double? totalBuy;
+  var missingTypeCount = 0;
   for (final (index, estimate) in estimates.indexed) {
-    if (estimate == null) continue;
+    if (estimate == null) {
+      missingTypeCount++;
+      continue;
+    }
     final quantity = entries[index].value;
     items.add(
       FitPriceLineItem(
@@ -189,5 +193,10 @@ Future<FitPriceBreakdown?> fitPriceBreakdown(Ref ref, String fitId) async {
   }
   if (items.isEmpty) return null;
 
-  return FitPriceBreakdown(items: items, totalSell: totalSell, totalBuy: totalBuy);
+  return FitPriceBreakdown(
+    items: items,
+    totalSell: totalSell,
+    totalBuy: totalBuy,
+    missingTypeCount: missingTypeCount,
+  );
 }

--- a/lib/features/market_price/state/price_worker_pool.dart
+++ b/lib/features/market_price/state/price_worker_pool.dart
@@ -1,14 +1,14 @@
 import "dart:async";
 import "dart:collection";
 
-/// Fetches the unit price for a typeID; `null` when unavailable.
-typedef PriceFetcher = Future<double?> Function(int typeId);
+/// Fetches a value for a typeID; `null` when unavailable.
+typedef PriceFetcher<T> = Future<T?> Function(int typeId);
 
-class _PriceRequest {
+class _PriceRequest<T> {
   _PriceRequest({required this.typeId});
 
   final int typeId;
-  final Completer<double?> completer = Completer<double?>();
+  final Completer<T?> completer = Completer<T?>();
 }
 
 /// Fixed pool of workers draining a queue of price requests.
@@ -18,25 +18,25 @@ class _PriceRequest {
 /// - At most `workerCount` fetches run concurrently (default 4), shielding
 ///   the fragile upstream API from request bursts when a fit opens.
 /// - Individual failures resolve to `null`; they never fail other requests.
-class PriceWorkerPool {
-  PriceWorkerPool({required PriceFetcher fetcher, int workerCount = defaultWorkerCount})
+class PriceWorkerPool<T> {
+  PriceWorkerPool({required PriceFetcher<T> fetcher, int workerCount = defaultWorkerCount})
     : _fetcher = fetcher,
       _workerCount = workerCount;
 
   static const defaultWorkerCount = 4;
 
-  final PriceFetcher _fetcher;
+  final PriceFetcher<T> _fetcher;
   final int _workerCount;
-  final Queue<_PriceRequest> _queue = Queue<_PriceRequest>();
-  final Map<int, _PriceRequest> _pending = {};
+  final Queue<_PriceRequest<T>> _queue = Queue<_PriceRequest<T>>();
+  final Map<int, _PriceRequest<T>> _pending = {};
   var _activeWorkers = 0;
 
-  /// Requests the unit price for [typeId].
-  Future<double?> request({required int typeId}) {
+  /// Requests the value for [typeId].
+  Future<T?> request({required int typeId}) {
     final existing = _pending[typeId];
     if (existing != null) return existing.completer.future;
 
-    final request = _PriceRequest(typeId: typeId);
+    final request = _PriceRequest<T>(typeId: typeId);
     _pending[typeId] = request;
     _queue.add(request);
     _pump();
@@ -51,7 +51,7 @@ class PriceWorkerPool {
     }
   }
 
-  Future<void> _work(_PriceRequest request) async {
+  Future<void> _work(_PriceRequest<T> request) async {
     try {
       final price = await _fetcher(request.typeId);
       request.completer.complete(price);

--- a/lib/features/market_price/ui/fit_price_tile.dart
+++ b/lib/features/market_price/ui/fit_price_tile.dart
@@ -1,4 +1,5 @@
 import "package:eve_fit_assistant/features/market_price/state/state.dart";
+import "package:eve_fit_assistant/features/market_price/ui/price_detail_page.dart";
 import "package:eve_fit_assistant/utils/context.dart";
 import "package:eve_fit_assistant/utils/num.dart";
 import "package:flutter/material.dart";
@@ -40,6 +41,7 @@ class FitPriceTile extends ConsumerWidget {
                 ),
               ),
       ),
+      onLongPress: () => showPriceDetailPage(context, fitId: fitId),
     );
   }
 }

--- a/lib/features/market_price/ui/price_detail_page.dart
+++ b/lib/features/market_price/ui/price_detail_page.dart
@@ -359,10 +359,40 @@ class _PriceItemTable extends ConsumerWidget {
           5: IntrinsicColumnWidth(),
         },
         defaultVerticalAlignment: TableCellVerticalAlignment.middle,
-        children: [for (final item in items) _buildRow(context, ref, item)],
+        children: [
+          _buildHeaderRow(context),
+          for (final item in items) _buildRow(context, ref, item),
+        ],
       ),
     ),
   );
+
+  TableRow _buildHeaderRow(BuildContext context) {
+    final l10n = context.l10n;
+    final sellColor = Colors.red.shade700;
+    final buyColor = Colors.green.shade700;
+    final style = context.theme.textTheme.labelSmall;
+
+    Widget headerCell(String text, Color color) => Padding(
+      padding: const EdgeInsets.only(left: 16, bottom: 4),
+      child: Text(
+        text,
+        textAlign: TextAlign.end,
+        style: style?.copyWith(color: color, fontWeight: FontWeight.w600),
+      ),
+    );
+
+    return TableRow(
+      children: [
+        const SizedBox.shrink(),
+        const SizedBox.shrink(),
+        headerCell("${_PriceSide.buy.label(context)} ${l10n.priceDetailUnit}", sellColor),
+        headerCell("${_PriceSide.buy.label(context)} ${l10n.priceDetailTotal}", sellColor),
+        headerCell("${_PriceSide.sell.label(context)} ${l10n.priceDetailUnit}", buyColor),
+        headerCell("${_PriceSide.sell.label(context)} ${l10n.priceDetailTotal}", buyColor),
+      ],
+    );
+  }
 
   TableRow _buildRow(BuildContext context, WidgetRef ref, FitPriceLineItem item) {
     final type = ref.watch(repoCollectionProvider.select((c) => c?.getType(item.typeId)));

--- a/lib/features/market_price/ui/price_detail_page.dart
+++ b/lib/features/market_price/ui/price_detail_page.dart
@@ -1,0 +1,427 @@
+import "package:eve_fit_assistant/components/icon/eve_icon.dart";
+import "package:eve_fit_assistant/components/localized_text.dart";
+import "package:eve_fit_assistant/features/market_price/models/models.dart";
+import "package:eve_fit_assistant/features/market_price/state/state.dart";
+import "package:eve_fit_assistant/pages/item-detail/page.dart";
+import "package:eve_fit_assistant/storage/fit/service.dart";
+import "package:eve_fit_assistant/storage/repo/collection.dart";
+import "package:eve_fit_assistant/utils/context.dart";
+import "package:eve_fit_assistant/utils/num.dart";
+import "package:eve_fit_assistant/utils/screen.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+Future<void> showPriceDetailPage(BuildContext context, {required String fitId}) => Navigator.of(
+  context,
+).push(MaterialPageRoute<void>(builder: (context) => PriceDetailPage(fitId: fitId)));
+
+class PriceDetailPage extends ConsumerWidget {
+  const PriceDetailPage({required this.fitId, super.key});
+
+  final String fitId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final fitState = ref.watch(fitProvider(fitId));
+    if (!fitState.isInitialized) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const SafeArea(child: Center(child: CircularProgressIndicator())),
+      );
+    }
+
+    final fit = fitState.fit;
+    final shipTypeId = fit.body.shipTypeId;
+    final shipType = ref.watch(repoCollectionProvider.select((c) => c?.getType(shipTypeId)));
+    final locale = context.locale.languageCode;
+    final shipName = shipType != null
+        ? ref.watch(
+                repoCollectionProvider.select(
+                  (c) => c?.getLocalizedName(shipType.typeName.id, locale),
+                ),
+              ) ??
+              ""
+        : "";
+    final title = context.l10n.priceDetailTitle(shipName: shipName, fitName: fit.metadata.name);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: SafeArea(
+        child: _PriceBreakdownBody(
+          fitId: fitId,
+          shipTypeId: shipTypeId,
+          fitName: fit.metadata.name,
+        ),
+      ),
+    );
+  }
+}
+
+class _PriceBreakdownBody extends ConsumerWidget {
+  const _PriceBreakdownBody({required this.fitId, required this.shipTypeId, required this.fitName});
+
+  final String fitId;
+  final int shipTypeId;
+  final String fitName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final breakdown = ref.watch(fitPriceBreakdownProvider(fitId));
+
+    return breakdown.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (_, _) => Center(child: Text(context.l10n.priceDetailLoadFailed)),
+      data: (value) {
+        if (value == null) {
+          return Center(child: Text(context.l10n.priceDetailNoData));
+        }
+        return _PriceBreakdownList(breakdown: value, shipTypeId: shipTypeId, fitName: fitName);
+      },
+    );
+  }
+}
+
+class _PriceBreakdownList extends ConsumerWidget {
+  const _PriceBreakdownList({
+    required this.breakdown,
+    required this.shipTypeId,
+    required this.fitName,
+  });
+
+  final FitPriceBreakdown breakdown;
+  final int shipTypeId;
+  final String fitName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final columns = columnCount(context);
+
+    if (columns >= 2) {
+      return ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          _HeaderTile(shipTypeId: shipTypeId, fitName: fitName),
+          const SizedBox(height: 4),
+          _SummarySection(breakdown: breakdown, columns: columns),
+          const Divider(height: 16, indent: 16, endIndent: 16),
+          _PriceItemTable(items: breakdown.items),
+        ],
+      );
+    }
+
+    return _SingleColumnTabs(breakdown: breakdown, shipTypeId: shipTypeId, fitName: fitName);
+  }
+}
+
+class _HeaderTile extends ConsumerWidget {
+  const _HeaderTile({required this.shipTypeId, required this.fitName});
+
+  final int shipTypeId;
+  final String fitName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final shipType = ref.watch(repoCollectionProvider.select((c) => c?.getType(shipTypeId)));
+    final locale = context.locale.languageCode;
+    final shipName = shipType != null
+        ? ref.watch(
+                repoCollectionProvider.select(
+                  (c) => c?.getLocalizedName(shipType.typeName.id, locale),
+                ),
+              ) ??
+              ""
+        : "";
+
+    return ListTile(
+      minTileHeight: 0,
+      leading: shipType != null ? EveIcon(icon: shipType.icon, size: 32) : null,
+      title: Text(
+        context.l10n.priceDetailTitle(shipName: shipName, fitName: fitName),
+        style: context.theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}
+
+class _SummarySection extends StatelessWidget {
+  const _SummarySection({required this.breakdown, required this.columns});
+
+  final FitPriceBreakdown breakdown;
+  final int columns;
+
+  @override
+  Widget build(BuildContext context) {
+    // The labels are reversed relative to the breakdown fields because of the
+    // way the breakdown is calculated. See its documentation for more details.
+    final buy = _SummaryTile(
+      label: context.l10n.priceDetailBuy,
+      value: breakdown.totalSell,
+      color: Colors.red.shade700,
+    );
+    final sell = _SummaryTile(
+      label: context.l10n.priceDetailSell,
+      value: breakdown.totalBuy,
+      color: Colors.green.shade700,
+    );
+
+    if (columns >= 2) {
+      return Row(
+        children: [
+          Expanded(child: buy),
+          const VerticalDivider(indent: 8, endIndent: 8),
+          Expanded(child: sell),
+        ],
+      );
+    }
+    return Column(children: [buy, sell]);
+  }
+}
+
+class _SummaryTile extends StatelessWidget {
+  const _SummaryTile({required this.label, required this.value, required this.color});
+
+  final String label;
+  final double? value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) => ListTile(
+    minTileHeight: 0,
+    minVerticalPadding: 4,
+    title: Text(label, style: context.theme.textTheme.titleSmall),
+    trailing: Text(
+      value != null ? "${value!.commaSeparated} ISK" : context.l10n.priceDetailUnavailable,
+      style: context.theme.textTheme.titleMedium?.copyWith(
+        color: color,
+        fontWeight: FontWeight.w600,
+      ),
+    ),
+  );
+}
+
+/// The two price perspectives of a fit.
+///
+/// The mapping to the breakdown fields is intentionally reversed: the prices a
+/// seller lists (`unitSell`/`totalSell`) are what it costs to *buy* the fit,
+/// while the prices a buyer offers (`unitBuy`/`totalBuy`) are what one receives
+/// when *selling* it. See [FitPriceBreakdown] for details.
+enum _PriceSide {
+  buy,
+  sell;
+
+  Color get color => switch (this) {
+    _PriceSide.buy => Colors.red.shade700,
+    _PriceSide.sell => Colors.green.shade700,
+  };
+
+  String label(BuildContext context) => switch (this) {
+    _PriceSide.buy => context.l10n.priceDetailBuy,
+    _PriceSide.sell => context.l10n.priceDetailSell,
+  };
+
+  double? unit(FitPriceLineItem item) => switch (this) {
+    _PriceSide.buy => item.unitSell,
+    _PriceSide.sell => item.unitBuy,
+  };
+
+  double? total(FitPriceLineItem item) => switch (this) {
+    _PriceSide.buy => item.totalSell,
+    _PriceSide.sell => item.totalBuy,
+  };
+}
+
+class _SingleColumnTabs extends ConsumerStatefulWidget {
+  const _SingleColumnTabs({
+    required this.breakdown,
+    required this.shipTypeId,
+    required this.fitName,
+  });
+
+  final FitPriceBreakdown breakdown;
+  final int shipTypeId;
+  final String fitName;
+
+  @override
+  ConsumerState<_SingleColumnTabs> createState() => _SingleColumnTabsState();
+}
+
+class _SingleColumnTabsState extends ConsumerState<_SingleColumnTabs>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: _PriceSide.values.length, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Column(
+    children: [
+      _HeaderTile(shipTypeId: widget.shipTypeId, fitName: widget.fitName),
+      _SummarySection(breakdown: widget.breakdown, columns: 1),
+      TabBar(
+        controller: _tabController,
+        tabs: [for (final side in _PriceSide.values) Tab(text: side.label(context))],
+      ),
+      Expanded(
+        child: TabBarView(
+          controller: _tabController,
+          children: [
+            for (final side in _PriceSide.values)
+              _SidePriceList(breakdown: widget.breakdown, side: side),
+          ],
+        ),
+      ),
+    ],
+  );
+}
+
+class _SidePriceList extends StatelessWidget {
+  const _SidePriceList({required this.breakdown, required this.side});
+
+  final FitPriceBreakdown breakdown;
+  final _PriceSide side;
+
+  @override
+  Widget build(BuildContext context) => ListView(
+    padding: const EdgeInsets.symmetric(vertical: 8),
+    children: [for (final item in breakdown.items) _SideItemTile(item: item, side: side)],
+  );
+}
+
+class _SideItemTile extends ConsumerWidget {
+  const _SideItemTile({required this.item, required this.side});
+
+  final FitPriceLineItem item;
+  final _PriceSide side;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final type = ref.watch(repoCollectionProvider.select((c) => c?.getType(item.typeId)));
+
+    return ListTile(
+      minTileHeight: 0,
+      minVerticalPadding: 8,
+      leading: type != null ? EveIcon(icon: type.icon) : null,
+      title: type != null ? LocalizedTypeName(typeId: item.typeId) : Text("Type ${item.typeId}"),
+      subtitle: item.quantity > 1
+          ? Text(
+              "x${item.quantity}",
+              style: context.theme.textTheme.bodySmall?.copyWith(
+                color: context.theme.colorScheme.onSurfaceVariant,
+              ),
+            )
+          : null,
+      trailing: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            _formatIsk(context, side.total(item)),
+            style: context.theme.textTheme.titleMedium?.copyWith(
+              color: side.color,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          if (item.quantity > 1)
+            Text(
+              _formatIsk(context, side.unit(item)),
+              style: context.theme.textTheme.bodySmall?.copyWith(color: side.color),
+            ),
+        ],
+      ),
+      onLongPress: () => showItemDetailPage(context, typeId: item.typeId),
+    );
+  }
+}
+
+class _PriceItemTable extends ConsumerWidget {
+  const _PriceItemTable({required this.items});
+
+  final List<FitPriceLineItem> items;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) => Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 16),
+    child: DefaultTextStyle(
+      style: const TextStyle(fontSize: 16),
+      child: Table(
+        columnWidths: const {
+          0: FixedColumnWidth(32),
+          1: FlexColumnWidth(),
+          2: IntrinsicColumnWidth(),
+          3: IntrinsicColumnWidth(),
+          4: IntrinsicColumnWidth(),
+          5: IntrinsicColumnWidth(),
+        },
+        defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+        children: [for (final item in items) _buildRow(context, ref, item)],
+      ),
+    ),
+  );
+
+  TableRow _buildRow(BuildContext context, WidgetRef ref, FitPriceLineItem item) {
+    final type = ref.watch(repoCollectionProvider.select((c) => c?.getType(item.typeId)));
+    final sellColor = Colors.red.shade700;
+    final buyColor = Colors.green.shade700;
+    final icon = type != null ? EveIcon(icon: type.icon, size: 32) : const SizedBox.shrink();
+
+    return TableRow(
+      children: [
+        icon,
+        InkWell(
+          onLongPress: () => showItemDetailPage(context, typeId: item.typeId),
+          child: Padding(
+            padding: const EdgeInsets.only(left: 16, top: 8, bottom: 8),
+            child: Row(
+              children: [
+                Flexible(
+                  child: type != null
+                      ? LocalizedTypeName(typeId: item.typeId)
+                      : Text("Type ${item.typeId}"),
+                ),
+                if (item.quantity > 1)
+                  Text(
+                    " x${item.quantity}",
+                    style: context.theme.textTheme.bodySmall?.copyWith(
+                      color: context.theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+        _priceCell(context, item.unitSell, color: sellColor, emphasized: false),
+        _priceCell(context, item.totalSell, color: sellColor, emphasized: true),
+        _priceCell(context, item.unitBuy, color: buyColor, emphasized: false),
+        _priceCell(context, item.totalBuy, color: buyColor, emphasized: true),
+      ],
+    );
+  }
+
+  Widget _priceCell(
+    BuildContext context,
+    double? price, {
+    required Color color,
+    required bool emphasized,
+  }) => Padding(
+    padding: const EdgeInsets.only(left: 16, top: 8, bottom: 8),
+    child: Text(
+      _formatIsk(context, price),
+      textAlign: TextAlign.end,
+      style: emphasized
+          ? context.theme.textTheme.titleMedium?.copyWith(color: color, fontWeight: FontWeight.w600)
+          : context.theme.textTheme.bodySmall?.copyWith(color: color),
+    ),
+  );
+}
+
+String _formatIsk(BuildContext context, double? price) =>
+    price != null ? "${price.commaSeparated} ISK" : context.l10n.priceDetailUnavailable;

--- a/lib/features/market_price/ui/price_detail_page.dart
+++ b/lib/features/market_price/ui/price_detail_page.dart
@@ -108,6 +108,7 @@ class _PriceBreakdownList extends ConsumerWidget {
         children: [
           _HeaderTile(shipTypeId: shipTypeId, fitName: fitName),
           const SizedBox(height: 4),
+          if (breakdown.isPartial) _PartialBanner(missingTypeCount: breakdown.missingTypeCount),
           _SummarySection(breakdown: breakdown, columns: columns),
           const Divider(height: 16, indent: 16, endIndent: 16),
           _PriceItemTable(items: breakdown.items),
@@ -172,6 +173,29 @@ class _SummarySection extends StatelessWidget {
     }
     return Column(children: [buy, sell]);
   }
+}
+
+class _PartialBanner extends StatelessWidget {
+  const _PartialBanner({required this.missingTypeCount});
+
+  final int missingTypeCount;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+    child: Row(
+      children: [
+        Icon(Icons.warning_amber_rounded, size: 18, color: Colors.orange.shade700),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            context.l10n.priceDetailPartial(count: missingTypeCount),
+            style: context.theme.textTheme.bodySmall?.copyWith(color: Colors.orange.shade700),
+          ),
+        ),
+      ],
+    ),
+  );
 }
 
 class _SummaryTile extends StatelessWidget {
@@ -262,6 +286,8 @@ class _SingleColumnTabsState extends ConsumerState<_SingleColumnTabs>
   Widget build(BuildContext context) => Column(
     children: [
       _HeaderTile(shipTypeId: widget.shipTypeId, fitName: widget.fitName),
+      if (widget.breakdown.isPartial)
+        _PartialBanner(missingTypeCount: widget.breakdown.missingTypeCount),
       _SummarySection(breakdown: widget.breakdown, columns: 1),
       TabBar(
         controller: _tabController,

--- a/lib/features/market_price/ui/price_detail_page.dart
+++ b/lib/features/market_price/ui/price_detail_page.dart
@@ -1,5 +1,6 @@
 import "package:eve_fit_assistant/components/icon/eve_icon.dart";
 import "package:eve_fit_assistant/components/localized_text.dart";
+import "package:eve_fit_assistant/data/proto/types.pb.dart" as pb_types;
 import "package:eve_fit_assistant/features/market_price/models/models.dart";
 import "package:eve_fit_assistant/features/market_price/state/state.dart";
 import "package:eve_fit_assistant/pages/item-detail/page.dart";
@@ -10,6 +11,20 @@ import "package:eve_fit_assistant/utils/num.dart";
 import "package:eve_fit_assistant/utils/screen.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
+
+(pb_types.Type?, String) _resolveShip(BuildContext context, WidgetRef ref, int shipTypeId) {
+  final shipType = ref.watch(repoCollectionProvider.select((c) => c?.getType(shipTypeId)));
+  final locale = context.locale.languageCode;
+  final shipName = shipType != null
+      ? ref.watch(
+              repoCollectionProvider.select(
+                (c) => c?.getLocalizedName(shipType.typeName.id, locale),
+              ),
+            ) ??
+            ""
+      : "";
+  return (shipType, shipName);
+}
 
 Future<void> showPriceDetailPage(BuildContext context, {required String fitId}) => Navigator.of(
   context,
@@ -32,16 +47,7 @@ class PriceDetailPage extends ConsumerWidget {
 
     final fit = fitState.fit;
     final shipTypeId = fit.body.shipTypeId;
-    final shipType = ref.watch(repoCollectionProvider.select((c) => c?.getType(shipTypeId)));
-    final locale = context.locale.languageCode;
-    final shipName = shipType != null
-        ? ref.watch(
-                repoCollectionProvider.select(
-                  (c) => c?.getLocalizedName(shipType.typeName.id, locale),
-                ),
-              ) ??
-              ""
-        : "";
+    final (_, shipName) = _resolveShip(context, ref, shipTypeId);
     final title = context.l10n.priceDetailTitle(shipName: shipName, fitName: fit.metadata.name);
 
     return Scaffold(
@@ -121,16 +127,7 @@ class _HeaderTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final shipType = ref.watch(repoCollectionProvider.select((c) => c?.getType(shipTypeId)));
-    final locale = context.locale.languageCode;
-    final shipName = shipType != null
-        ? ref.watch(
-                repoCollectionProvider.select(
-                  (c) => c?.getLocalizedName(shipType.typeName.id, locale),
-                ),
-              ) ??
-              ""
-        : "";
+    final (shipType, shipName) = _resolveShip(context, ref, shipTypeId);
 
     return ListTile(
       minTileHeight: 0,

--- a/test/features/market_price/price_response_test.dart
+++ b/test/features/market_price/price_response_test.dart
@@ -15,13 +15,13 @@ void main() {
     test("falls back through sections and keys in order", () {
       expect(
         extractEstimatedPrice({
-          "sell": {"avg": 42.0},
+          "sell": {"max": 42.0},
         }),
         42.0,
       );
       expect(
         extractEstimatedPrice({
-          "all": {"median": 7.0},
+          "all": {"min": 7.0},
         }),
         7.0,
       );
@@ -31,8 +31,20 @@ void main() {
         }),
         3.0,
       );
-      expect(extractEstimatedPrice({"avg": 11.0}), 11.0);
-      expect(extractEstimatedPrice({"price": 5}), 5.0);
+      expect(
+        extractEstimatedPrice({
+          "sell": {"volume": 100},
+          "all": {"max": 11.0},
+        }),
+        11.0,
+      );
+      expect(
+        extractEstimatedPrice({
+          "sell": {"volume": 100},
+          "buy": {"min": 5.0},
+        }),
+        5.0,
+      );
     });
 
     test("accepts integer values", () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fit “price details” screen showing buy/sell totals and itemized unit/total pricing, including unavailable states.
  * Open the price details by long-pressing a fit price tile, with desktop/table and mobile/tabbed layouts.
  * Added new English and Chinese localization strings for the price detail UI.
* **Improvements**
  * Enhanced market price retrieval and breakdown fetching with fresher cache usage and more reliable handling of missing/failed data.
  * Improved estimated price parsing by prioritizing valid sell/buy ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->