### PR TITLE
ci(release): namespace git tags as releases/v<version>

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -144,7 +144,7 @@ The `release.yml` workflow on the merge commit then:
 4. Publishes the release to the remote `testing` channel.
 5. Publishes the release note as a remote announcement entry so users are notified
    of the new version.
-6. Creates a lightweight Git tag (`v<version>`) pointing at the merge commit.
+6. Creates a lightweight Git tag (`releases/v<version>`) pointing at the merge commit.
 
 If the merged PR is missing `V-Tested Release`, the release aborts.
 

--- a/bootstrap/ci/release_github.py
+++ b/bootstrap/ci/release_github.py
@@ -100,7 +100,7 @@ def register_github_release_command(ci_group: click.Group) -> None:
             mode="w",
             encoding="utf-8",
             suffix=".md",
-            prefix=f"github_release_{tag}_",
+            prefix=f"github_release_{tag.replace('/', '_')}_",
             delete=False,
         ) as f:
             body_path = Path(f.name)
@@ -109,7 +109,7 @@ def register_github_release_command(ci_group: click.Group) -> None:
         is_prerelease = "-" in semver
 
         cmd = ["gh", "release", "create", tag]
-        cmd.extend(["--title", tag])
+        cmd.extend(["--title", f"v{semver}"])
         if is_prerelease:
             cmd.append("--prerelease")
         cmd.extend(["--notes-file", str(body_path)])

--- a/bootstrap/config.py
+++ b/bootstrap/config.py
@@ -159,7 +159,7 @@ class ProjectVersion(BaseModel):
         return base
 
     def render_tag(self) -> str:
-        return f"v{self.render_semver()}"
+        return f"releases/v{self.render_semver()}"
 
 
 class SchemaConfig(BaseModel):

--- a/bootstrap/tests/test_ci_release_github.py
+++ b/bootstrap/tests/test_ci_release_github.py
@@ -78,7 +78,7 @@ class TestGithubReleaseCommand:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         version = "0.3.0-alpha.1+42"
-        tag = "v0.3.0-alpha.1"
+        tag = "releases/v0.3.0-alpha.1"
         monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
         _make_notes(tmp_path, version)
         _make_apks(tmp_path, version)
@@ -89,6 +89,7 @@ class TestGithubReleaseCommand:
         assert "[DRY-RUN]" in result.output
         assert "gh release create" in result.output
         assert tag in result.output
+        assert "--title v0.3.0-alpha.1" in result.output
         assert "--prerelease" in result.output
         assert "0.3.0-alpha.1+42-android.apk" in result.output
         assert "0.3.0-alpha.1+42-android-arm64.apk" in result.output
@@ -96,7 +97,7 @@ class TestGithubReleaseCommand:
 
     def test_dry_run_stable_release(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         version = "1.0.0"
-        tag = "v1.0.0"
+        tag = "releases/v1.0.0"
         monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
         semver = version.split("+")[0]
         notes_dir = tmp_path / "docs" / "changelog" / semver.replace(".", "-")
@@ -124,7 +125,7 @@ class TestGithubReleaseCommand:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         version = "0.3.0-alpha.1"
-        tag = "v0.3.0-alpha.1"
+        tag = "releases/v0.3.0-alpha.1"
         monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
         semver = version.split("+")[0]
         notes_dir = tmp_path / "docs" / "changelog" / semver.replace(".", "-")
@@ -142,7 +143,7 @@ class TestGithubReleaseCommand:
 
     def test_fails_missing_apk_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         version = "0.3.0-alpha.1+42"
-        tag = "v0.3.0-alpha.1"
+        tag = "releases/v0.3.0-alpha.1"
         monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
         _make_notes(tmp_path, version)
 
@@ -155,7 +156,7 @@ class TestGithubReleaseCommand:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         version = "0.3.0-alpha.1+42"
-        tag = "v0.3.0-alpha.1"
+        tag = "releases/v0.3.0-alpha.1"
         monkeypatch.setattr("bootstrap.ci.release_github.PROJECT_ROOT", tmp_path)
 
         result = _invoke(tmp_path, version, tag)

--- a/bootstrap/tests/test_ci_release_verify.py
+++ b/bootstrap/tests/test_ci_release_verify.py
@@ -228,7 +228,7 @@ class TestReleaseVerifyIntegration:
         runner = click.testing.CliRunner()
         result = runner.invoke(cli, ["ci", "release", "verify", "--check-notes"])
         assert result.exit_code == 0, result.output
-        assert "Expected tag: v0.1.0-beta.2" in result.output
+        assert "Expected tag: releases/v0.1.0-beta.2" in result.output
 
     def test_pubspec_mismatch(self, tmp_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         version = {"major": 0, "minor": 1, "patch": 0, "pre_label": "beta", "pre_num": 2}

--- a/cliff.toml
+++ b/cliff.toml
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 """
 body = """\
-## [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version | trim_start_matches(pat="releases/") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group }}
 {% for commit in commits %}
@@ -23,7 +23,7 @@ trim = true
 [git]
 conventional_commits = true
 filter_unconventional = false
-tag_pattern = "v[0-9]*"
+tag_pattern = "^(releases/)?v[0-9]+"
 skip_tags = "alpha-v.*"
 
 commit_parsers = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Standardized release tags to use the `releases/v<version>` format.
  * Improved GitHub release titles to display clean semantic versions.
  * Release workflows now safely handle tags containing path separators.

* **Changelog**
  * Version headings no longer include the internal `releases/` prefix.
  * Tag matching now supports both prefixed and unprefixed release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->