### PR TITLE
fix(build): refuse to optimise rustls kotlin component

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,5 @@
+# rustls-platform-verifier calls its Kotlin component by name over JNI
+# (org.rustls.platformverifier.CertificateVerifier). With no Java-side
+# references, R8 strips it from release builds and TLS verification fails
+# with ClassNotFoundException at runtime.
+-keep class org.rustls.platformverifier.** { *; }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release builds so certificate verification continues to work correctly on Android.
  * Prevented required security components from being removed during app optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->