### PR TITLE
feat(fit): show drone bay and fighter hangar capacity usage

### DIFF
--- a/lib/constant/eve.dart
+++ b/lib/constant/eve.dart
@@ -194,6 +194,10 @@ class EveConstAttrID {
   /// - High is good: True
   static const int droneBandwidthLoad = 1273;
 
+  /// - Name: droneCapacity
+  /// - High is good: True
+  static const int droneCapacity = 283;
+
   /// - Name: maxRange
   /// - High is good: True
   static const int maxRange = 54;
@@ -233,6 +237,10 @@ class EveConstAttrID {
   /// - Name: fighterSquadronMaxSize
   /// - High is good: True
   static const int fighterSquadronMaxSize = 2215;
+
+  /// - Name: fighterCapacity
+  /// - High is good: True
+  static const int fighterCapacity = 2205;
 
   /// - Name: capacity
   /// - High is good: True

--- a/lib/constant/eve.dart
+++ b/lib/constant/eve.dart
@@ -240,7 +240,7 @@ class EveConstAttrID {
 
   /// - Name: fighterCapacity
   /// - High is good: True
-  static const int fighterCapacity = 2205;
+  static const int fighterCapacity = 2055;
 
   /// - Name: capacity
   /// - High is good: True

--- a/lib/pages/fit/components/equipment_header.dart
+++ b/lib/pages/fit/components/equipment_header.dart
@@ -100,6 +100,42 @@ class _EquipmentHeader extends StatelessWidget {
   );
 }
 
+class _HeaderCapacityCounter extends StatelessWidget {
+  const _HeaderCapacityCounter({
+    required this.count,
+    required this.total,
+    this.prefix,
+    this.suffix,
+  });
+
+  final String? prefix;
+  final String? suffix;
+  final int count;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = count > total ? Colors.red : null;
+    final textStyle = DefaultTextStyle.of(context).style;
+
+    return Text.rich(
+      TextSpan(
+        children: [
+          if (prefix != null) TextSpan(text: "$prefix "),
+          TextSpan(
+            text: "$count",
+            style: textStyle.copyWith(color: color),
+          ),
+          TextSpan(text: " / $total"),
+          if (suffix != null) TextSpan(text: " $suffix"),
+        ],
+      ),
+      softWrap: false,
+      overflow: TextOverflow.fade,
+    );
+  }
+}
+
 class _EquipmentHeaderCounter extends StatelessWidget {
   const _EquipmentHeaderCounter({required this.icon, required this.count, required this.total});
 

--- a/lib/pages/fit/screenshot_page.dart
+++ b/lib/pages/fit/screenshot_page.dart
@@ -326,6 +326,19 @@ class _ScreenshotEquipmentColumn extends ConsumerWidget {
       fit.body.slots.subsystem.length,
     );
 
+    final droneBayUsed =
+        fitContext.emulated?.hull.getAttribute(EveConstExtendedAttrID.droneCapacityLoad).round() ??
+        0;
+    final droneBayCapacity =
+        fitContext.emulated?.hull.getAttribute(EveConstAttrID.droneCapacity).round() ?? 0;
+    final fighterHangarUsed =
+        fitContext.emulated?.hull
+            .getAttribute(EveConstExtendedAttrID.fighterCapacityLoad)
+            .round() ??
+        0;
+    final fighterHangarCapacity =
+        fitContext.emulated?.hull.getAttribute(EveConstAttrID.fighterCapacity).round() ?? 0;
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -498,6 +511,10 @@ class _ScreenshotEquipmentColumn extends ConsumerWidget {
         _EquipmentHeader(
           title: context.l10n.drone,
           issues: _collectFitIssuesForSection(context, ref, fitContext, _FitIssueSection.drone),
+          rightInfo: [
+            if (droneBayCapacity > 0 || droneBayUsed > 0)
+              _HeaderCapacityCounter(suffix: "m³", count: droneBayUsed, total: droneBayCapacity),
+          ],
           interactiveIssueIndicator: false,
         ),
         if (fit.body.drones.isEmpty)
@@ -530,7 +547,7 @@ class _ScreenshotEquipmentColumn extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               spacing: 10,
               children: [
-                _FighterHeaderCounter(
+                _HeaderCapacityCounter(
                   prefix: "H",
                   count: _fighterCountForGroup(const {1653, 4779}, fitContext, ref),
                   total:
@@ -539,7 +556,7 @@ class _ScreenshotEquipmentColumn extends ConsumerWidget {
                           .round() ??
                       0,
                 ),
-                _FighterHeaderCounter(
+                _HeaderCapacityCounter(
                   prefix: "L",
                   count: _fighterCountForGroup(const {1652, 4777}, fitContext, ref),
                   total:
@@ -548,7 +565,7 @@ class _ScreenshotEquipmentColumn extends ConsumerWidget {
                           .round() ??
                       0,
                 ),
-                _FighterHeaderCounter(
+                _HeaderCapacityCounter(
                   prefix: "S",
                   count: _fighterCountForGroup(const {1537, 4778}, fitContext, ref),
                   total:
@@ -557,11 +574,17 @@ class _ScreenshotEquipmentColumn extends ConsumerWidget {
                           .round() ??
                       0,
                 ),
-                _FighterHeaderCounter(
+                _HeaderCapacityCounter(
                   suffix: "x",
                   count: fit.body.fighters.length,
                   total: fitContext.ship.fighterTubes,
                 ),
+                if (fighterHangarCapacity > 0 || fighterHangarUsed > 0)
+                  _HeaderCapacityCounter(
+                    suffix: "m³",
+                    count: fighterHangarUsed,
+                    total: fighterHangarCapacity,
+                  ),
               ],
             ),
           ),

--- a/lib/pages/fit/tabs/drone.dart
+++ b/lib/pages/fit/tabs/drone.dart
@@ -20,10 +20,20 @@ class _DroneTab extends ConsumerWidget {
 
     final drones = fit.body.drones.toList();
 
+    final bayUsed =
+        fitContext.emulated?.hull.getAttribute(EveConstExtendedAttrID.droneCapacityLoad).round() ??
+        0;
+    final bayCapacity =
+        fitContext.emulated?.hull.getAttribute(EveConstAttrID.droneCapacity).round() ?? 0;
+
     return Column(
       children: [
         _EquipmentTitleRow(
           issues: _collectFitIssuesForSection(context, ref, fitContext, _FitIssueSection.drone),
+          rightInfo: [
+            if (bayCapacity > 0 || bayUsed > 0)
+              _HeaderCapacityCounter(suffix: "m³", count: bayUsed, total: bayCapacity),
+          ],
           leftActions: <Widget>[
             InkWell(
               onTap: interactionOptions.allowMutations

--- a/lib/pages/fit/tabs/fighter.dart
+++ b/lib/pages/fit/tabs/fighter.dart
@@ -19,6 +19,14 @@ class _FighterTab extends ConsumerWidget {
     final heavyLimit =
         fitContext.emulated?.hull.getAttribute(EveConstAttrID.fighterHeavySlots).round() ?? 0;
 
+    final hangarUsed =
+        fitContext.emulated?.hull
+            .getAttribute(EveConstExtendedAttrID.fighterCapacityLoad)
+            .round() ??
+        0;
+    final hangarCapacity =
+        fitContext.emulated?.hull.getAttribute(EveConstAttrID.fighterCapacity).round() ?? 0;
+
     var lightCount = 0;
     var supportCount = 0;
     var heavyCount = 0;
@@ -71,14 +79,16 @@ class _FighterTab extends ConsumerWidget {
             ),
           ],
           rightInfo: [
-            _FighterHeaderCounter(prefix: "H", count: heavyCount, total: heavyLimit),
-            _FighterHeaderCounter(prefix: "L", count: lightCount, total: lightLimit),
-            _FighterHeaderCounter(prefix: "S", count: supportCount, total: supportLimit),
-            _FighterHeaderCounter(
+            _HeaderCapacityCounter(prefix: "H", count: heavyCount, total: heavyLimit),
+            _HeaderCapacityCounter(prefix: "L", count: lightCount, total: lightLimit),
+            _HeaderCapacityCounter(prefix: "S", count: supportCount, total: supportLimit),
+            _HeaderCapacityCounter(
               suffix: "x",
               count: fighters.length,
               total: fitContext.ship.fighterTubes,
             ),
+            if (hangarCapacity > 0 || hangarUsed > 0)
+              _HeaderCapacityCounter(suffix: "m³", count: hangarUsed, total: hangarCapacity),
           ],
         ),
         const Divider(),
@@ -116,37 +126,6 @@ class _FighterTab extends ConsumerWidget {
                 ),
         ),
       ],
-    );
-  }
-}
-
-class _FighterHeaderCounter extends StatelessWidget {
-  const _FighterHeaderCounter({required this.count, required this.total, this.prefix, this.suffix});
-
-  final String? prefix;
-  final String? suffix;
-  final int count;
-  final int total;
-
-  @override
-  Widget build(BuildContext context) {
-    final color = count > total ? Colors.red : null;
-    final textStyle = DefaultTextStyle.of(context).style;
-
-    return Text.rich(
-      TextSpan(
-        children: [
-          if (prefix != null) TextSpan(text: "$prefix "),
-          TextSpan(
-            text: "$count",
-            style: textStyle.copyWith(color: color),
-          ),
-          TextSpan(text: " / $total"),
-          if (suffix != null) TextSpan(text: " $suffix"),
-        ],
-      ),
-      softWrap: false,
-      overflow: TextOverflow.fade,
     );
   }
 }


### PR DESCRIPTION
Closes #324 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added drone bay capacity counters to drone equipment headers.
  - Added fighter hangar capacity, tube, and size counters to fighter equipment headers.
  - Counters highlight over-capacity usage in red and adapt to available space.
  - Capacity information is also displayed in fitting screenshots when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->