### PR TITLE
feat(fit): group module tile dropdown actions with dividers

### DIFF
--- a/lib/components/list/slide_action.dart
+++ b/lib/components/list/slide_action.dart
@@ -19,6 +19,7 @@ class TileAction {
     this.label,
     this.foregroundColor,
     this.autoClose = true,
+    this.group,
   }) : assert(icon != null || label != null);
 
   final IconData? icon;
@@ -26,6 +27,13 @@ class TileAction {
   final Color backgroundColor;
   final Color? foregroundColor;
   final bool autoClose;
+
+  /// Optional key identifying the action's visual group in dropdown menus.
+  ///
+  /// Menu entries are separated by a thin divider whenever the [group] of two
+  /// adjacent actions differs (see [showTileActionsMenu]).
+  final Object? group;
+
   final void Function(BuildContext context) onPressed;
 
   SlidableAction toSlidableAction() => SlidableAction(
@@ -64,6 +72,9 @@ ActionPane? buildTileActionPane(List<TileAction> actions) {
 
 /// Opens a dropdown listing [actions] (icon + label, no background color) at
 /// [position] and returns the selected action, if any.
+///
+/// A thin divider is inserted between adjacent actions whose
+/// [TileAction.group] differs.
 Future<TileAction?> showTileActionsMenu(
   BuildContext context,
   RelativeRect position,
@@ -72,7 +83,8 @@ Future<TileAction?> showTileActionsMenu(
   context: context,
   position: position,
   items: [
-    for (final action in actions)
+    for (final (index, action) in actions.indexed) ...[
+      if (index > 0 && actions[index - 1].group != action.group) const PopupMenuDivider(),
       PopupMenuItem(
         value: action,
         child: Row(
@@ -82,6 +94,7 @@ Future<TileAction?> showTileActionsMenu(
           ],
         ),
       ),
+    ],
   ],
 );
 
@@ -90,6 +103,24 @@ Future<TileAction?> showTileActionsMenu(
 void _dispatchTileAction(BuildContext context, TileAction selected) {
   if (selected.autoClose) unawaited(Slidable.of(context)?.close());
   selected.onPressed(context);
+}
+
+/// Flattens [actions] into dropdown order: actions sharing a
+/// [TileAction.group] key become contiguous, following [groupOrder]; actions
+/// without a group listed in [groupOrder] keep their relative order at the
+/// end.
+List<TileAction> flattenTileActionGroups(Iterable<TileAction> actions, List<Object> groupOrder) {
+  final byGroup = <Object, List<TileAction>>{};
+  final rest = <TileAction>[];
+  for (final action in actions) {
+    final group = action.group;
+    if (group != null && groupOrder.contains(group)) {
+      byGroup.putIfAbsent(group, () => []).add(action);
+    } else {
+      rest.add(action);
+    }
+  }
+  return [for (final group in groupOrder) ...?byGroup[group], ...rest];
 }
 
 class _OverflowTileActionButton extends StatelessWidget {

--- a/lib/pages/fit/components/equipment/slot_row/slot_row.dart
+++ b/lib/pages/fit/components/equipment/slot_row/slot_row.dart
@@ -2,6 +2,9 @@ part of "../../../page.dart";
 
 const bool _dynamicItemConversionEnabled = true;
 
+/// Visual groups of a slot tile's dropdown actions, in dropdown order.
+enum _SlotActionGroup { action, charge, abyss }
+
 class _AnySlotRow extends StatelessWidget {
   const _AnySlotRow({
     required this.fitContext,
@@ -248,7 +251,13 @@ class _SlotRowDisplay extends ConsumerWidget {
       startActionPane: buildTileActionPane(startActions),
       endActionPane: buildTileActionPane(endActions),
       child: SlidableEdgeZone(
-        child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
+        child: TileSecondaryActionRegion(
+          actions: flattenTileActionGroups([
+            ...startActions,
+            ...endActions,
+          ], _SlotActionGroup.values),
+          child: content,
+        ),
       ),
     );
   }
@@ -265,6 +274,7 @@ class _SlotRowDisplay extends ConsumerWidget {
           foregroundColor: Colors.white,
           icon: Icons.battery_charging_full,
           label: context.l10n.charge,
+          group: _SlotActionGroup.charge,
         ),
       );
     }
@@ -277,6 +287,7 @@ class _SlotRowDisplay extends ConsumerWidget {
           foregroundColor: Colors.white,
           icon: Icons.cyclone_outlined,
           label: context.l10n.dynamicRevert,
+          group: _SlotActionGroup.abyss,
         ),
       );
     } else if (_supportsDynamicItemConversion() &&
@@ -288,6 +299,7 @@ class _SlotRowDisplay extends ConsumerWidget {
           foregroundColor: Colors.white,
           icon: Icons.cyclone_outlined,
           label: context.l10n.dynamicConvert,
+          group: _SlotActionGroup.abyss,
         ),
       );
     }
@@ -301,6 +313,7 @@ class _SlotRowDisplay extends ConsumerWidget {
           backgroundColor: Colors.grey.shade200,
           foregroundColor: Colors.black,
           label: context.l10n.copy,
+          group: _SlotActionGroup.action,
         ),
       );
     }
@@ -319,6 +332,7 @@ class _SlotRowDisplay extends ConsumerWidget {
           foregroundColor: Colors.white,
           icon: Icons.cancel,
           label: context.l10n.charge,
+          group: _SlotActionGroup.charge,
         ),
       );
     }
@@ -330,6 +344,7 @@ class _SlotRowDisplay extends ConsumerWidget {
         foregroundColor: Colors.white,
         icon: Icons.delete,
         label: context.l10n.delete,
+        group: _SlotActionGroup.action,
       ),
     );
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added grouped action menus with visual dividers between action categories.
  * Actions now appear in a consistent, prioritized order while preserving uncategorized actions.
  * Equipment slot actions are organized into clearer categories, including charge, dynamic, copy, and delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->