### PR TITLE
feat(fit): place overflow dropdown before visible action on tile end slide pane

### DIFF
--- a/lib/components/list/slide_action.dart
+++ b/lib/components/list/slide_action.dart
@@ -51,7 +51,9 @@ class TileAction {
 ///
 /// Up to [_kMaxVisibleActions] actions are shown as-is. With more actions the
 /// first one stays visible and the rest fold into a dropdown overflow button.
-ActionPane? buildTileActionPane(List<TileAction> actions) {
+/// The visible action comes first unless [overflowFirst] is set (used by the
+/// end pane so the overflow button stays adjacent to the tile).
+ActionPane? buildTileActionPane(List<TileAction> actions, {bool overflowFirst = false}) {
   if (actions.isEmpty) return null;
   if (actions.length <= _kMaxVisibleActions) {
     return ActionPane(
@@ -64,8 +66,13 @@ ActionPane? buildTileActionPane(List<TileAction> actions) {
     extentRatio: _kActionExtentRatio * _kMaxVisibleActions,
     motion: const StretchMotion(),
     children: [
-      actions.first.toSlidableAction(),
-      _OverflowTileActionButton(actions: actions.sublist(1)),
+      if (overflowFirst) ...[
+        _OverflowTileActionButton(actions: actions.sublist(1)),
+        actions.first.toSlidableAction(),
+      ] else ...[
+        actions.first.toSlidableAction(),
+        _OverflowTileActionButton(actions: actions.sublist(1)),
+      ],
     ],
   );
 }

--- a/lib/pages/fit/components/equipment/slot_row/drone_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/drone_slot.dart
@@ -85,7 +85,7 @@ class _DroneSlotRow extends ConsumerWidget {
     if (!interactionOptions.allowMutations) return content;
 
     return Slidable(
-      endActionPane: buildTileActionPane(recoveryActions),
+      endActionPane: buildTileActionPane(recoveryActions, overflowFirst: true),
       child: SlidableEdgeZone(
         child: TileSecondaryActionRegion(actions: recoveryActions, child: content),
       ),
@@ -160,7 +160,7 @@ class _DroneSlotRow extends ConsumerWidget {
 
     return Slidable(
       startActionPane: buildTileActionPane(startActions),
-      endActionPane: buildTileActionPane(endActions),
+      endActionPane: buildTileActionPane(endActions, overflowFirst: true),
       child: SlidableEdgeZone(
         child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
       ),

--- a/lib/pages/fit/components/equipment/slot_row/fighter_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/fighter_slot.dart
@@ -236,7 +236,7 @@ class _FighterSlotRow extends ConsumerWidget {
 
     return Slidable(
       startActionPane: buildTileActionPane(startActions),
-      endActionPane: buildTileActionPane(endActions),
+      endActionPane: buildTileActionPane(endActions, overflowFirst: true),
       child: SlidableEdgeZone(
         child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
       ),

--- a/lib/pages/fit/components/equipment/slot_row/slot_row.dart
+++ b/lib/pages/fit/components/equipment/slot_row/slot_row.dart
@@ -249,7 +249,7 @@ class _SlotRowDisplay extends ConsumerWidget {
 
     return Slidable(
       startActionPane: buildTileActionPane(startActions),
-      endActionPane: buildTileActionPane(endActions),
+      endActionPane: buildTileActionPane(endActions, overflowFirst: true),
       child: SlidableEdgeZone(
         child: TileSecondaryActionRegion(
           actions: flattenTileActionGroups([

--- a/lib/pages/fit/components/equipment/slot_row/subsystem_slot.dart
+++ b/lib/pages/fit/components/equipment/slot_row/subsystem_slot.dart
@@ -63,7 +63,7 @@ class _SubsystemSlotRow extends ConsumerWidget {
 
     return Slidable(
       startActionPane: buildTileActionPane(startActions),
-      endActionPane: buildTileActionPane(endActions),
+      endActionPane: buildTileActionPane(endActions, overflowFirst: true),
       child: SlidableEdgeZone(
         child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
       ),
@@ -150,7 +150,7 @@ class _SubsystemSlotRow extends ConsumerWidget {
 
     return Slidable(
       startActionPane: buildTileActionPane(startActions),
-      endActionPane: buildTileActionPane(endActions),
+      endActionPane: buildTileActionPane(endActions, overflowFirst: true),
       child: SlidableEdgeZone(
         child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
       ),


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Overflow actions now appear before visible actions in equipment slot menus.
  * Updated drone, fighter, subsystem, and standard equipment slots for consistent action ordering.
  * Existing menus retain their default ordering where the new behavior is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->