### PR TITLE
refactor(fit): reorder module tile start slide actions to charge, dynamic, copy

### DIFF
--- a/lib/pages/fit/components/equipment/slot_row/slot_row.dart
+++ b/lib/pages/fit/components/equipment/slot_row/slot_row.dart
@@ -257,15 +257,14 @@ class _SlotRowDisplay extends ConsumerWidget {
     final actions = <TileAction>[];
     final isDynamic = fitContext.dynamicItemFor(slotInfo.slot.itemId) != null;
 
-    if (_canCopy()) {
+    if (_canHaveCharge(ref)) {
       actions.add(
         TileAction(
-          onPressed: (_) => _handleCopy(context, ref),
-          autoClose: false,
-          icon: Icons.copy,
-          backgroundColor: Colors.grey.shade200,
-          foregroundColor: Colors.black,
-          label: context.l10n.copy,
+          onPressed: (_) => _handleSetCharge(context, ref),
+          backgroundColor: Colors.green,
+          foregroundColor: Colors.white,
+          icon: Icons.battery_charging_full,
+          label: context.l10n.charge,
         ),
       );
     }
@@ -293,14 +292,15 @@ class _SlotRowDisplay extends ConsumerWidget {
       );
     }
 
-    if (_canHaveCharge(ref)) {
+    if (_canCopy()) {
       actions.add(
         TileAction(
-          onPressed: (_) => _handleSetCharge(context, ref),
-          backgroundColor: Colors.green,
-          foregroundColor: Colors.white,
-          icon: Icons.battery_charging_full,
-          label: context.l10n.charge,
+          onPressed: (_) => _handleCopy(context, ref),
+          autoClose: false,
+          icon: Icons.copy,
+          backgroundColor: Colors.grey.shade200,
+          foregroundColor: Colors.black,
+          label: context.l10n.copy,
         ),
       );
     }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the equipment slot action order so charging appears first, followed by dynamic-item actions and copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->