### PR TITLE
feat(fit): fold overflowing tile slide actions into dropdown and add new actions

### DIFF
--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -12,6 +12,7 @@
   "showInfo": "Show Info",
   "copy": "Copy",
   "share": "Share",
+  "more": "More",
   "dynamicConvert": "Abyssal",
   "dynamicRevert": "Revert",
   "dynamicSelectTitle": "Select mutaplasmid",

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -14,6 +14,7 @@
   "showInfo": "显示详情",
   "copy": "复制",
   "share": "分享",
+  "more": "更多",
   "dynamicConvert": "深渊",
   "dynamicRevert": "还原",
   "dynamicSelectTitle": "选择深渊物质",

--- a/lib/components/list/slide_action.dart
+++ b/lib/components/list/slide_action.dart
@@ -1,0 +1,159 @@
+import "dart:async";
+
+import "package:eve_fit_assistant/compat/io.dart";
+import "package:eve_fit_assistant/utils/context.dart";
+import "package:flutter/foundation.dart";
+import "package:flutter/material.dart";
+import "package:flutter_slidable/flutter_slidable.dart";
+
+const double _kActionExtentRatio = 0.15;
+const int _kMaxVisibleActions = 2;
+
+/// A sliding-tile action decoupled from its rendering, so the same definition
+/// can be shown as a [SlidableAction] or as a dropdown menu entry.
+class TileAction {
+  const TileAction({
+    required this.onPressed,
+    required this.backgroundColor,
+    this.icon,
+    this.label,
+    this.foregroundColor,
+    this.autoClose = true,
+  }) : assert(icon != null || label != null);
+
+  final IconData? icon;
+  final String? label;
+  final Color backgroundColor;
+  final Color? foregroundColor;
+  final bool autoClose;
+  final void Function(BuildContext context) onPressed;
+
+  SlidableAction toSlidableAction() => SlidableAction(
+    onPressed: onPressed,
+    backgroundColor: backgroundColor,
+    foregroundColor: foregroundColor,
+    autoClose: autoClose,
+    icon: icon,
+    label: label,
+    padding: .zero,
+  );
+}
+
+/// Builds an [ActionPane] for one side of a tile.
+///
+/// Up to [_kMaxVisibleActions] actions are shown as-is. With more actions the
+/// first one stays visible and the rest fold into a dropdown overflow button.
+ActionPane? buildTileActionPane(List<TileAction> actions) {
+  if (actions.isEmpty) return null;
+  if (actions.length <= _kMaxVisibleActions) {
+    return ActionPane(
+      extentRatio: _kActionExtentRatio * actions.length,
+      motion: const StretchMotion(),
+      children: [for (final action in actions) action.toSlidableAction()],
+    );
+  }
+  return ActionPane(
+    extentRatio: _kActionExtentRatio * _kMaxVisibleActions,
+    motion: const StretchMotion(),
+    children: [
+      actions.first.toSlidableAction(),
+      _OverflowTileActionButton(actions: actions.sublist(1)),
+    ],
+  );
+}
+
+/// Opens a dropdown listing [actions] (icon + label, no background color) at
+/// [position] and returns the selected action, if any.
+Future<TileAction?> showTileActionsMenu(
+  BuildContext context,
+  RelativeRect position,
+  List<TileAction> actions,
+) => showMenu<TileAction>(
+  context: context,
+  position: position,
+  items: [
+    for (final action in actions)
+      PopupMenuItem(
+        value: action,
+        child: Row(
+          children: [
+            if (action.icon != null) ...[Icon(action.icon, size: 20), const SizedBox(width: 12)],
+            Expanded(child: Text(action.label ?? "")),
+          ],
+        ),
+      ),
+  ],
+);
+
+class _OverflowTileActionButton extends StatelessWidget {
+  const _OverflowTileActionButton({required this.actions});
+
+  final List<TileAction> actions;
+
+  Future<void> _openMenu(BuildContext buttonContext) async {
+    final box = buttonContext.findRenderObject()! as RenderBox;
+    final selected = await showTileActionsMenu(
+      buttonContext,
+      RelativeRect.fromRect(
+        box.localToGlobal(Offset.zero) & box.size,
+        Offset.zero & MediaQuery.sizeOf(buttonContext),
+      ),
+      actions,
+    );
+    // The pane must stay mounted while the menu is open: closing the Slidable
+    // unmounts this button, which would leave the selection unhandled.
+    if (!buttonContext.mounted) return;
+    unawaited(Slidable.of(buttonContext)?.close());
+    selected?.onPressed(buttonContext);
+  }
+
+  @override
+  Widget build(BuildContext context) => CustomSlidableAction(
+    onPressed: (buttonContext) => unawaited(_openMenu(buttonContext)),
+    autoClose: false,
+    backgroundColor: Colors.grey.shade200,
+    foregroundColor: Colors.black,
+    padding: .zero,
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Flexible(child: Icon(Icons.more_vert)),
+        const SizedBox(height: 4),
+        Flexible(child: Text(context.l10n.more, overflow: TextOverflow.ellipsis)),
+      ],
+    ),
+  );
+}
+
+bool get _supportsSecondaryActionMenu => !kIsWeb && (Platform.isWindows || Platform.isLinux);
+
+/// Adds a desktop right-click dropdown listing all of a tile's slide actions.
+///
+/// On platforms other than Windows/Linux native (or when there are no
+/// actions) this is a pass-through.
+class TileSecondaryActionRegion extends StatelessWidget {
+  const TileSecondaryActionRegion({required this.actions, required this.child, super.key});
+
+  final List<TileAction> actions;
+  final Widget child;
+
+  Future<void> _openMenu(BuildContext context, Offset position) async {
+    final selected = await showTileActionsMenu(
+      context,
+      RelativeRect.fromLTRB(position.dx, position.dy, position.dx, position.dy),
+      actions,
+    );
+    if (selected == null || !context.mounted) return;
+    selected.onPressed(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_supportsSecondaryActionMenu || actions.isEmpty) return child;
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onSecondaryTapUp: (details) => unawaited(_openMenu(context, details.globalPosition)),
+      child: child,
+    );
+  }
+}

--- a/lib/components/list/slide_action.dart
+++ b/lib/components/list/slide_action.dart
@@ -85,6 +85,13 @@ Future<TileAction?> showTileActionsMenu(
   ],
 );
 
+/// Invokes [selected], closing the enclosing [Slidable] first when
+/// [TileAction.autoClose] is set.
+void _dispatchTileAction(BuildContext context, TileAction selected) {
+  if (selected.autoClose) unawaited(Slidable.of(context)?.close());
+  selected.onPressed(context);
+}
+
 class _OverflowTileActionButton extends StatelessWidget {
   const _OverflowTileActionButton({required this.actions});
 
@@ -103,8 +110,11 @@ class _OverflowTileActionButton extends StatelessWidget {
     // The pane must stay mounted while the menu is open: closing the Slidable
     // unmounts this button, which would leave the selection unhandled.
     if (!buttonContext.mounted) return;
-    unawaited(Slidable.of(buttonContext)?.close());
-    selected?.onPressed(buttonContext);
+    if (selected == null) {
+      unawaited(Slidable.of(buttonContext)?.close());
+      return;
+    }
+    _dispatchTileAction(buttonContext, selected);
   }
 
   @override
@@ -144,7 +154,7 @@ class TileSecondaryActionRegion extends StatelessWidget {
       actions,
     );
     if (selected == null || !context.mounted) return;
-    selected.onPressed(context);
+    _dispatchTileAction(context, selected);
   }
 
   @override

--- a/lib/pages/fit/components/equipment/slot_row/drone_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/drone_slot.dart
@@ -13,64 +13,57 @@ class _DroneSlotRow extends ConsumerWidget {
   final FitContext fitContext;
   final FitInteractionOptions interactionOptions;
 
-  List<SlidableAction> _buildStartActions(BuildContext context, WidgetRef ref) => <SlidableAction>[
+  List<TileAction> _buildStartActions(BuildContext context, WidgetRef ref) => <TileAction>[
     if (fitContext.fit.body.drones.getOrNull(slotIdent.index)?.quantity != 1)
-      SlidableAction(
+      TileAction(
         onPressed: (_) => _handleSetAmount(context, ref, 1),
         backgroundColor: Colors.green.shade200,
         foregroundColor: Colors.black,
         label: "x1",
-        padding: .zero,
       ),
     if (fitContext.fit.body.drones.getOrNull(slotIdent.index)?.quantity != 5)
-      SlidableAction(
+      TileAction(
         onPressed: (_) => _handleSetAmount(context, ref, 5),
         backgroundColor: Colors.green.shade400,
         foregroundColor: Colors.white,
         label: "x5",
-        padding: .zero,
       ),
   ];
 
-  List<SlidableAction> _buildEndActions(BuildContext context, WidgetRef ref) => <SlidableAction>[
+  List<TileAction> _buildEndActions(BuildContext context, WidgetRef ref) => <TileAction>[
     if ((fitContext.fit.body.drones.getOrNull(slotIdent.index)?.quantity ?? 0) > 1)
-      SlidableAction(
+      TileAction(
         onPressed: (_) => _handleAddAmount(context, ref, -1),
         autoClose: false,
         backgroundColor: Colors.red.shade400,
         foregroundColor: Colors.white,
         label: "-1",
-        padding: .zero,
       ),
-    SlidableAction(
+    TileAction(
       onPressed: (_) => _handleAddAmount(context, ref, 1),
       autoClose: false,
       backgroundColor: Colors.green.shade400,
       foregroundColor: Colors.black,
       label: "+1",
-      padding: .zero,
     ),
-    SlidableAction(
+    TileAction(
       onPressed: (_) => _handleRemoveDrone(context, ref),
       backgroundColor: colorActionDelete,
       foregroundColor: Colors.white,
       icon: Icons.delete,
       label: context.l10n.delete,
-      padding: .zero,
     ),
   ];
 
-  List<SlidableAction> _buildRecoveryActions(BuildContext context, WidgetRef ref) =>
-      <SlidableAction>[
-        SlidableAction(
-          onPressed: (_) => _handleRemoveDrone(context, ref),
-          backgroundColor: colorActionDelete,
-          foregroundColor: Colors.white,
-          icon: Icons.delete,
-          label: context.l10n.delete,
-          padding: .zero,
-        ),
-      ];
+  List<TileAction> _buildRecoveryActions(BuildContext context, WidgetRef ref) => <TileAction>[
+    TileAction(
+      onPressed: (_) => _handleRemoveDrone(context, ref),
+      backgroundColor: colorActionDelete,
+      foregroundColor: Colors.white,
+      icon: Icons.delete,
+      label: context.l10n.delete,
+    ),
+  ];
 
   Future<void> _handleSetAmount(BuildContext context, WidgetRef ref, int amount) async {
     await fitContext.fitWrapper.changeDroneAmount(slotIdent.index, amount);
@@ -92,13 +85,9 @@ class _DroneSlotRow extends ConsumerWidget {
     if (!interactionOptions.allowMutations) return content;
 
     return Slidable(
-      endActionPane: ActionPane(
-        extentRatio: 0.15 * recoveryActions.length,
-        motion: const StretchMotion(),
-        children: recoveryActions,
-      ),
+      endActionPane: buildTileActionPane(recoveryActions),
       child: SlidableEdgeZone(
-        child: ListTile(title: Text(title), trailing: Text("x $quantity")),
+        child: TileSecondaryActionRegion(actions: recoveryActions, child: content),
       ),
     );
   }
@@ -170,17 +159,11 @@ class _DroneSlotRow extends ConsumerWidget {
     if (!interactionOptions.allowMutations) return content;
 
     return Slidable(
-      startActionPane: ActionPane(
-        extentRatio: 0.15 * startActions.length,
-        motion: const StretchMotion(),
-        children: startActions,
+      startActionPane: buildTileActionPane(startActions),
+      endActionPane: buildTileActionPane(endActions),
+      child: SlidableEdgeZone(
+        child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
       ),
-      endActionPane: ActionPane(
-        extentRatio: 0.15 * endActions.length,
-        motion: const StretchMotion(),
-        children: endActions,
-      ),
-      child: SlidableEdgeZone(child: content),
     );
   }
 }

--- a/lib/pages/fit/components/equipment/slot_row/fighter_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/fighter_slot.dart
@@ -109,50 +109,45 @@ class _FighterSlotRow extends ConsumerWidget {
         representative?.getAttribute(EveConstAttrID.fighterSquadronMaxSize).round() ?? 0;
     final maxQuantity = resolvedMaxQuantity > 0 ? resolvedMaxQuantity : storedFighter.quantity;
     final availableAbilityMask = _resolveAbilityMask(representative);
-    final startActions = <SlidableAction>[
+    final startActions = <TileAction>[
       if (storedFighter.quantity != 1)
-        SlidableAction(
+        TileAction(
           onPressed: (_) => _setAmount(1),
           backgroundColor: Colors.green.shade200,
           foregroundColor: Colors.black,
           label: "x1",
-          padding: .zero,
         ),
       if (maxQuantity > 1 && storedFighter.quantity != maxQuantity)
-        SlidableAction(
+        TileAction(
           onPressed: (_) => _setAmount(maxQuantity),
           backgroundColor: Colors.green.shade400,
           foregroundColor: Colors.white,
           label: context.l10n.fitActionFill,
-          padding: .zero,
         ),
     ];
-    final endActions = <SlidableAction>[
+    final endActions = <TileAction>[
       if (storedFighter.quantity > 1)
-        SlidableAction(
+        TileAction(
           onPressed: (_) => _changeAmount(-1),
           autoClose: false,
           backgroundColor: Colors.red.shade400,
           foregroundColor: Colors.white,
           label: "-1",
-          padding: .zero,
         ),
       if (maxQuantity <= 1 || storedFighter.quantity < maxQuantity)
-        SlidableAction(
+        TileAction(
           onPressed: (_) => _changeAmount(1),
           autoClose: false,
           backgroundColor: Colors.green.shade400,
           foregroundColor: Colors.black,
           label: "+1",
-          padding: .zero,
         ),
-      SlidableAction(
+      TileAction(
         onPressed: (_) => fitContext.fitWrapper.removeFighter(slotIdent.index),
         backgroundColor: colorActionDelete,
         foregroundColor: Colors.white,
         icon: Icons.delete,
         label: context.l10n.delete,
-        padding: .zero,
       ),
     ];
     final dps = representative?.getAttribute(EveConstExtendedAttrID.fighterDamagePerSecond);
@@ -240,19 +235,11 @@ class _FighterSlotRow extends ConsumerWidget {
     if (!interactionOptions.allowMutations) return content;
 
     return Slidable(
-      startActionPane: startActions.isEmpty
-          ? null
-          : ActionPane(
-              extentRatio: 0.15 * startActions.length,
-              motion: const StretchMotion(),
-              children: startActions,
-            ),
-      endActionPane: ActionPane(
-        extentRatio: 0.15 * endActions.length,
-        motion: const StretchMotion(),
-        children: endActions,
+      startActionPane: buildTileActionPane(startActions),
+      endActionPane: buildTileActionPane(endActions),
+      child: SlidableEdgeZone(
+        child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
       ),
-      child: SlidableEdgeZone(child: content),
     );
   }
 }

--- a/lib/pages/fit/components/equipment/slot_row/slot_row.dart
+++ b/lib/pages/fit/components/equipment/slot_row/slot_row.dart
@@ -245,76 +245,62 @@ class _SlotRowDisplay extends ConsumerWidget {
     }
 
     return Slidable(
-      startActionPane: startActions.isEmpty
-          ? null
-          : ActionPane(
-              extentRatio: 0.15 * startActions.length,
-              motion: const StretchMotion(),
-              children: startActions,
-            ),
-      endActionPane: endActions.isEmpty
-          ? null
-          : ActionPane(
-              extentRatio: 0.15 * endActions.length,
-              motion: const StretchMotion(),
-              children: endActions,
-            ),
-      child: SlidableEdgeZone(child: content),
+      startActionPane: buildTileActionPane(startActions),
+      endActionPane: buildTileActionPane(endActions),
+      child: SlidableEdgeZone(
+        child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
+      ),
     );
   }
 
-  List<SlidableAction> _buildStartActions(BuildContext context, WidgetRef ref) {
-    final actions = <SlidableAction>[];
+  List<TileAction> _buildStartActions(BuildContext context, WidgetRef ref) {
+    final actions = <TileAction>[];
     final isDynamic = fitContext.dynamicItemFor(slotInfo.slot.itemId) != null;
 
     if (_canCopy()) {
       actions.add(
-        SlidableAction(
+        TileAction(
           onPressed: (_) => _handleCopy(context, ref),
           autoClose: false,
           icon: Icons.copy,
           backgroundColor: Colors.grey.shade200,
           foregroundColor: Colors.black,
           label: context.l10n.copy,
-          padding: .zero,
         ),
       );
     }
 
     if (isDynamic) {
       actions.add(
-        SlidableAction(
+        TileAction(
           onPressed: (_) => fitContext.fitWrapper.revertSlotFromDynamic(slotIdent),
           backgroundColor: Colors.grey,
           foregroundColor: Colors.white,
           icon: Icons.cyclone_outlined,
           label: context.l10n.dynamicRevert,
-          padding: .zero,
         ),
       );
     } else if (_supportsDynamicItemConversion() &&
         _availableDynamicModifierTypeIds(ref).isNotEmpty) {
       actions.add(
-        SlidableAction(
+        TileAction(
           onPressed: (_) => _handleConvertToDynamic(context, ref),
           backgroundColor: Colors.red,
           foregroundColor: Colors.white,
           icon: Icons.cyclone_outlined,
           label: context.l10n.dynamicConvert,
-          padding: .zero,
         ),
       );
     }
 
     if (_canHaveCharge(ref)) {
       actions.add(
-        SlidableAction(
+        TileAction(
           onPressed: (_) => _handleSetCharge(context, ref),
           backgroundColor: Colors.green,
           foregroundColor: Colors.white,
           icon: Icons.battery_charging_full,
           label: context.l10n.charge,
-          padding: .zero,
         ),
       );
     }
@@ -322,30 +308,28 @@ class _SlotRowDisplay extends ConsumerWidget {
     return actions;
   }
 
-  List<SlidableAction> _buildEndActions(BuildContext context, WidgetRef ref) {
-    final actions = <SlidableAction>[];
+  List<TileAction> _buildEndActions(BuildContext context, WidgetRef ref) {
+    final actions = <TileAction>[];
 
     if (slotInfo.slot.charge.isSome() && _canHaveCharge(ref)) {
       actions.add(
-        SlidableAction(
+        TileAction(
           onPressed: (_) => fitContext.fitWrapper.removeSlotCharge(slotIdent),
           backgroundColor: Colors.grey,
           foregroundColor: Colors.white,
           icon: Icons.cancel,
           label: context.l10n.charge,
-          padding: .zero,
         ),
       );
     }
 
     actions.add(
-      SlidableAction(
+      TileAction(
         onPressed: (_) => fitContext.fitWrapper.removeSlotAdjusted(slotIdent, ref),
         backgroundColor: colorActionDelete,
         foregroundColor: Colors.white,
         icon: Icons.delete,
         label: context.l10n.delete,
-        padding: .zero,
       ),
     );
 

--- a/lib/pages/fit/components/equipment/slot_row/subsystem_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/subsystem_slot.dart
@@ -32,20 +32,25 @@ class _SubsystemSlotRow extends ConsumerWidget {
     await fitContext.fitWrapper.equipSlot(slotIdent, typeId, ref);
   }
 
-  ActionPane _buildReplaceActionPane(BuildContext context, WidgetRef ref) => ActionPane(
-    extentRatio: 0.15,
-    motion: const StretchMotion(),
-    children: [
-      SlidableAction(
-        onPressed: (_) => _handleReplaceSubsystem(context, ref),
-        backgroundColor: Colors.grey.shade200,
-        foregroundColor: Colors.black,
-        icon: Icons.change_circle_outlined,
-        label: context.l10n.edit,
-        padding: .zero,
-      ),
-    ],
-  );
+  List<TileAction> _buildReplaceActions(BuildContext context, WidgetRef ref) => [
+    TileAction(
+      onPressed: (_) => _handleReplaceSubsystem(context, ref),
+      backgroundColor: Colors.grey.shade200,
+      foregroundColor: Colors.black,
+      icon: Icons.change_circle_outlined,
+      label: context.l10n.edit,
+    ),
+  ];
+
+  List<TileAction> _buildRemoveActions(BuildContext context, WidgetRef ref) => [
+    TileAction(
+      onPressed: (_) => _handleRemoveSubsystem(ref),
+      backgroundColor: colorActionDelete,
+      foregroundColor: Colors.white,
+      icon: Icons.delete,
+      label: context.l10n.delete,
+    ),
+  ];
 
   Widget _buildRecoveryRow(BuildContext context, WidgetRef ref, String title) {
     final content = ListTile(title: Text(title));
@@ -53,23 +58,15 @@ class _SubsystemSlotRow extends ConsumerWidget {
       return content;
     }
 
+    final startActions = _buildReplaceActions(context, ref);
+    final endActions = _buildRemoveActions(context, ref);
+
     return Slidable(
-      startActionPane: _buildReplaceActionPane(context, ref),
-      endActionPane: ActionPane(
-        extentRatio: 0.15,
-        motion: const StretchMotion(),
-        children: [
-          SlidableAction(
-            onPressed: (_) => _handleRemoveSubsystem(ref),
-            backgroundColor: colorActionDelete,
-            foregroundColor: Colors.white,
-            icon: Icons.delete,
-            label: context.l10n.delete,
-            padding: .zero,
-          ),
-        ],
+      startActionPane: buildTileActionPane(startActions),
+      endActionPane: buildTileActionPane(endActions),
+      child: SlidableEdgeZone(
+        child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
       ),
-      child: SlidableEdgeZone(child: content),
     );
   }
 
@@ -148,23 +145,15 @@ class _SubsystemSlotRow extends ConsumerWidget {
       return content;
     }
 
+    final startActions = _buildReplaceActions(context, ref);
+    final endActions = _buildRemoveActions(context, ref);
+
     return Slidable(
-      startActionPane: _buildReplaceActionPane(context, ref),
-      endActionPane: ActionPane(
-        extentRatio: 0.15,
-        motion: const StretchMotion(),
-        children: [
-          SlidableAction(
-            onPressed: (_) => _handleRemoveSubsystem(ref),
-            backgroundColor: colorActionDelete,
-            foregroundColor: Colors.white,
-            icon: Icons.delete,
-            label: context.l10n.delete,
-            padding: .zero,
-          ),
-        ],
+      startActionPane: buildTileActionPane(startActions),
+      endActionPane: buildTileActionPane(endActions),
+      child: SlidableEdgeZone(
+        child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
       ),
-      child: SlidableEdgeZone(child: content),
     );
   }
 }

--- a/lib/pages/fit/page.dart
+++ b/lib/pages/fit/page.dart
@@ -11,6 +11,7 @@ import "package:eve_fit_assistant/components/icon/state_icon.dart";
 import "package:eve_fit_assistant/components/layout.dart";
 import "package:eve_fit_assistant/components/list/eve_list_tile.dart";
 import "package:eve_fit_assistant/components/list/eve_select_list.dart";
+import "package:eve_fit_assistant/components/list/slide_action.dart";
 import "package:eve_fit_assistant/components/localized_text.dart";
 import "package:eve_fit_assistant/components/resonance_box.dart";
 import "package:eve_fit_assistant/components/resource_bar.dart";

--- a/test/components/list/slide_action_test.dart
+++ b/test/components/list/slide_action_test.dart
@@ -1,3 +1,4 @@
+import "package:eve_fit_assistant/compat/io.dart" show Platform;
 import "package:eve_fit_assistant/components/list/slide_action.dart";
 import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
@@ -86,28 +87,32 @@ void main() {
     expect(find.byIcon(Icons.more_vert), findsNothing);
   });
 
-  testWidgets("secondary tap lists all actions and invokes the selection", (tester) async {
-    final invoked = <String>[];
-    await tester.pumpWidget(
-      testApp(
-        Scaffold(
-          body: TileSecondaryActionRegion(
-            actions: [_action("A", () => invoked.add("A")), _action("B", () => invoked.add("B"))],
-            child: const ListTile(title: Text("tile")),
+  testWidgets(
+    "secondary tap lists all actions and invokes the selection",
+    (tester) async {
+      final invoked = <String>[];
+      await tester.pumpWidget(
+        testApp(
+          Scaffold(
+            body: TileSecondaryActionRegion(
+              actions: [_action("A", () => invoked.add("A")), _action("B", () => invoked.add("B"))],
+              child: const ListTile(title: Text("tile")),
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    await tester.tap(find.text("tile"), buttons: kSecondaryMouseButton);
-    await tester.pumpAndSettle();
+      await tester.tap(find.text("tile"), buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
 
-    expect(find.text("A"), findsOneWidget);
-    expect(find.text("B"), findsOneWidget);
+      expect(find.text("A"), findsOneWidget);
+      expect(find.text("B"), findsOneWidget);
 
-    await tester.tap(find.text("B"));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text("B"));
+      await tester.pumpAndSettle();
 
-    expect(invoked, ["B"]);
-  });
+      expect(invoked, ["B"]);
+    },
+    skip: !(Platform.isWindows || Platform.isLinux),
+  );
 }

--- a/test/components/list/slide_action_test.dart
+++ b/test/components/list/slide_action_test.dart
@@ -1,0 +1,113 @@
+import "package:eve_fit_assistant/components/list/slide_action.dart";
+import "package:flutter/gestures.dart";
+import "package:flutter/material.dart";
+import "package:flutter_slidable/flutter_slidable.dart";
+import "package:flutter_test/flutter_test.dart";
+
+import "../../test_helpers.dart";
+
+TileAction _action(String label, void Function() onInvoke) =>
+    TileAction(onPressed: (_) => onInvoke(), backgroundColor: Colors.grey, label: label);
+
+Widget _slidableTile(List<TileAction> actions) => Scaffold(
+  body: Slidable(
+    startActionPane: buildTileActionPane(actions),
+    child: const ListTile(title: Text("tile")),
+  ),
+);
+
+Future<void> _openStartPane(WidgetTester tester) async {
+  await tester.drag(find.text("tile"), const Offset(300, 0));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets("two actions are shown as-is without overflow", (tester) async {
+    await tester.pumpWidget(testApp(_slidableTile([_action("A", () {}), _action("B", () {})])));
+
+    await _openStartPane(tester);
+
+    expect(find.text("A"), findsOneWidget);
+    expect(find.text("B"), findsOneWidget);
+    expect(find.byIcon(Icons.more_vert), findsNothing);
+  });
+
+  testWidgets("three actions fold into overflow menu that invokes the selection", (tester) async {
+    final invoked = <String>[];
+    await tester.pumpWidget(
+      testApp(
+        _slidableTile([
+          _action("A", () => invoked.add("A")),
+          _action("B", () => invoked.add("B")),
+          _action("C", () => invoked.add("C")),
+        ]),
+      ),
+    );
+
+    await _openStartPane(tester);
+
+    expect(find.text("A"), findsOneWidget);
+    expect(find.text("B"), findsNothing);
+    expect(find.byIcon(Icons.more_vert), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+
+    expect(find.text("B"), findsOneWidget);
+    expect(find.text("C"), findsOneWidget);
+
+    await tester.tap(find.text("C"));
+    await tester.pumpAndSettle();
+
+    expect(invoked, ["C"]);
+    expect(find.byIcon(Icons.more_vert), findsNothing);
+  });
+
+  testWidgets("dismissing the overflow menu invokes nothing and closes the pane", (tester) async {
+    final invoked = <String>[];
+    await tester.pumpWidget(
+      testApp(
+        _slidableTile([
+          _action("A", () {}),
+          _action("B", () => invoked.add("B")),
+          _action("C", () {}),
+        ]),
+      ),
+    );
+
+    await _openStartPane(tester);
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    expect(invoked, isEmpty);
+    expect(find.byIcon(Icons.more_vert), findsNothing);
+  });
+
+  testWidgets("secondary tap lists all actions and invokes the selection", (tester) async {
+    final invoked = <String>[];
+    await tester.pumpWidget(
+      testApp(
+        Scaffold(
+          body: TileSecondaryActionRegion(
+            actions: [_action("A", () => invoked.add("A")), _action("B", () => invoked.add("B"))],
+            child: const ListTile(title: Text("tile")),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text("tile"), buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text("A"), findsOneWidget);
+    expect(find.text("B"), findsOneWidget);
+
+    await tester.tap(find.text("B"));
+    await tester.pumpAndSettle();
+
+    expect(invoked, ["B"]);
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable actions for list and equipment tiles.
  * Added overflow menus when tiles have multiple actions.
  * Added right-click action support on Windows and Linux.
  * Added localized “More” text in English and Chinese.
* **Improvements**
  * Standardized swipe and secondary actions across equipment slots.
  * Preserved existing recovery, conversion, charging, copying, and deletion actions.
* **Tests**
  * Added coverage for action display, overflow menus, dismissal, and secondary-click selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->