### PR TITLE
fix(fit): treat closed antiScroll level as protection disabled

### DIFF
--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -309,7 +309,7 @@
   "appSettingsPageFontScaleL": "L",
   "appSettingsPageFontScaleXL": "XL",
   "appSettingsPageAntiScrollTitle": "List Tile Swipe Protection",
-  "appSettingsPageAntiScrollDescription": "Adjusts how horizontal swipes on list tiles are handled. The left and right edge zones of a tile reveal its swipe actions, while the center zone switches pages. Higher levels shrink the center page-switch zone, making it harder to switch pages accidentally while interacting with tiles. When closed, the entire tile area switches pages.\nWeak: 50%, Medium: 33%, Strong: 20%.",
+  "appSettingsPageAntiScrollDescription": "Adjusts how horizontal swipes on list tiles are handled. The left and right edge zones of a tile reveal its swipe actions, while the center zone switches pages. Higher levels shrink the center page-switch zone, making it harder to switch pages accidentally while interacting with tiles. When closed, tiles keep their default behavior: swiping reveals swipe actions and never switches pages.\nWeak: 50%, Medium: 33%, Strong: 20%.",
   "appSettingsPageAntiScrollClosed": "Close",
   "appSettingsPageAntiScrollWeak": "Weak",
   "appSettingsPageAntiScrollMedium": "Medium",

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -764,7 +764,7 @@
   "appSettingsPageFontScaleL": "大",
   "appSettingsPageFontScaleXL": "特大",
   "appSettingsPageAntiScrollTitle": "列表项防误滑",
-  "appSettingsPageAntiScrollDescription": "调整列表项上横向滑动手势的响应区域。列表项左右两侧的边缘区域用于呼出侧滑操作，中央区域用于滑动切换页面。等级越高，中央可切换页面的区域越小，越不容易误触页面切换。关闭后，整个列表项区域都可用于滑动切换页面。\n弱：50%；中：33%；强：20%。",
+  "appSettingsPageAntiScrollDescription": "调整列表项上横向滑动手势的响应区域。列表项左右两侧的边缘区域用于呼出侧滑操作，中央区域用于滑动切换页面。等级越高，中央可切换页面的区域越小，越不容易误触页面切换。关闭后，列表项保持默认行为：滑动仅呼出侧滑操作，不会切换页面。\n弱：50%；中：33%；强：20%。",
   "appSettingsPageAntiScrollClosed": "关闭",
   "appSettingsPageAntiScrollWeak": "弱",
   "appSettingsPageAntiScrollMedium": "中",

--- a/lib/pages/fit/components/slidable_edge_zone.dart
+++ b/lib/pages/fit/components/slidable_edge_zone.dart
@@ -1,3 +1,4 @@
+import "package:eve_fit_assistant/config/list_tile_anti_scroll.dart";
 import "package:eve_fit_assistant/storage/setting/setting.dart";
 import "package:flutter/widgets.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -45,6 +46,10 @@ class SlidableEdgeScope extends InheritedWidget {
 /// the tab scaffold can use them to switch tabs. Taps, long-presses and
 /// vertical scrolls are unaffected. The width of the center zone is
 /// configured by the [AppSetting.listTileAntiScrollLevel] setting.
+///
+/// When the level is [ListTileAntiScrollLevel.closed], the protection is
+/// disabled: no zones are installed, the slidable keeps its raw behavior, and
+/// drags starting on the tile never switch tabs.
 class SlidableEdgeZone extends ConsumerWidget {
   const SlidableEdgeZone({required this.child, super.key});
 
@@ -53,12 +58,16 @@ class SlidableEdgeZone extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tracker = SlidableEdgeScope.of(context);
-    final edgeRatio =
-        (1.0 -
-            ref.watch(
-              appSettingServiceProvider.select((s) => s.listTileAntiScrollLevel.centerRatio),
-            )) /
-        2.0;
+    final level = ref.watch(appSettingServiceProvider.select((s) => s.listTileAntiScrollLevel));
+
+    if (level == ListTileAntiScrollLevel.closed) {
+      return Listener(
+        onPointerDown: (event) => tracker.setOnEdge(event.pointer, value: true),
+        child: child,
+      );
+    }
+
+    final edgeRatio = (1.0 - level.centerRatio) / 2.0;
 
     return LayoutBuilder(
       builder: (context, constraints) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated anti-scroll setting descriptions in English and Chinese to clarify behavior when tiles are closed.

* **Bug Fixes**
  * Improved anti-scroll gesture handling to prevent unwanted page switches during swipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->