### PR TITLE
feat(data): sync snapshot engine data into Cloudflare D1

### DIFF
--- a/.github/actions/sync-platform-d1/action.yml
+++ b/.github/actions/sync-platform-d1/action.yml
@@ -1,0 +1,40 @@
+name: Sync snapshot to platform D1
+
+description: >-
+  Sync the built resource snapshots' engine data (types, type dogma, dogma
+  attributes, dogma effects, buffs, plus name/icon metadata) into the
+  efa-platform-prod D1 database via the efa-platform-data-sync worker.
+  Expects the v2-snapshots artifact contents (cache/remote/assets/ and
+  snapshot-hashes.json) to already be present in the working directory,
+  protobuf bindings generated, and efa.dev.toml initialized.
+
+inputs:
+  token:
+    description: "Bearer token matching the worker's SYNC_TOKEN secret"
+    required: true
+  hashes:
+    description: "Path to the snapshot hashes JSON file"
+    required: false
+    default: "snapshot-hashes.json"
+  schema-root:
+    description: "Schema V2 root containing the snapshots"
+    required: false
+    default: "cache/remote"
+
+runs:
+  using: composite
+  steps:
+    - name: Sync snapshots to platform D1
+      shell: bash
+      env:
+        D1_SYNC_TOKEN: ${{ inputs.token }}
+        HASHES: ${{ inputs.hashes }}
+        SCHEMA_ROOT: ${{ inputs.schema-root }}
+      run: |
+        # shellcheck disable=SC2016
+        nix develop .#python --command bash -c \
+          'uv run x.py \
+            --dev-env d1.token="${D1_SYNC_TOKEN}" \
+            ci release-data d1-sync \
+            --hashes "${HASHES}" \
+            --schema-root "${SCHEMA_ROOT}"'

--- a/.github/workflows/_release-data.yml
+++ b/.github/workflows/_release-data.yml
@@ -30,6 +30,9 @@ on:
       REMOTE_STORAGE_SECRET_KEY:
         description: "Remote S3 secret key for publishing"
         required: false
+      D1_SYNC_TOKEN:
+        description: "Bearer token for the platform D1 data-sync worker"
+        required: false
 
 permissions:
   contents: read
@@ -187,3 +190,45 @@ jobs:
             ${{ secrets.CI_STORAGE_SECRET_KEY }}
             ${{ secrets.REMOTE_STORAGE_ACCESS_KEY }}
             ${{ secrets.REMOTE_STORAGE_SECRET_KEY }}
+
+  d1-sync:
+    name: Sync snapshots to platform D1
+    needs: publish
+    # No D1 mock exists for test mode; real releases only.
+    if: inputs.test_mode == false
+    runs-on: ubuntu-latest
+    environment: production-data
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Install Python dependencies
+        run: nix develop .#python --command bash -c 'uv sync'
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: v2-snapshots
+          path: .
+
+      - name: Generate protobuf
+        run: nix develop .#codegen --command bash -c 'uv run x.py generate protobuf'
+
+      - name: Init dev env
+        uses: ./.github/actions/init-dev-env
+
+      - name: Sync snapshots to platform D1
+        uses: ./.github/actions/sync-platform-d1
+        with:
+          token: ${{ secrets.D1_SYNC_TOKEN }}
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: ./.github/actions/upload-diagnostics
+        with:
+          name: diagnostics-data-d1-sync
+          redact-values: |
+            ${{ secrets.D1_SYNC_TOKEN }}

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -541,3 +541,73 @@ def register_ci_commands(cli_group: click.Group) -> None:
                 f"Remote head verified: {synced_hash[:16]}...",
             )
         )
+
+    @release_data.command("d1-sync")
+    @click.option(
+        "--hashes",
+        type=click.Path(exists=True, file_okay=True, path_type=Path),
+        default="snapshot-hashes.json",
+        help="Path to the snapshot hashes JSON file.",
+    )
+    @click.option(
+        "--schema-root",
+        type=click.Path(file_okay=False, path_type=Path),
+        default="cache/remote",
+        help="Schema V2 root containing the snapshots (default: cache/remote).",
+    )
+    @click.option("--url", default=None, help="Override the data-sync worker URL.")
+    @click.option("--token", default=None, help="Override the data-sync bearer token.")
+    @click.option(
+        "--batch-size",
+        type=click.IntRange(min=1),
+        default=2000,
+        help="Rows per upload request (default: 2000).",
+    )
+    @click.option(
+        "--dry-run",
+        is_flag=True,
+        help="Decode and count entries without uploading.",
+    )
+    def release_data_d1_sync(
+        hashes: Path,
+        schema_root: Path,
+        url: str | None,
+        token: str | None,
+        batch_size: int,
+        dry_run: bool,
+    ):
+        """Sync snapshot engine data into the platform D1 database."""
+        import bootstrap.config
+
+        from bootstrap.data.d1.sync import HttpTransport
+        from bootstrap.data.d1.sync import run_sync
+
+        resolved_root = (PROJECT_ROOT / schema_root).resolve()
+        hashes_path = (PROJECT_ROOT / hashes).resolve()
+        hashes_data = json.loads(hashes_path.read_text(encoding="utf-8"))
+        if not isinstance(hashes_data, dict):
+            raise click.ClickException(f"Invalid hashes file: {hashes_path}")
+
+        bootstrap.config.DeveloperConfiguration.ensure_loaded()
+        d1 = bootstrap.config.DEV_CONFIGURATION.d1
+
+        resolved_url = url or d1.url
+        resolved_token = token or (d1.token.get_secret_value() if d1.token else None)
+
+        transport = None
+        if not dry_run:
+            if not resolved_token:
+                raise click.ClickException(
+                    "No D1 sync token configured. Set [d1].token in efa.dev.toml, "
+                    "pass --token, or use --dev-env d1.token=... (or --dry-run)."
+                )
+            transport = HttpTransport(resolved_url, resolved_token)
+
+        run_sync(
+            hashes_data,
+            resolved_root,
+            transport,
+            batch_size=batch_size,
+            dry_run=dry_run,
+        )
+        click.echo(styled([Style.BRIGHT, Fore.GREEN], "D1 sync completed."))

--- a/bootstrap/config.py
+++ b/bootstrap/config.py
@@ -387,6 +387,13 @@ class DeveloperCi(BaseModel):
         return self.raw_artifacts, self.require_storage()
 
 
+class DeveloperD1(BaseModel):
+    """Platform D1 sync endpoint configuration."""
+
+    url: str = Field(default="https://api.efa-tech.dev/platform/storage/data-sync")
+    token: SecretStr | None = None
+
+
 class DeveloperConfiguration(BaseModel):
     paths: DeveloperPaths = Field(default_factory=DeveloperPaths)
     workspace: DeveloperWorkspace = Field(default_factory=DeveloperWorkspace)
@@ -395,6 +402,7 @@ class DeveloperConfiguration(BaseModel):
     native: DeveloperNative = Field(default_factory=DeveloperNative)
     remote: DeveloperRemote = Field(default_factory=DeveloperRemote)
     ci: DeveloperCi = Field(default_factory=DeveloperCi)
+    d1: DeveloperD1 = Field(default_factory=DeveloperD1)
 
     @staticmethod
     def load_from_global():

--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -298,6 +298,9 @@ def run_sync(
     Content rows are deduplicated across servers before uploading (identical
     entries share a content hash); registration rows are uploaded per server.
     """
+    if not 1 <= batch_size <= 10_000:
+        raise ValueError(f"batch_size must be between 1 and 10000, got {batch_size}")
+
     content: dict[tuple[str, str], bytes] = {}
     registrations: dict[tuple[str, str], list[Registration]] = {}
 

--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -10,6 +10,10 @@ the ``efa-platform-prod`` D1 database.
 Layout per family ``<f>``:
   - table ``<f>``:     (content_hash TEXT PRIMARY KEY, content BLOB)
   - table ``<f>_reg``: (server_id, snapshot_hash, entry_id, content_hash)
+
+A snapshot is only complete once the uploader has posted every content and
+registration batch and then marked it in the ``snapshots`` registry table
+(``POST complete``); readers must check that registry before serving data.
 """
 
 from __future__ import annotations
@@ -329,3 +333,16 @@ def run_sync(
                 {"server_id": server_id, "snapshot_hash": snapshot_hash, "entries": batch},
             )
         info(f"Registered {len(reg_rows)} rows for {server_id} ({snapshot_hash[:16]}...)")
+
+        # Completeness marker: only reached when every content batch and every
+        # registration batch for this snapshot succeeded. Readers treat a
+        # snapshot without this marker as incomplete.
+        transport.post(
+            "complete",
+            {
+                "server_id": server_id,
+                "snapshot_hash": snapshot_hash,
+                "entry_count": len(reg_rows),
+            },
+        )
+        info(f"Marked snapshot complete for {server_id} ({snapshot_hash[:16]}...)")

--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 
 from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -68,10 +69,10 @@ class Entry:
     family: str
     entry_id: int
     content: bytes
+    hash: str = field(init=False)
 
-    @property
-    def hash(self) -> str:
-        return content_hash(self.content)
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "hash", content_hash(self.content))
 
 
 @dataclass(frozen=True)
@@ -93,14 +94,29 @@ class HttpTransport:
     """requests-based transport for the platform data-sync worker."""
 
     def __init__(self, base_url: str, token: str, timeout: float = 120.0) -> None:
+        import requests
+
+        from requests.adapters import HTTPAdapter
+        from urllib3.util.retry import Retry
+
         self._base_url = base_url.rstrip("/")
         self._token = token
         self._timeout = timeout
+        self._session = requests.Session()
+        # Both endpoints are idempotent (INSERT OR IGNORE / INSERT OR REPLACE),
+        # so retrying a POST on transient failures is safe.
+        retry = Retry(
+            total=5,
+            backoff_factor=1.0,
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=frozenset({"POST"}),
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
 
     def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
-        import requests
-
-        resp = requests.post(
+        resp = self._session.post(
             f"{self._base_url}/{path.lstrip('/')}",
             json=payload,
             headers={"Authorization": f"Bearer {self._token}"},
@@ -283,7 +299,7 @@ def run_sync(
     entries share a content hash); registration rows are uploaded per server.
     """
     content: dict[tuple[str, str], bytes] = {}
-    registrations: dict[str, list[Registration]] = {}
+    registrations: dict[tuple[str, str], list[Registration]] = {}
 
     for server_id, snapshot_hash in sorted(hashes.items()):
         info(f"Loading snapshot entries for {server_id} ({snapshot_hash[:16]}...)...")
@@ -292,7 +308,7 @@ def run_sync(
         for entry in entries:
             content.setdefault((entry.family, entry.hash), entry.content)
             regs.append(Registration(entry.family, entry.entry_id, entry.hash))
-        registrations[f"{server_id}\n{snapshot_hash}"] = regs
+        registrations[(server_id, snapshot_hash)] = regs
 
     info(f"Total unique content rows: {len(content)}")
     info(f"Total registration rows: {sum(len(r) for r in registrations.values())}")
@@ -321,8 +337,7 @@ def run_sync(
         reply = transport.post("content", {"entries": batch})
         info(f"Uploaded {len(batch)} content rows (inserted: {reply.get('inserted', '?')})")
 
-    for server_key, regs in sorted(registrations.items()):
-        server_id, snapshot_hash = server_key.split("\n", 1)
+    for (server_id, snapshot_hash), regs in sorted(registrations.items()):
         reg_rows = [
             {"family": reg.family, "entry_id": reg.entry_id, "content_hash": reg.hash}
             for reg in regs

--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -1,0 +1,331 @@
+"""Sync resource snapshot engine data into the platform D1 database.
+
+Splits the snapshot's native engine protobuf collections (types, type dogma,
+dogma attributes, dogma effects, buff collections) into per-entry rows and
+builds per-entry name/icon metadata from the snapshot's collection and
+localization database, then uploads everything to the platform data-sync
+worker (``api.efa-tech.dev/platform/storage/data-sync``), which stores them in
+the ``efa-platform-prod`` D1 database.
+
+Layout per family ``<f>``:
+  - table ``<f>``:     (content_hash TEXT PRIMARY KEY, content BLOB)
+  - table ``<f>_reg``: (server_id, snapshot_hash, entry_id, content_hash)
+"""
+
+from __future__ import annotations
+
+import base64
+import sqlite3
+import sys
+import tempfile
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Protocol
+
+from bootstrap.constant import NATIVE_LIB_ROOT
+from bootstrap.log import info
+from bootstrap.remote.hash import content_hash
+from bootstrap.remote.hash import ident_hash
+from bootstrap.remote.models import read_pb2
+from bootstrap.remote.paths import blob_path
+from bootstrap.remote.paths import resource_snapshot_dir
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+#: Engine data families, mapped to their snapshot resource IDs and the efos
+#: protobuf message used to decode the whole collection.
+ENGINE_FAMILIES: dict[str, tuple[str, str]] = {
+    "types": ("resource://static/native/types.pb2", "Types"),
+    "type_dogma": ("resource://static/native/typeDogma.pb2", "TypeDogma"),
+    "dogma_attributes": ("resource://static/native/dogmaAttributes.pb2", "DogmaAttributes"),
+    "dogma_effects": ("resource://static/native/dogmaEffects.pb2", "DogmaEffects"),
+    "buffs": ("resource://static/native/dbuffcollections.pb2", "BuffCollections"),
+}
+
+COLLECTION_RESOURCE_ID = "resource://static/collection.pb2"
+LOCALIZATION_RESOURCE_ID = "resource://localization/localization.db"
+
+#: Metadata families built at sync time (not present as snapshot resources).
+META_FAMILIES = ("type_meta", "dogma_attribute_meta", "dogma_effect_meta")
+
+ALL_FAMILIES = tuple(ENGINE_FAMILIES) + META_FAMILIES
+
+
+@dataclass(frozen=True)
+class Entry:
+    """A single D1 content row candidate."""
+
+    family: str
+    entry_id: int
+    content: bytes
+
+    @property
+    def hash(self) -> str:
+        return content_hash(self.content)
+
+
+@dataclass(frozen=True)
+class Registration:
+    """A single ``<family>_reg`` row."""
+
+    family: str
+    entry_id: int
+    hash: str
+
+
+class SyncTransport(Protocol):
+    """POST a JSON payload to a worker endpoint path and return the decoded reply."""
+
+    def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]: ...
+
+
+class HttpTransport:
+    """requests-based transport for the platform data-sync worker."""
+
+    def __init__(self, base_url: str, token: str, timeout: float = 120.0) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._token = token
+        self._timeout = timeout
+
+    def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        import requests
+
+        resp = requests.post(
+            f"{self._base_url}/{path.lstrip('/')}",
+            json=payload,
+            headers={"Authorization": f"Bearer {self._token}"},
+            timeout=self._timeout,
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"D1 sync request to {path} failed with HTTP {resp.status_code}: {resp.text[:500]}"
+            )
+        body = resp.json()
+        if not body.get("ok", False):
+            raise RuntimeError(f"D1 sync request to {path} returned error: {body}")
+        return body
+
+
+def _load_efos_pb2():
+    """Import the checked-in efos protobuf bindings from the engine crate."""
+    root = str(NATIVE_LIB_ROOT)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    import efos_pb2
+
+    return efos_pb2
+
+
+def _load_resource_index(schema_root: Path, snapshot_hash: str):
+    from bootstrap.remote.models import ResourceIndex
+
+    index_path = resource_snapshot_dir(schema_root, snapshot_hash) / "resources.pb2"
+    if not index_path.exists():
+        raise FileNotFoundError(f"Resource index not found: {index_path}")
+    return read_pb2(index_path, ResourceIndex)
+
+
+def _resolve_blob(schema_root: Path, index, resource_id: str) -> bytes:
+    """Read a blob from the schema root addressed by its snapshot resource entry."""
+    for entry in index.entries:
+        if entry.resource_id == resource_id:
+            path = blob_path(schema_root, ident_hash(resource_id), entry.content_hash)
+            if not path.exists():
+                raise FileNotFoundError(f"Blob missing for {resource_id}: {path}")
+            return path.read_bytes()
+    raise KeyError(f"Resource {resource_id} not present in snapshot index")
+
+
+def split_engine_entries(family: str, data: bytes) -> list[Entry]:
+    """Split a whole-collection efos protobuf into per-entry rows."""
+    efos_pb2 = _load_efos_pb2()
+    _resource_id, message_name = ENGINE_FAMILIES[family]
+    msg = getattr(efos_pb2, message_name)()
+    msg.ParseFromString(data)
+    return [
+        Entry(family, int(entry_id), value.SerializeToString())
+        for entry_id, value in sorted(msg.entries.items())
+    ]
+
+
+def _load_localized_strings(db_path: Path) -> tuple[list[str], dict[tuple[str, int], str]]:
+    """Load all localization strings: (locales, (locale, id) -> value)."""
+    connection = sqlite3.connect(db_path)
+    try:
+        locales = [row[0] for row in connection.execute("SELECT DISTINCT locale FROM strings")]
+        strings = {
+            (locale, entry_id): value
+            for locale, entry_id, value in connection.execute(
+                "SELECT locale, id, value FROM strings"
+            )
+        }
+    finally:
+        connection.close()
+    return sorted(locales), strings
+
+
+def build_meta_entries(
+    collection_data: bytes,
+    localization_db_data: bytes,
+    effect_names: dict[int, str],
+) -> list[Entry]:
+    """Build per-entry name/icon metadata rows from collection + localization data.
+
+    ``effect_names`` maps dogma effect IDs to their internal effect names,
+    taken from the native dogmaEffects collection (effects carry no display
+    name or icon in the source data).
+    """
+    from bootstrap.data.schema import collections_pb2
+    from bootstrap.data.schema import platform_data_pb2
+
+    collection = collections_pb2.Collection()
+    collection.ParseFromString(collection_data)
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+        tmp.write(localization_db_data)
+        tmp.flush()
+        locales, strings = _load_localized_strings(Path(tmp.name))
+
+    entries: list[Entry] = []
+
+    def _names(loc_id: int) -> dict[str, str]:
+        return {
+            locale: strings[(locale, loc_id)] for locale in locales if (locale, loc_id) in strings
+        }
+
+    for type_id, type_pb in sorted(collection.types.items()):
+        meta = platform_data_pb2.PlatformTypeMeta(type_id=type_id)
+        for locale, value in _names(type_pb.type_name.id).items():
+            meta.name[locale] = value
+        if type_pb.icon.HasField("icon_id"):
+            meta.icon_id = type_pb.icon.icon_id
+        if type_pb.icon.HasField("graphic_id"):
+            meta.graphic_id = type_pb.icon.graphic_id
+        entries.append(Entry("type_meta", int(type_id), meta.SerializeToString()))
+
+    for attribute_id, attribute_pb in sorted(collection.dogma_attributes.items()):
+        meta = platform_data_pb2.PlatformDogmaAttributeMeta(dogma_attribute_id=attribute_id)
+        if attribute_pb.HasField("display_name"):
+            names = _names(attribute_pb.display_name.id)
+        else:
+            names = {}
+        for locale in locales:
+            meta.name[locale] = names.get(locale, attribute_pb.name)
+        if attribute_pb.icon.HasField("icon_id"):
+            meta.icon_id = attribute_pb.icon.icon_id
+        entries.append(Entry("dogma_attribute_meta", int(attribute_id), meta.SerializeToString()))
+
+    for effect_id, name in sorted(effect_names.items()):
+        meta = platform_data_pb2.PlatformDogmaEffectMeta(dogma_effect_id=effect_id, name=name)
+        entries.append(Entry("dogma_effect_meta", int(effect_id), meta.SerializeToString()))
+
+    return entries
+
+
+def load_snapshot_entries(schema_root: Path, snapshot_hash: str) -> list[Entry]:
+    """Decode every D1-bound entry (engine families + metadata) for a snapshot."""
+    index = _load_resource_index(schema_root, snapshot_hash)
+
+    entries: list[Entry] = []
+    for family, (resource_id, _message_name) in ENGINE_FAMILIES.items():
+        blob = _resolve_blob(schema_root, index, resource_id)
+        family_entries = split_engine_entries(family, blob)
+        info(f"Snapshot {snapshot_hash[:16]}...: {len(family_entries)} {family} entries")
+        entries.extend(family_entries)
+
+    effect_names = {
+        entry.entry_id: _decode_effect_name(entry.content)
+        for entry in entries
+        if entry.family == "dogma_effects"
+    }
+
+    collection_blob = _resolve_blob(schema_root, index, COLLECTION_RESOURCE_ID)
+    localization_blob = _resolve_blob(schema_root, index, LOCALIZATION_RESOURCE_ID)
+    meta_entries = build_meta_entries(collection_blob, localization_blob, effect_names)
+    info(f"Snapshot {snapshot_hash[:16]}...: {len(meta_entries)} metadata entries")
+    entries.extend(meta_entries)
+
+    return entries
+
+
+def _decode_effect_name(entry_content: bytes) -> str:
+    efos_pb2 = _load_efos_pb2()
+    effect = efos_pb2.DogmaEffects.DogmaEffect()
+    effect.ParseFromString(entry_content)
+    return effect.name
+
+
+def _batched(items: list, batch_size: int) -> Iterable[list]:
+    for offset in range(0, len(items), batch_size):
+        yield items[offset : offset + batch_size]
+
+
+def run_sync(
+    hashes: dict[str, str],
+    schema_root: Path,
+    transport: SyncTransport | None,
+    batch_size: int = 2000,
+    dry_run: bool = False,
+) -> None:
+    """Sync every server snapshot in ``hashes`` to the platform D1 database.
+
+    Content rows are deduplicated across servers before uploading (identical
+    entries share a content hash); registration rows are uploaded per server.
+    """
+    content: dict[tuple[str, str], bytes] = {}
+    registrations: dict[str, list[Registration]] = {}
+
+    for server_id, snapshot_hash in sorted(hashes.items()):
+        info(f"Loading snapshot entries for {server_id} ({snapshot_hash[:16]}...)...")
+        entries = load_snapshot_entries(schema_root, snapshot_hash)
+        regs: list[Registration] = []
+        for entry in entries:
+            content.setdefault((entry.family, entry.hash), entry.content)
+            regs.append(Registration(entry.family, entry.entry_id, entry.hash))
+        registrations[f"{server_id}\n{snapshot_hash}"] = regs
+
+    info(f"Total unique content rows: {len(content)}")
+    info(f"Total registration rows: {sum(len(r) for r in registrations.values())}")
+
+    if dry_run:
+        per_family: dict[str, int] = {}
+        for family, _hash in content:
+            per_family[family] = per_family.get(family, 0) + 1
+        for family in ALL_FAMILIES:
+            info(f"  {family}: {per_family.get(family, 0)} content rows")
+        info("Dry run: skipped upload.")
+        return
+
+    if transport is None:
+        raise ValueError("transport is required unless dry_run is set")
+
+    content_rows = [
+        {
+            "family": family,
+            "content_hash": entry_hash,
+            "content_b64": base64.b64encode(data).decode("ascii"),
+        }
+        for (family, entry_hash), data in sorted(content.items())
+    ]
+    for batch in _batched(content_rows, batch_size):
+        reply = transport.post("content", {"entries": batch})
+        info(f"Uploaded {len(batch)} content rows (inserted: {reply.get('inserted', '?')})")
+
+    for server_key, regs in sorted(registrations.items()):
+        server_id, snapshot_hash = server_key.split("\n", 1)
+        reg_rows = [
+            {"family": reg.family, "entry_id": reg.entry_id, "content_hash": reg.hash}
+            for reg in regs
+        ]
+        for batch in _batched(reg_rows, batch_size):
+            reply = transport.post(
+                "register",
+                {"server_id": server_id, "snapshot_hash": snapshot_hash, "entries": batch},
+            )
+        info(f"Registered {len(reg_rows)} rows for {server_id} ({snapshot_hash[:16]}...)")

--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -187,10 +187,10 @@ def build_meta_entries(
     collection = collections_pb2.Collection()
     collection.ParseFromString(collection_data)
 
-    with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
-        tmp.write(localization_db_data)
-        tmp.flush()
-        locales, strings = _load_localized_strings(Path(tmp.name))
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = Path(tmp_dir) / "localization.db"
+        db_path.write_bytes(localization_db_data)
+        locales, strings = _load_localized_strings(db_path)
 
     entries: list[Entry] = []
 

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -82,6 +82,9 @@ def _build_snapshot(schema_root: Path, snapshot_hash: str) -> dict[str, bytes]:
     effect = dogma_effects.entries[10]
     effect.effectCategory = 1
     effect.name = "shipModuleRemoteArmorRepairer"
+    negative_effect = dogma_effects.entries[-64]
+    negative_effect.effectCategory = 1
+    negative_effect.name = "shipModularity"
 
     buffs = efos_pb2.BuffCollections()
     buff = buffs.entries[20]
@@ -171,7 +174,7 @@ class TestLoadSnapshotEntries:
             "dogma_effect_meta",
         }
         assert set(by_family["types"]) == {587}
-        assert set(by_family["dogma_effect_meta"]) == {10}
+        assert set(by_family["dogma_effect_meta"]) == {10, -64}
 
     def test_meta_content(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import load_snapshot_entries
@@ -199,9 +202,19 @@ class TestLoadSnapshotEntries:
 
         effect_meta = platform_data_pb2.PlatformDogmaEffectMeta()
         effect_meta.ParseFromString(
-            next(e.content for e in entries if e.family == "dogma_effect_meta")
+            next(e.content for e in entries if e.family == "dogma_effect_meta" and e.entry_id == 10)
         )
+        assert effect_meta.dogma_effect_id == 10
         assert effect_meta.name == "shipModuleRemoteArmorRepairer"
+
+        negative_effect_meta = platform_data_pb2.PlatformDogmaEffectMeta()
+        negative_effect_meta.ParseFromString(
+            next(
+                e.content for e in entries if e.family == "dogma_effect_meta" and e.entry_id == -64
+            )
+        )
+        assert negative_effect_meta.dogma_effect_id == -64
+        assert negative_effect_meta.name == "shipModularity"
 
 
 class _FakeTransport:
@@ -274,20 +287,20 @@ class TestRunSync:
             e["content_hash"] for _path, payload in content_posts for e in payload["entries"]
         ]
         assert len(content_hashes) == len(set(content_hashes))
-        assert len(content_hashes) == 8  # one entry per family
+        assert len(content_hashes) == 10  # one entry per family
 
         assert len(register_posts) == 2
         servers = {payload["server_id"] for _path, payload in register_posts}
         assert servers == {"alpha", "beta"}
         for _path, payload in register_posts:
-            assert len(payload["entries"]) == 8
+            assert len(payload["entries"]) == 10
 
         complete_posts = [p for p in transport.posts if p[0] == "complete"]
         assert len(complete_posts) == 2
         complete_servers = {payload["server_id"] for _path, payload in complete_posts}
         assert complete_servers == {"alpha", "beta"}
         for _path, payload in complete_posts:
-            assert payload["entry_count"] == 8
+            assert payload["entry_count"] == 10
 
     def test_complete_not_posted_when_register_fails(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -213,6 +213,47 @@ class _FakeTransport:
         return {"ok": True, "inserted": len(payload.get("entries", []))}
 
 
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, body: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+        self.text = json.dumps(self._body)
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    def post(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+        return self._response
+
+
+class TestHttpTransport:
+    def _make_transport(self, response: _FakeResponse) -> Any:
+        pytest.importorskip("requests")
+        from bootstrap.data.d1.sync import HttpTransport
+
+        transport: Any = HttpTransport.__new__(HttpTransport)
+        transport._base_url = "https://worker.example"
+        transport._token = "test-token"  # noqa: S105
+        transport._timeout = 1.0
+        transport._session = _FakeSession(response)
+        return transport
+
+    def test_non_200_raises(self) -> None:
+        transport = self._make_transport(_FakeResponse(status_code=403, body={"err": "nope"}))
+        with pytest.raises(RuntimeError, match="HTTP 403"):
+            transport.post("content", {"entries": []})
+
+    def test_ok_false_raises(self) -> None:
+        transport = self._make_transport(_FakeResponse(body={"ok": False, "error": "bad"}))
+        with pytest.raises(RuntimeError, match="returned error"):
+            transport.post("register", {})
+
+
 class TestRunSync:
     def test_dedup_and_register(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -321,6 +321,29 @@ class TestRunSync:
         with pytest.raises(ValueError, match="transport is required"):
             run_sync({"alpha": snapshot_hash}, schema_root, None)
 
+    @pytest.mark.parametrize("batch_size", [0, -1, 10_001])
+    def test_rejects_invalid_batch_size(self, schema_root: Path, batch_size: int) -> None:
+        from bootstrap.data.d1.sync import run_sync
+
+        # Validation happens before any snapshot is loaded, so no snapshot
+        # fixtures are needed here.
+        with pytest.raises(ValueError, match="batch_size must be between 1 and 10000"):
+            run_sync({"alpha": "ab" * 32}, schema_root, None, batch_size=batch_size)
+
+    @pytest.mark.parametrize("batch_size", [1, 10_000])
+    def test_accepts_boundary_batch_size(self, schema_root: Path, batch_size: int) -> None:
+        from bootstrap.data.d1.sync import run_sync
+
+        snapshot_hash = "f0" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+
+        transport = _FakeTransport()
+        run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=batch_size)
+
+        for _path, payload in transport.posts:
+            assert len(payload.get("entries", [])) <= batch_size
+        assert [p for p in transport.posts if p[0] == "complete"] != []
+
 
 class TestCli:
     def test_d1_sync_dry_run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -1,0 +1,290 @@
+"""Tests for the platform D1 snapshot syncer (bootstrap/data/d1)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+pytest.importorskip("google.protobuf", reason="protobuf runtime required for pb2 bindings")
+
+
+@pytest.fixture
+def schema_root(tmp_path: Path) -> Path:
+    return tmp_path / "remote"
+
+
+def _write_blob(schema_root: Path, resource_id: str, data: bytes) -> None:
+    from bootstrap.remote.hash import content_hash
+    from bootstrap.remote.hash import ident_hash
+    from bootstrap.remote.paths import blob_path
+
+    path = blob_path(schema_root, ident_hash(resource_id), content_hash(data))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _make_localization_db(strings: dict[tuple[str, int], str]) -> bytes:
+    with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+        connection = sqlite3.connect(tmp.name)
+        try:
+            connection.execute("CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            connection.execute(
+                "CREATE TABLE strings("
+                "locale TEXT NOT NULL, id INTEGER NOT NULL, value TEXT NOT NULL, "
+                "PRIMARY KEY(locale, id)) WITHOUT ROWID"
+            )
+            connection.executemany(
+                "INSERT INTO strings(locale, id, value) VALUES (?, ?, ?)",
+                [(locale, entry_id, value) for (locale, entry_id), value in strings.items()],
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        return Path(tmp.name).read_bytes()
+
+
+def _build_snapshot(schema_root: Path, snapshot_hash: str) -> dict[str, bytes]:
+    """Write a minimal snapshot (5 engine blobs + collection + localization)."""
+    from bootstrap.data.d1.sync import COLLECTION_RESOURCE_ID
+    from bootstrap.data.d1.sync import ENGINE_FAMILIES
+    from bootstrap.data.d1.sync import LOCALIZATION_RESOURCE_ID
+    from bootstrap.data.d1.sync import _load_efos_pb2
+    from bootstrap.data.schema import collections_pb2
+    from bootstrap.data.schema import resource_index_pb2
+
+    efos_pb2 = _load_efos_pb2()
+
+    types = efos_pb2.Types()
+    types.entries[587].groupID = 25
+    types.entries[587].categoryID = 6
+
+    type_dogma = efos_pb2.TypeDogma()
+    type_dogma.entries[587].dogmaAttributes.add(attributeID=9, value=100.0)
+    type_dogma.entries[587].dogmaEffects.add(effectID=10, isDefault=False)
+
+    dogma_attributes = efos_pb2.DogmaAttributes()
+    attr = dogma_attributes.entries[9]
+    attr.published = True
+    attr.defaultValue = 0.0
+    attr.highIsGood = True
+    attr.stackable = True
+    attr.name = "shieldCapacity"
+
+    dogma_effects = efos_pb2.DogmaEffects()
+    effect = dogma_effects.entries[10]
+    effect.effectCategory = 1
+    effect.name = "shipModuleRemoteArmorRepairer"
+
+    buffs = efos_pb2.BuffCollections()
+    buff = buffs.entries[20]
+    buff.aggregateMode = efos_pb2.BuffCollections.Buff.MAXIMUM
+    buff.buffID = 20
+    buff.operationName = efos_pb2.BuffCollections.Buff.POST_MUL
+    buff.showOutputValueInUI = efos_pb2.BuffCollections.Buff.SHOW_NORMAL
+
+    collection = collections_pb2.Collection()
+    ctype = collection.types[587]
+    ctype.type_id = 587
+    ctype.icon.icon_id = 46
+    ctype.group_id = 25
+    ctype.is_dynamic_type = False
+    ctype.published = True
+    ctype.type_name.id = 100587
+    cattr = collection.dogma_attributes[9]
+    cattr.dogma_attribute_id = 9
+    cattr.name = "shieldCapacity"
+    cattr.description = "..."
+    cattr.icon.icon_id = 105
+    cattr.display_name.id = 200009
+    cattr.published = True
+    cattr.high_is_good = True
+    cattr.display_when_zero = False
+    cattr.stackable = True
+    collection.slots.SetInParent()
+
+    localization = _make_localization_db(
+        {
+            ("en-us", 100587): "Rifter",
+            ("zh", 100587): "裂谷级",
+            ("en-us", 200009): "Shield Capacity",
+        }
+    )
+
+    blobs: dict[str, bytes] = {
+        "types": types.SerializeToString(),
+        "type_dogma": type_dogma.SerializeToString(),
+        "dogma_attributes": dogma_attributes.SerializeToString(),
+        "dogma_effects": dogma_effects.SerializeToString(),
+        "buffs": buffs.SerializeToString(),
+        COLLECTION_RESOURCE_ID: collection.SerializeToString(),
+        LOCALIZATION_RESOURCE_ID: localization,
+    }
+
+    index = resource_index_pb2.ResourceIndex()
+    index.schema_version = 1
+    index.format_version = 2
+    for family, (resource_id, _msg) in ENGINE_FAMILIES.items():
+        blobs[resource_id] = blobs.pop(family)
+    for resource_id, data in blobs.items():
+        _write_blob(schema_root, resource_id, data)
+        from bootstrap.remote.hash import content_hash
+
+        entry = index.entries.add()
+        entry.resource_id = resource_id
+        entry.content_hash = content_hash(data)
+        entry.size = len(data)
+
+    snapshot_dir = schema_root / "assets" / "resources" / snapshot_hash
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    (snapshot_dir / "resources.pb2").write_bytes(index.SerializeToString())
+    return blobs
+
+
+class TestLoadSnapshotEntries:
+    def test_splits_engine_and_meta_families(self, schema_root: Path) -> None:
+        from bootstrap.data.d1.sync import load_snapshot_entries
+
+        snapshot_hash = "ab" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+
+        entries = load_snapshot_entries(schema_root, snapshot_hash)
+        by_family: dict[str, dict[int, bytes]] = {}
+        for entry in entries:
+            by_family.setdefault(entry.family, {})[entry.entry_id] = entry.content
+
+        assert set(by_family) == {
+            "types",
+            "type_dogma",
+            "dogma_attributes",
+            "dogma_effects",
+            "buffs",
+            "type_meta",
+            "dogma_attribute_meta",
+            "dogma_effect_meta",
+        }
+        assert set(by_family["types"]) == {587}
+        assert set(by_family["dogma_effect_meta"]) == {10}
+
+    def test_meta_content(self, schema_root: Path) -> None:
+        from bootstrap.data.d1.sync import load_snapshot_entries
+        from bootstrap.data.schema import platform_data_pb2
+
+        snapshot_hash = "cd" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+        entries = load_snapshot_entries(schema_root, snapshot_hash)
+
+        type_meta = platform_data_pb2.PlatformTypeMeta()
+        type_meta.ParseFromString(
+            next(e.content for e in entries if e.family == "type_meta" and e.entry_id == 587)
+        )
+        assert dict(type_meta.name) == {"en-us": "Rifter", "zh": "裂谷级"}
+        assert type_meta.icon_id == 46
+
+        attr_meta = platform_data_pb2.PlatformDogmaAttributeMeta()
+        attr_meta.ParseFromString(
+            next(e.content for e in entries if e.family == "dogma_attribute_meta")
+        )
+        assert attr_meta.dogma_attribute_id == 9
+        assert attr_meta.name["en-us"] == "Shield Capacity"
+        assert attr_meta.name["zh"] == "shieldCapacity"  # fallback to internal name
+        assert attr_meta.icon_id == 105
+
+        effect_meta = platform_data_pb2.PlatformDogmaEffectMeta()
+        effect_meta.ParseFromString(
+            next(e.content for e in entries if e.family == "dogma_effect_meta")
+        )
+        assert effect_meta.name == "shipModuleRemoteArmorRepairer"
+
+
+class _FakeTransport:
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+
+    def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        self.posts.append((path, payload))
+        return {"ok": True, "inserted": len(payload.get("entries", []))}
+
+
+class TestRunSync:
+    def test_dedup_and_register(self, schema_root: Path) -> None:
+        from bootstrap.data.d1.sync import run_sync
+
+        hash_a = "aa" * 32
+        hash_b = "bb" * 32
+        _build_snapshot(schema_root, hash_a)
+        _build_snapshot(schema_root, hash_b)
+
+        transport = _FakeTransport()
+        run_sync({"alpha": hash_a, "beta": hash_b}, schema_root, transport, batch_size=5000)
+
+        content_posts = [p for p in transport.posts if p[0] == "content"]
+        register_posts = [p for p in transport.posts if p[0] == "register"]
+
+        # Identical snapshots: content uploaded once, deduplicated by hash.
+        content_hashes = [
+            e["content_hash"] for _path, payload in content_posts for e in payload["entries"]
+        ]
+        assert len(content_hashes) == len(set(content_hashes))
+        assert len(content_hashes) == 8  # one entry per family
+
+        assert len(register_posts) == 2
+        servers = {payload["server_id"] for _path, payload in register_posts}
+        assert servers == {"alpha", "beta"}
+        for _path, payload in register_posts:
+            assert len(payload["entries"]) == 8
+
+    def test_dry_run_uploads_nothing(self, schema_root: Path) -> None:
+        from bootstrap.data.d1.sync import run_sync
+
+        snapshot_hash = "ee" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+        run_sync({"alpha": snapshot_hash}, schema_root, None, dry_run=True)
+
+    def test_requires_transport(self, schema_root: Path) -> None:
+        from bootstrap.data.d1.sync import run_sync
+
+        snapshot_hash = "ef" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+        with pytest.raises(ValueError, match="transport is required"):
+            run_sync({"alpha": snapshot_hash}, schema_root, None)
+
+
+class TestCli:
+    def test_d1_sync_dry_run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import click
+        import click.testing
+
+        from bootstrap.cli import register_all_commands
+
+        monkeypatch.setattr("bootstrap.ci.commands.PROJECT_ROOT", tmp_path)
+        schema_root = tmp_path / "cache" / "remote"
+        snapshot_hash = "12" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+        (tmp_path / "snapshot-hashes.json").write_text(
+            json.dumps({"alpha": snapshot_hash}), encoding="utf-8"
+        )
+
+        @click.group()
+        def cli() -> None:
+            pass
+
+        register_all_commands(cli)
+        result = click.testing.CliRunner().invoke(
+            cli,
+            [
+                "ci",
+                "release-data",
+                "d1-sync",
+                "--hashes",
+                str(tmp_path / "snapshot-hashes.json"),
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0, result.output

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -241,6 +241,30 @@ class TestRunSync:
         for _path, payload in register_posts:
             assert len(payload["entries"]) == 8
 
+        complete_posts = [p for p in transport.posts if p[0] == "complete"]
+        assert len(complete_posts) == 2
+        complete_servers = {payload["server_id"] for _path, payload in complete_posts}
+        assert complete_servers == {"alpha", "beta"}
+        for _path, payload in complete_posts:
+            assert payload["entry_count"] == 8
+
+    def test_complete_not_posted_when_register_fails(self, schema_root: Path) -> None:
+        from bootstrap.data.d1.sync import run_sync
+
+        snapshot_hash = "dd" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+
+        class _FailingTransport(_FakeTransport):
+            def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+                if path == "register":
+                    raise RuntimeError("boom")
+                return super().post(path, payload)
+
+        transport = _FailingTransport()
+        with pytest.raises(RuntimeError, match="boom"):
+            run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=5000)
+        assert [p for p in transport.posts if p[0] == "complete"] == []
+
     def test_dry_run_uploads_nothing(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync
 

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -31,8 +31,9 @@ def _write_blob(schema_root: Path, resource_id: str, data: bytes) -> None:
 
 
 def _make_localization_db(strings: dict[tuple[str, int], str]) -> bytes:
-    with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
-        connection = sqlite3.connect(tmp.name)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        db_path = Path(tmp_dir) / "localization.db"
+        connection = sqlite3.connect(db_path)
         try:
             connection.execute("CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL)")
             connection.execute(
@@ -47,7 +48,7 @@ def _make_localization_db(strings: dict[tuple[str, int], str]) -> bytes:
             connection.commit()
         finally:
             connection.close()
-        return Path(tmp.name).read_bytes()
+        return db_path.read_bytes()
 
 
 def _build_snapshot(schema_root: Path, snapshot_hash: str) -> dict[str, bytes]:

--- a/ci/config/efa.dev.toml
+++ b/ci/config/efa.dev.toml
@@ -50,3 +50,9 @@ public_url = "https://ci.storage.efa-tech.dev"
 [ci.raw_artifacts]
 remote_root = "data-generator/raw-artifact"
 public_url = "https://ci.storage.efa-tech.dev"
+
+# Platform D1 sync endpoint. The token is a placeholder overwritten by
+# --dev-env d1.token=... in release jobs.
+[d1]
+url = "https://api.efa-tech.dev/platform/storage/data-sync"
+token = "placeholder-d1-sync-token"

--- a/data/schema/platform_data.proto
+++ b/data/schema/platform_data.proto
@@ -1,0 +1,29 @@
+syntax = "proto2";
+package platform_data;
+
+// Per-entry metadata stored in the platform D1 database.
+// These messages are not part of the resource snapshot; they are built at
+// sync time from the snapshot's collection + localization data.
+
+message PlatformTypeMeta {
+  required uint32 type_id = 1;
+  // locale -> display name
+  map<string, string> name = 2;
+
+  optional uint32 icon_id = 3;
+  optional uint32 graphic_id = 4;
+}
+
+message PlatformDogmaAttributeMeta {
+  required uint32 dogma_attribute_id = 1;
+  // locale -> display name
+  map<string, string> name = 2;
+
+  optional uint32 icon_id = 3;
+}
+
+message PlatformDogmaEffectMeta {
+  required uint32 dogma_effect_id = 1;
+  // Internal effect name (e.g. "shipModuleRemoteArmorRepairer").
+  required string name = 2;
+}

--- a/data/schema/platform_data.proto
+++ b/data/schema/platform_data.proto
@@ -23,7 +23,8 @@ message PlatformDogmaAttributeMeta {
 }
 
 message PlatformDogmaEffectMeta {
-  required uint32 dogma_effect_id = 1;
+  // Effect IDs can be negative in the source data (e.g. -64).
+  required int32 dogma_effect_id = 1;
   // Internal effect name (e.g. "shipModuleRemoteArmorRepairer").
   required string name = 2;
 }

--- a/efa.dev.example.toml
+++ b/efa.dev.example.toml
@@ -95,3 +95,10 @@ remote_root = "data-generator/raw-artifact"
 # Optional: public URL used to read build.txt without credentials.
 # If omitted, [ci.storage].public_url is used when available.
 # public_url = "https://ci.storage.efa-tech.dev"
+
+[d1]
+# Platform D1 sync endpoint (Cloudflare Worker ingesting snapshot entries).
+# Used by `./x ci release-data d1-sync`.
+url = "https://api.efa-tech.dev/platform/storage/data-sync"
+# Bearer token matching the worker's SYNC_TOKEN secret.
+# token = "your-d1-sync-token"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,25 @@ importers:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)
 
+  worker/efa-platform-data-sync:
+    dependencies:
+      hono:
+        specifier: ^4.13.1
+        version: 4.13.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^5.20260810.1
+        version: 5.20260810.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      wrangler:
+        specifier: ^4.120.0
+        version: 4.120.0(@cloudflare/workers-types@5.20260810.1)
+
   worker/email-filter:
     devDependencies:
       '@cloudflare/workers-types':

--- a/worker/efa-platform-data-sync/.dev.vars.example
+++ b/worker/efa-platform-data-sync/.dev.vars.example
@@ -1,0 +1,5 @@
+# Copy this file to .dev.vars and fill in the values.
+# Secrets for local development (wrangler dev).
+# For production, use: wrangler secret put SYNC_TOKEN
+
+SYNC_TOKEN=your-sync-token

--- a/worker/efa-platform-data-sync/.gitignore
+++ b/worker/efa-platform-data-sync/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.wrangler/
+.dev.vars

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -19,6 +19,15 @@ has two tables:
 - `<f>_reg` — `(server_id, snapshot_hash, entry_id, content_hash)`:
   registration rows mapping a snapshot's entries onto content rows.
 
+Uploads span many requests (one transaction each), so a failed sync leaves
+partial `<f>_reg` rows behind. The `snapshots` table —
+`(server_id, snapshot_hash, entry_count, completed_at)` — is the completeness
+registry: the uploader inserts a row only after every content and registration
+batch for the snapshot succeeded, and the worker verifies the actual
+registration row count before accepting the marker. **Readers must check
+`snapshots` first and treat a `(server_id, snapshot_hash)` with no row as
+incomplete.**
+
 See `migrations/0001_init.sql` and `data/schema/platform_data.proto`.
 
 ## API
@@ -53,8 +62,26 @@ hash). At most 10000 entries per request. Responds `{ "ok": true, "inserted": n 
 ```
 
 Verifies every referenced content hash exists (409 with a `missing` list
-otherwise), then `INSERT OR REPLACE`s the registration rows. At most 10000
+otherwise), then `INSERT OR IGNORE`s the registration rows (immutable per
+primary key, so re-runs are free of write quota). At most 10000
 entries per request. Responds `{ "ok": true, "inserted": n }`.
+
+### `POST /platform/storage/data-sync/complete`
+
+```json
+{ "server_id": "tranquility", "snapshot_hash": "sha256-hex", "entry_count": 8 }
+```
+
+Marks a snapshot complete. Verifies server-side that the registration rows
+present for `(server_id, snapshot_hash)` across all `<f>_reg` tables equal
+`entry_count` (409 otherwise), then upserts the `snapshots` registry row.
+Responds `{ "ok": true }`.
+
+### `GET /platform/storage/data-sync/snapshot?server_id=...&snapshot_hash=...`
+
+Completeness check for readers. Responds `{ "ok": true, "complete": false }`
+when the snapshot has no registry row, or
+`{ "ok": true, "complete": true, "entry_count": n, "completed_at": "..." }`.
 
 ## Deployment
 

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -1,0 +1,77 @@
+# efa-platform-data-sync — Cloudflare Worker
+
+Ingests per-entry engine data from resource snapshots into the
+`efa-platform-prod` D1 database, keyed by `(server_id, snapshot_hash)` so any
+historical snapshot stays addressable (checkout-ref semantics).
+
+Mounted at `api.efa-tech.dev/platform/storage/data-sync`.
+
+## Data model
+
+Eight families: the five native engine collections (`types`, `type_dogma`,
+`dogma_attributes`, `dogma_effects`, `buffs`) plus sync-built metadata
+(`type_meta`, `dogma_attribute_meta`, `dogma_effect_meta`). Each family `<f>`
+has two tables:
+
+- `<f>` — `(content_hash TEXT PRIMARY KEY, content BLOB)`: content-addressed
+  single-entry protobuf payloads (efos `efos.*` entry messages for the engine
+  families, `efa.v2`-style `platform_data.*` messages for metadata).
+- `<f>_reg` — `(server_id, snapshot_hash, entry_id, content_hash)`:
+  registration rows mapping a snapshot's entries onto content rows.
+
+See `migrations/0001_init.sql` and `data/schema/platform_data.proto`.
+
+## API
+
+All mutating endpoints require `Authorization: Bearer <SYNC_TOKEN>`.
+
+### `GET /platform/storage/data-sync/health`
+
+Returns `{ "ok": true }` after a `SELECT 1` probe.
+
+### `POST /platform/storage/data-sync/content`
+
+```json
+{
+  "entries": [
+    { "family": "types", "content_hash": "sha256-hex", "content_b64": "..." }
+  ]
+}
+```
+
+`INSERT OR IGNORE`s every row into the family content table (dedup by content
+hash). At most 10000 entries per request. Responds `{ "ok": true, "inserted": n }`.
+
+### `POST /platform/storage/data-sync/register`
+
+```json
+{
+  "server_id": "tranquility",
+  "snapshot_hash": "sha256-hex",
+  "entries": [{ "family": "types", "entry_id": 587, "content_hash": "sha256-hex" }]
+}
+```
+
+Verifies every referenced content hash exists (409 with a `missing` list
+otherwise), then `INSERT OR REPLACE`s the registration rows. At most 10000
+entries per request. Responds `{ "ok": true, "inserted": n }`.
+
+## Deployment
+
+Deployed via the Cloudflare Git integration; the build phase runs
+`./build.sh` (dependency install + `tsc --noEmit`), the deploy command is
+`wrangler deploy`.
+
+One-time setup:
+
+1. `wrangler d1 create efa-platform-prod` and paste the printed `database_id`
+   into `wrangler.toml`.
+2. `wrangler d1 migrations apply efa-platform-prod --remote`.
+3. `wrangler secret put SYNC_TOKEN`; add the same value as the `D1_SYNC_TOKEN`
+   secret of the `production-data` GitHub environment.
+
+## Sync driver
+
+The Python side lives in `bootstrap/data/d1/`; run via
+`./x ci release-data d1-sync --hashes snapshot-hashes.json --schema-root cache/remote`
+(token from `[d1].token` in `efa.dev.toml` or `--dev-env d1.token=...`).

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -63,7 +63,10 @@ hash). At most 10000 entries per request. Responds `{ "ok": true, "inserted": n 
 
 Verifies every referenced content hash exists (409 with a `missing` list
 otherwise), then `INSERT OR IGNORE`s the registration rows (immutable per
-primary key, so re-runs are free of write quota). At most 10000
+primary key, so re-runs are free of write quota). Inserts are conditional on
+the absence of the `snapshots` marker: once `/complete` has frozen a snapshot,
+further registrations for it are skipped and the request fails with
+409 `Snapshot already complete`. At most 10000
 entries per request. Responds `{ "ok": true, "inserted": n }`.
 
 ### `POST /platform/storage/data-sync/complete`

--- a/worker/efa-platform-data-sync/build.sh
+++ b/worker/efa-platform-data-sync/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# Build phase for the Cloudflare Git integration.
-set -e
-
-pnpm ci
-pnpx tsc --noEmit

--- a/worker/efa-platform-data-sync/build.sh
+++ b/worker/efa-platform-data-sync/build.sh
@@ -2,5 +2,5 @@
 # Build phase for the Cloudflare Git integration.
 set -e
 
-npm ci
-npx tsc --noEmit
+pnpm ci
+pnpx tsc --noEmit

--- a/worker/efa-platform-data-sync/build.sh
+++ b/worker/efa-platform-data-sync/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Build phase for the Cloudflare Git integration.
+set -e
+
+npm ci
+npx tsc --noEmit

--- a/worker/efa-platform-data-sync/migrations/0001_init.sql
+++ b/worker/efa-platform-data-sync/migrations/0001_init.sql
@@ -1,0 +1,99 @@
+-- Platform data store: per-entry, content-addressed engine data rows.
+-- Each family <f> has a content table and a registration table mapping
+-- (server_id, snapshot_hash, entry_id) -> content_hash.
+
+CREATE TABLE types (
+    content_hash TEXT PRIMARY KEY,
+    content BLOB NOT NULL
+);
+CREATE TABLE types_reg (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_id INTEGER NOT NULL,
+    content_hash TEXT NOT NULL REFERENCES types (content_hash),
+    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+);
+
+CREATE TABLE type_dogma (
+    content_hash TEXT PRIMARY KEY,
+    content BLOB NOT NULL
+);
+CREATE TABLE type_dogma_reg (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_id INTEGER NOT NULL,
+    content_hash TEXT NOT NULL REFERENCES type_dogma (content_hash),
+    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+);
+
+CREATE TABLE dogma_attributes (
+    content_hash TEXT PRIMARY KEY,
+    content BLOB NOT NULL
+);
+CREATE TABLE dogma_attributes_reg (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_id INTEGER NOT NULL,
+    content_hash TEXT NOT NULL REFERENCES dogma_attributes (content_hash),
+    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+);
+
+CREATE TABLE dogma_effects (
+    content_hash TEXT PRIMARY KEY,
+    content BLOB NOT NULL
+);
+CREATE TABLE dogma_effects_reg (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_id INTEGER NOT NULL,
+    content_hash TEXT NOT NULL REFERENCES dogma_effects (content_hash),
+    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+);
+
+CREATE TABLE buffs (
+    content_hash TEXT PRIMARY KEY,
+    content BLOB NOT NULL
+);
+CREATE TABLE buffs_reg (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_id INTEGER NOT NULL,
+    content_hash TEXT NOT NULL REFERENCES buffs (content_hash),
+    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+);
+
+CREATE TABLE type_meta (
+    content_hash TEXT PRIMARY KEY,
+    content BLOB NOT NULL
+);
+CREATE TABLE type_meta_reg (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_id INTEGER NOT NULL,
+    content_hash TEXT NOT NULL REFERENCES type_meta (content_hash),
+    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+);
+
+CREATE TABLE dogma_attribute_meta (
+    content_hash TEXT PRIMARY KEY,
+    content BLOB NOT NULL
+);
+CREATE TABLE dogma_attribute_meta_reg (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_id INTEGER NOT NULL,
+    content_hash TEXT NOT NULL REFERENCES dogma_attribute_meta (content_hash),
+    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+);
+
+CREATE TABLE dogma_effect_meta (
+    content_hash TEXT PRIMARY KEY,
+    content BLOB NOT NULL
+);
+CREATE TABLE dogma_effect_meta_reg (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_id INTEGER NOT NULL,
+    content_hash TEXT NOT NULL REFERENCES dogma_effect_meta (content_hash),
+    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+);

--- a/worker/efa-platform-data-sync/migrations/0001_init.sql
+++ b/worker/efa-platform-data-sync/migrations/0001_init.sql
@@ -26,6 +26,8 @@ CREATE TABLE types_reg (
     content_hash TEXT NOT NULL REFERENCES types (content_hash),
     PRIMARY KEY (server_id, snapshot_hash, entry_id)
 );
+-- Reverse lookup for reference counting / orphan cleanup / FK checks on DELETE.
+CREATE INDEX types_reg_content_hash ON types_reg (content_hash);
 
 CREATE TABLE type_dogma (
     content_hash TEXT PRIMARY KEY,
@@ -38,6 +40,7 @@ CREATE TABLE type_dogma_reg (
     content_hash TEXT NOT NULL REFERENCES type_dogma (content_hash),
     PRIMARY KEY (server_id, snapshot_hash, entry_id)
 );
+CREATE INDEX type_dogma_reg_content_hash ON type_dogma_reg (content_hash);
 
 CREATE TABLE dogma_attributes (
     content_hash TEXT PRIMARY KEY,
@@ -50,6 +53,7 @@ CREATE TABLE dogma_attributes_reg (
     content_hash TEXT NOT NULL REFERENCES dogma_attributes (content_hash),
     PRIMARY KEY (server_id, snapshot_hash, entry_id)
 );
+CREATE INDEX dogma_attributes_reg_content_hash ON dogma_attributes_reg (content_hash);
 
 CREATE TABLE dogma_effects (
     content_hash TEXT PRIMARY KEY,
@@ -62,6 +66,7 @@ CREATE TABLE dogma_effects_reg (
     content_hash TEXT NOT NULL REFERENCES dogma_effects (content_hash),
     PRIMARY KEY (server_id, snapshot_hash, entry_id)
 );
+CREATE INDEX dogma_effects_reg_content_hash ON dogma_effects_reg (content_hash);
 
 CREATE TABLE buffs (
     content_hash TEXT PRIMARY KEY,
@@ -74,6 +79,7 @@ CREATE TABLE buffs_reg (
     content_hash TEXT NOT NULL REFERENCES buffs (content_hash),
     PRIMARY KEY (server_id, snapshot_hash, entry_id)
 );
+CREATE INDEX buffs_reg_content_hash ON buffs_reg (content_hash);
 
 CREATE TABLE type_meta (
     content_hash TEXT PRIMARY KEY,
@@ -86,6 +92,7 @@ CREATE TABLE type_meta_reg (
     content_hash TEXT NOT NULL REFERENCES type_meta (content_hash),
     PRIMARY KEY (server_id, snapshot_hash, entry_id)
 );
+CREATE INDEX type_meta_reg_content_hash ON type_meta_reg (content_hash);
 
 CREATE TABLE dogma_attribute_meta (
     content_hash TEXT PRIMARY KEY,
@@ -98,6 +105,7 @@ CREATE TABLE dogma_attribute_meta_reg (
     content_hash TEXT NOT NULL REFERENCES dogma_attribute_meta (content_hash),
     PRIMARY KEY (server_id, snapshot_hash, entry_id)
 );
+CREATE INDEX dogma_attribute_meta_reg_content_hash ON dogma_attribute_meta_reg (content_hash);
 
 CREATE TABLE dogma_effect_meta (
     content_hash TEXT PRIMARY KEY,
@@ -110,3 +118,4 @@ CREATE TABLE dogma_effect_meta_reg (
     content_hash TEXT NOT NULL REFERENCES dogma_effect_meta (content_hash),
     PRIMARY KEY (server_id, snapshot_hash, entry_id)
 );
+CREATE INDEX dogma_effect_meta_reg_content_hash ON dogma_effect_meta_reg (content_hash);

--- a/worker/efa-platform-data-sync/migrations/0001_init.sql
+++ b/worker/efa-platform-data-sync/migrations/0001_init.sql
@@ -2,6 +2,19 @@
 -- Each family <f> has a content table and a registration table mapping
 -- (server_id, snapshot_hash, entry_id) -> content_hash.
 
+-- Snapshot completeness registry. Content and registration uploads span many
+-- requests (one transaction each), so a failed run leaves partial <f>_reg rows
+-- behind. The uploader inserts a row here only after every content and
+-- registration batch for the snapshot succeeded; readers MUST treat any
+-- (server_id, snapshot_hash) with no row here as incomplete and reject it.
+CREATE TABLE snapshots (
+    server_id TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    entry_count INTEGER NOT NULL,
+    completed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (server_id, snapshot_hash)
+);
+
 CREATE TABLE types (
     content_hash TEXT PRIMARY KEY,
     content BLOB NOT NULL

--- a/worker/efa-platform-data-sync/package.json
+++ b/worker/efa-platform-data-sync/package.json
@@ -6,7 +6,8 @@
         "dev": "wrangler dev --port 8790",
         "deploy": "wrangler deploy",
         "check": "tsc --noEmit",
-        "lint": "biome check --write src/"
+        "lint": "biome check --write src/",
+        "test": "node --test \"test/*.test.ts\""
     },
     "dependencies": {
         "hono": "^4.13.1",

--- a/worker/efa-platform-data-sync/package.json
+++ b/worker/efa-platform-data-sync/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "efa-platform-data-sync",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "dev": "wrangler dev --port 8790",
+        "deploy": "wrangler deploy",
+        "check": "tsc --noEmit",
+        "lint": "biome check --write src/"
+    },
+    "dependencies": {
+        "hono": "^4.13.1",
+        "zod": "^4.4.3"
+    },
+    "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260810.1",
+        "typescript": "^7.0.2",
+        "wrangler": "^4.120.0"
+    }
+}

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -328,8 +328,8 @@ app.get("/snapshot", async (c) => {
 });
 
 app.onError((err, c) => {
-    const message = err instanceof Error ? err.message : String(err);
-    return c.json({ ok: false, error: "Internal server error", details: message }, 500);
+    console.error("Unhandled error", err);
+    return c.json({ ok: false, error: "Internal server error" }, 500);
 });
 
 const root = new Hono<{ Bindings: Env }>();

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -36,7 +36,8 @@ const ContentRequestSchema = z.object({
 
 const RegisterEntrySchema = z.object({
     family: z.enum(Object.keys(FAMILIES) as [Family, ...Family[]]),
-    entry_id: z.number().int().nonnegative(),
+    // Engine-internal pseudo attributes/effects carry negative int32 IDs.
+    entry_id: z.number().int().gte(-2147483648).lte(2147483647),
     content_hash: z.string().regex(HASH_RE),
 });
 

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -67,6 +67,21 @@ function base64ToBytes(value: string): Uint8Array {
     return bytes;
 }
 
+function bytesToHex(bytes: Uint8Array): string {
+    let hex = "";
+    for (const b of bytes) {
+        hex += b.toString(16).padStart(2, "0");
+    }
+    return hex;
+}
+
+// Matches bootstrap/remote/hash.py content_hash(): plain SHA-256 of the raw
+// bytes, lowercase hex, no prefix or envelope.
+async function sha256Hex(data: Uint8Array): Promise<string> {
+    const digest = await crypto.subtle.digest("SHA-256", data.buffer as ArrayBuffer);
+    return bytesToHex(new Uint8Array(digest));
+}
+
 function chunked<T>(items: T[], size: number): T[][] {
     const chunks: T[][] = [];
     for (let offset = 0; offset < items.length; offset += size) {
@@ -123,10 +138,37 @@ app.post("/content", async (c) => {
     }
 
     const byFamily = new Map<Family, { hash: string; content: Uint8Array }[]>();
+    const rejected: { family: Family; content_hash: string; reason: string }[] = [];
     for (const entry of parsed.data.entries) {
+        let content: Uint8Array;
+        try {
+            content = base64ToBytes(entry.content_b64);
+        } catch {
+            rejected.push({
+                family: entry.family,
+                content_hash: entry.content_hash,
+                reason: "invalid base64",
+            });
+            continue;
+        }
+        const actual = await sha256Hex(content);
+        if (actual !== entry.content_hash) {
+            rejected.push({
+                family: entry.family,
+                content_hash: entry.content_hash,
+                reason: `hash mismatch: content hashes to ${actual}`,
+            });
+            continue;
+        }
         const rows = byFamily.get(entry.family) ?? [];
-        rows.push({ hash: entry.content_hash, content: base64ToBytes(entry.content_b64) });
+        rows.push({ hash: entry.content_hash, content });
         byFamily.set(entry.family, rows);
+    }
+    if (rejected.length > 0) {
+        return c.json(
+            { ok: false, error: "Content verification failed", rejected: rejected.slice(0, 100) },
+            400,
+        );
     }
 
     let inserted = 0;

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -77,16 +77,35 @@ function chunked<T>(items: T[], size: number): T[][] {
 
 const app = new Hono<{ Bindings: Env }>();
 
+const MOUNT_PATH = "/platform/storage/data-sync";
+// Reader-facing probes; everything else (including any future route) requires
+// the sync token by default.
+const PUBLIC_GET_PATHS = new Set([`${MOUNT_PATH}/health`, `${MOUNT_PATH}/snapshot`]);
+
+function timingSafeEqual(a: string, b: string): boolean {
+    const encoder = new TextEncoder();
+    const aBytes = encoder.encode(a);
+    const bBytes = encoder.encode(b);
+    if (aBytes.length !== bBytes.length) {
+        return false;
+    }
+    let diff = 0;
+    for (let i = 0; i < aBytes.length; i++) {
+        diff |= aBytes[i] ^ bBytes[i];
+    }
+    return diff === 0;
+}
+
 app.use("*", async (c, next) => {
-    if (c.req.method === "GET") {
+    if (c.req.method === "GET" && PUBLIC_GET_PATHS.has(new URL(c.req.url).pathname)) {
         return next();
     }
     const token = c.env.SYNC_TOKEN;
     if (!token) {
         return c.json({ ok: false, error: "Server misconfigured: SYNC_TOKEN is not set" }, 500);
     }
-    const header = c.req.header("Authorization");
-    if (header !== `Bearer ${token}`) {
+    const header = c.req.header("Authorization") ?? "";
+    if (!timingSafeEqual(header, `Bearer ${token}`)) {
         return c.json({ ok: false, error: "Unauthorized" }, 401);
     }
     return next();
@@ -210,8 +229,11 @@ app.post("/complete", async (c) => {
         return c.json({ ok: false, error: "Validation failed", details: parsed.error.issues }, 400);
     }
 
-    const { server_id: serverId, snapshot_hash: snapshotHash, entry_count: entryCount } =
-        parsed.data;
+    const {
+        server_id: serverId,
+        snapshot_hash: snapshotHash,
+        entry_count: entryCount,
+    } = parsed.data;
 
     // Verify completeness server-side: the marker is only written when the
     // registration rows actually present match the uploader's entry count.
@@ -269,5 +291,5 @@ app.onError((err, c) => {
 });
 
 const root = new Hono<{ Bindings: Env }>();
-root.route("/platform/storage/data-sync", app);
+root.route(MOUNT_PATH, app);
 export default root;

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -54,7 +54,7 @@ const CompleteRequestSchema = z.object({
 
 // D1 allows at most 100 bound parameters per statement.
 const CONTENT_ROWS_PER_STATEMENT = 50; // 2 params per row
-const REGISTER_ROWS_PER_STATEMENT = 25; // 4 params per row
+const REGISTER_ROWS_PER_STATEMENT = 24; // 4 params per row + 2 freeze-guard params
 const HASHES_PER_LOOKUP = 100;
 const STATEMENTS_PER_BATCH = 50;
 
@@ -247,10 +247,15 @@ app.post("/register", async (c) => {
         for (const chunk of chunked(rows, REGISTER_ROWS_PER_STATEMENT)) {
             const placeholders = chunk.map(() => "(?, ?, ?, ?)").join(", ");
             const binds = chunk.flatMap((row) => [serverId, snapshotHash, row.id, row.hash]);
+            binds.push(serverId, snapshotHash);
             statements.push(
                 c.env.PLATFORM_DB.prepare(
                     `INSERT OR IGNORE INTO ${table} ` +
-                        `(server_id, snapshot_hash, entry_id, content_hash) VALUES ${placeholders}`,
+                        "(server_id, snapshot_hash, entry_id, content_hash) " +
+                        `SELECT column1, column2, column3, column4 FROM (VALUES ${placeholders}) ` +
+                        "WHERE NOT EXISTS (" +
+                        "SELECT 1 FROM snapshots WHERE server_id = ? AND snapshot_hash = ?" +
+                        ")",
                 ).bind(...binds),
             );
         }
@@ -260,6 +265,15 @@ app.post("/register", async (c) => {
                 inserted += result.meta.changes ?? 0;
             }
         }
+    }
+
+    const snapshot = await c.env.PLATFORM_DB.prepare(
+        "SELECT entry_count FROM snapshots WHERE server_id = ? AND snapshot_hash = ?",
+    )
+        .bind(serverId, snapshotHash)
+        .first();
+    if (snapshot) {
+        return c.json({ ok: false, error: "Snapshot already complete" }, 409);
     }
 
     return c.json({ ok: true, inserted });

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -46,6 +46,12 @@ const RegisterRequestSchema = z.object({
     entries: z.array(RegisterEntrySchema).min(1).max(10000),
 });
 
+const CompleteRequestSchema = z.object({
+    server_id: z.string().min(1),
+    snapshot_hash: z.string().regex(HASH_RE),
+    entry_count: z.number().int().nonnegative(),
+});
+
 // D1 allows at most 100 bound parameters per statement.
 const CONTENT_ROWS_PER_STATEMENT = 50; // 2 params per row
 const REGISTER_ROWS_PER_STATEMENT = 25; // 4 params per row
@@ -182,7 +188,7 @@ app.post("/register", async (c) => {
             const binds = chunk.flatMap((row) => [serverId, snapshotHash, row.id, row.hash]);
             statements.push(
                 c.env.PLATFORM_DB.prepare(
-                    `INSERT OR REPLACE INTO ${table} ` +
+                    `INSERT OR IGNORE INTO ${table} ` +
                         `(server_id, snapshot_hash, entry_id, content_hash) VALUES ${placeholders}`,
                 ).bind(...binds),
             );
@@ -196,6 +202,65 @@ app.post("/register", async (c) => {
     }
 
     return c.json({ ok: true, inserted });
+});
+
+app.post("/complete", async (c) => {
+    const parsed = CompleteRequestSchema.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) {
+        return c.json({ ok: false, error: "Validation failed", details: parsed.error.issues }, 400);
+    }
+
+    const { server_id: serverId, snapshot_hash: snapshotHash, entry_count: entryCount } =
+        parsed.data;
+
+    // Verify completeness server-side: the marker is only written when the
+    // registration rows actually present match the uploader's entry count.
+    let registered = 0;
+    for (const family of Object.keys(FAMILIES) as Family[]) {
+        const table = FAMILIES[family].reg;
+        const row = await c.env.PLATFORM_DB.prepare(
+            `SELECT COUNT(*) AS n FROM ${table} WHERE server_id = ? AND snapshot_hash = ?`,
+        )
+            .bind(serverId, snapshotHash)
+            .first<{ n: number }>();
+        registered += row?.n ?? 0;
+    }
+    if (registered !== entryCount) {
+        return c.json(
+            { ok: false, error: "Snapshot incomplete", expected: entryCount, registered },
+            409,
+        );
+    }
+
+    await c.env.PLATFORM_DB.prepare(
+        "INSERT OR REPLACE INTO snapshots (server_id, snapshot_hash, entry_count) VALUES (?, ?, ?)",
+    )
+        .bind(serverId, snapshotHash, entryCount)
+        .run();
+
+    return c.json({ ok: true });
+});
+
+app.get("/snapshot", async (c) => {
+    const serverId = c.req.query("server_id");
+    const snapshotHash = c.req.query("snapshot_hash");
+    if (!serverId || !snapshotHash || !HASH_RE.test(snapshotHash)) {
+        return c.json({ ok: false, error: "Invalid server_id or snapshot_hash" }, 400);
+    }
+    const row = await c.env.PLATFORM_DB.prepare(
+        "SELECT entry_count, completed_at FROM snapshots WHERE server_id = ? AND snapshot_hash = ?",
+    )
+        .bind(serverId, snapshotHash)
+        .first<{ entry_count: number; completed_at: string }>();
+    if (!row) {
+        return c.json({ ok: true, complete: false });
+    }
+    return c.json({
+        ok: true,
+        complete: true,
+        entry_count: row.entry_count,
+        completed_at: row.completed_at,
+    });
 });
 
 app.onError((err, c) => {

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -1,0 +1,208 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+interface Env {
+    PLATFORM_DB: D1Database;
+    SYNC_TOKEN?: string;
+}
+
+const FAMILIES = {
+    types: { content: "types", reg: "types_reg" },
+    type_dogma: { content: "type_dogma", reg: "type_dogma_reg" },
+    dogma_attributes: { content: "dogma_attributes", reg: "dogma_attributes_reg" },
+    dogma_effects: { content: "dogma_effects", reg: "dogma_effects_reg" },
+    buffs: { content: "buffs", reg: "buffs_reg" },
+    type_meta: { content: "type_meta", reg: "type_meta_reg" },
+    dogma_attribute_meta: {
+        content: "dogma_attribute_meta",
+        reg: "dogma_attribute_meta_reg",
+    },
+    dogma_effect_meta: { content: "dogma_effect_meta", reg: "dogma_effect_meta_reg" },
+} as const;
+
+type Family = keyof typeof FAMILIES;
+
+const HASH_RE = /^[0-9a-f]{64}$/;
+
+const ContentEntrySchema = z.object({
+    family: z.enum(Object.keys(FAMILIES) as [Family, ...Family[]]),
+    content_hash: z.string().regex(HASH_RE),
+    content_b64: z.string().min(1),
+});
+
+const ContentRequestSchema = z.object({
+    entries: z.array(ContentEntrySchema).min(1).max(10000),
+});
+
+const RegisterEntrySchema = z.object({
+    family: z.enum(Object.keys(FAMILIES) as [Family, ...Family[]]),
+    entry_id: z.number().int().nonnegative(),
+    content_hash: z.string().regex(HASH_RE),
+});
+
+const RegisterRequestSchema = z.object({
+    server_id: z.string().min(1),
+    snapshot_hash: z.string().regex(HASH_RE),
+    entries: z.array(RegisterEntrySchema).min(1).max(10000),
+});
+
+// D1 allows at most 100 bound parameters per statement.
+const CONTENT_ROWS_PER_STATEMENT = 50; // 2 params per row
+const REGISTER_ROWS_PER_STATEMENT = 25; // 4 params per row
+const HASHES_PER_LOOKUP = 100;
+const STATEMENTS_PER_BATCH = 50;
+
+function base64ToBytes(value: string): Uint8Array {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+}
+
+function chunked<T>(items: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let offset = 0; offset < items.length; offset += size) {
+        chunks.push(items.slice(offset, offset + size));
+    }
+    return chunks;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.use("*", async (c, next) => {
+    if (c.req.method === "GET") {
+        return next();
+    }
+    const token = c.env.SYNC_TOKEN;
+    if (!token) {
+        return c.json({ ok: false, error: "Server misconfigured: SYNC_TOKEN is not set" }, 500);
+    }
+    const header = c.req.header("Authorization");
+    if (header !== `Bearer ${token}`) {
+        return c.json({ ok: false, error: "Unauthorized" }, 401);
+    }
+    return next();
+});
+
+app.get("/health", async (c) => {
+    await c.env.PLATFORM_DB.prepare("SELECT 1").first();
+    return c.json({ ok: true });
+});
+
+app.post("/content", async (c) => {
+    const parsed = ContentRequestSchema.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) {
+        return c.json({ ok: false, error: "Validation failed", details: parsed.error.issues }, 400);
+    }
+
+    const byFamily = new Map<Family, { hash: string; content: Uint8Array }[]>();
+    for (const entry of parsed.data.entries) {
+        const rows = byFamily.get(entry.family) ?? [];
+        rows.push({ hash: entry.content_hash, content: base64ToBytes(entry.content_b64) });
+        byFamily.set(entry.family, rows);
+    }
+
+    let inserted = 0;
+    for (const [family, rows] of byFamily) {
+        const table = FAMILIES[family].content;
+        const statements: D1PreparedStatement[] = [];
+        for (const chunk of chunked(rows, CONTENT_ROWS_PER_STATEMENT)) {
+            const placeholders = chunk.map(() => "(?, ?)").join(", ");
+            const binds: (string | ArrayBuffer)[] = chunk.flatMap((row) => [
+                row.hash,
+                row.content.buffer as ArrayBuffer,
+            ]);
+            statements.push(
+                c.env.PLATFORM_DB.prepare(
+                    `INSERT OR IGNORE INTO ${table} (content_hash, content) VALUES ${placeholders}`,
+                ).bind(...binds),
+            );
+        }
+        for (const batch of chunked(statements, STATEMENTS_PER_BATCH)) {
+            const results = await c.env.PLATFORM_DB.batch(batch);
+            for (const result of results) {
+                inserted += result.meta.changes ?? 0;
+            }
+        }
+    }
+
+    return c.json({ ok: true, inserted });
+});
+
+app.post("/register", async (c) => {
+    const parsed = RegisterRequestSchema.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) {
+        return c.json({ ok: false, error: "Validation failed", details: parsed.error.issues }, 400);
+    }
+
+    const { server_id: serverId, snapshot_hash: snapshotHash, entries } = parsed.data;
+
+    const byFamily = new Map<Family, { id: number; hash: string }[]>();
+    for (const entry of entries) {
+        const rows = byFamily.get(entry.family) ?? [];
+        rows.push({ id: entry.entry_id, hash: entry.content_hash });
+        byFamily.set(entry.family, rows);
+    }
+
+    // Referential integrity: every registered content hash must already exist.
+    const missing: { family: Family; content_hash: string }[] = [];
+    for (const [family, rows] of byFamily) {
+        const table = FAMILIES[family].content;
+        const uniqueHashes = [...new Set(rows.map((row) => row.hash))];
+        for (const chunk of chunked(uniqueHashes, HASHES_PER_LOOKUP)) {
+            const placeholders = chunk.map(() => "?").join(", ");
+            const found = await c.env.PLATFORM_DB.prepare(
+                `SELECT content_hash FROM ${table} WHERE content_hash IN (${placeholders})`,
+            )
+                .bind(...chunk)
+                .all<{ content_hash: string }>();
+            const foundSet = new Set(found.results.map((row) => row.content_hash));
+            for (const hash of chunk) {
+                if (!foundSet.has(hash)) {
+                    missing.push({ family, content_hash: hash });
+                }
+            }
+        }
+    }
+    if (missing.length > 0) {
+        return c.json(
+            { ok: false, error: "Unknown content hashes", missing: missing.slice(0, 100) },
+            409,
+        );
+    }
+
+    let inserted = 0;
+    for (const [family, rows] of byFamily) {
+        const table = FAMILIES[family].reg;
+        const statements: D1PreparedStatement[] = [];
+        for (const chunk of chunked(rows, REGISTER_ROWS_PER_STATEMENT)) {
+            const placeholders = chunk.map(() => "(?, ?, ?, ?)").join(", ");
+            const binds = chunk.flatMap((row) => [serverId, snapshotHash, row.id, row.hash]);
+            statements.push(
+                c.env.PLATFORM_DB.prepare(
+                    `INSERT OR REPLACE INTO ${table} ` +
+                        `(server_id, snapshot_hash, entry_id, content_hash) VALUES ${placeholders}`,
+                ).bind(...binds),
+            );
+        }
+        for (const batch of chunked(statements, STATEMENTS_PER_BATCH)) {
+            const results = await c.env.PLATFORM_DB.batch(batch);
+            for (const result of results) {
+                inserted += result.meta.changes ?? 0;
+            }
+        }
+    }
+
+    return c.json({ ok: true, inserted });
+});
+
+app.onError((err, c) => {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ ok: false, error: "Internal server error", details: message }, 500);
+});
+
+const root = new Hono<{ Bindings: Env }>();
+root.route("/platform/storage/data-sync", app);
+export default root;

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -27,7 +27,7 @@ const HASH_RE = /^[0-9a-f]{64}$/;
 const ContentEntrySchema = z.object({
     family: z.enum(Object.keys(FAMILIES) as [Family, ...Family[]]),
     content_hash: z.string().regex(HASH_RE),
-    content_b64: z.string().min(1),
+    content_b64: z.base64().min(1),
 });
 
 const ContentRequestSchema = z.object({

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { describe, it } from "node:test";
+import worker from "../src/index.ts";
+
+const MOUNT = "/platform/storage/data-sync";
+const TOKEN = "test-token";
+
+interface D1ResultLike {
+    results: unknown[];
+    success: boolean;
+    meta: { changes: number };
+}
+
+type SqlParam = string | number | Uint8Array | null;
+
+function toSqlParam(value: unknown): SqlParam {
+    if (value instanceof ArrayBuffer) {
+        return new Uint8Array(value);
+    }
+    return value as SqlParam;
+}
+
+class TestStatement {
+    private readonly db: DatabaseSync;
+    readonly sql: string;
+    private readonly params: unknown[];
+
+    constructor(db: DatabaseSync, sql: string, params: unknown[] = []) {
+        this.db = db;
+        this.sql = sql;
+        this.params = params;
+    }
+
+    bind(...params: unknown[]): TestStatement {
+        return new TestStatement(this.db, this.sql, params);
+    }
+
+    private boundParams(): SqlParam[] {
+        return this.params.map(toSqlParam);
+    }
+
+    async first<T>(): Promise<T | null> {
+        const row = this.db.prepare(this.sql).get(...this.boundParams());
+        return (row as T | undefined) ?? null;
+    }
+
+    async all<T>(): Promise<D1ResultLike & { results: T[] }> {
+        const rows = this.db.prepare(this.sql).all(...this.boundParams());
+        return { results: rows as T[], success: true, meta: { changes: 0 } };
+    }
+
+    async run(): Promise<D1ResultLike> {
+        const info = this.db.prepare(this.sql).run(...this.boundParams());
+        return { results: [], success: true, meta: { changes: Number(info.changes) } };
+    }
+
+    executeForBatch(): Promise<D1ResultLike> {
+        return /^\s*select/i.test(this.sql) ? this.all() : this.run();
+    }
+}
+
+class TestD1Database {
+    private readonly db: DatabaseSync;
+
+    constructor(db: DatabaseSync) {
+        this.db = db;
+    }
+
+    prepare(sql: string): TestStatement {
+        return new TestStatement(this.db, sql);
+    }
+
+    async batch(statements: TestStatement[]): Promise<D1ResultLike[]> {
+        this.db.exec("BEGIN");
+        try {
+            const results: D1ResultLike[] = [];
+            for (const statement of statements) {
+                results.push(await statement.executeForBatch());
+            }
+            this.db.exec("COMMIT");
+            return results;
+        } catch (error) {
+            this.db.exec("ROLLBACK");
+            throw error;
+        }
+    }
+}
+
+interface TestContext {
+    db: DatabaseSync;
+    post: (path: string, body: unknown) => Promise<Response>;
+    get: (path: string) => Promise<Response>;
+}
+
+function setup(): TestContext {
+    const db = new DatabaseSync(":memory:");
+    db.exec(readFileSync(new URL("../migrations/0001_init.sql", import.meta.url), "utf8"));
+    const env = { PLATFORM_DB: new TestD1Database(db) as unknown as D1Database, SYNC_TOKEN: TOKEN };
+    return {
+        db,
+        post: (path, body) =>
+            worker.fetch(
+                new Request(`https://example.com${MOUNT}${path}`, {
+                    method: "POST",
+                    headers: {
+                        "content-type": "application/json",
+                        authorization: `Bearer ${TOKEN}`,
+                    },
+                    body: JSON.stringify(body),
+                }),
+                env,
+            ),
+        get: (path) => worker.fetch(new Request(`https://example.com${MOUNT}${path}`), env),
+    };
+}
+
+async function sha256Hex(data: Uint8Array): Promise<string> {
+    const digest = await crypto.subtle.digest("SHA-256", data.buffer as ArrayBuffer);
+    return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function toBase64(data: Uint8Array): string {
+    return btoa(String.fromCharCode(...data));
+}
+
+describe("snapshot freeze", () => {
+    it("rejects /register after /complete and keeps the registration set frozen", async () => {
+        const { db, post, get } = setup();
+        const serverId = "tranquility";
+        const snapshotHash = "ab".repeat(32);
+
+        const content = new TextEncoder().encode("type-entry-1");
+        const contentHash = await sha256Hex(content);
+
+        let res = await post("/content", {
+            entries: [
+                { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
+            ],
+        });
+        assert.equal(res.status, 200);
+
+        res = await post("/register", {
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entries: [{ family: "types", entry_id: 1, content_hash: contentHash }],
+        });
+        assert.equal(res.status, 200);
+        assert.deepEqual(await res.json(), { ok: true, inserted: 1 });
+
+        res = await post("/complete", {
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 1,
+        });
+        assert.equal(res.status, 200);
+
+        res = await post("/register", {
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entries: [{ family: "types", entry_id: 2, content_hash: contentHash }],
+        });
+        assert.equal(res.status, 409);
+        const conflict = (await res.json()) as { ok: boolean; error: string };
+        assert.equal(conflict.ok, false);
+        assert.equal(conflict.error, "Snapshot already complete");
+
+        const regCount = db
+            .prepare(
+                "SELECT COUNT(*) AS n FROM types_reg WHERE server_id = ? AND snapshot_hash = ?",
+            )
+            .get(serverId, snapshotHash) as { n: number };
+        assert.equal(regCount.n, 1);
+
+        res = await get(`/snapshot?server_id=${serverId}&snapshot_hash=${snapshotHash}`);
+        assert.equal(res.status, 200);
+        const snapshot = (await res.json()) as {
+            ok: boolean;
+            complete: boolean;
+            entry_count: number;
+        };
+        assert.equal(snapshot.complete, true);
+        assert.equal(snapshot.entry_count, 1);
+    });
+});

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -184,3 +184,44 @@ describe("snapshot freeze", () => {
         assert.equal(snapshot.entry_count, 1);
     });
 });
+
+describe("entry_id validation", () => {
+    it("accepts negative entry IDs used by engine-internal pseudo entries", async () => {
+        const { post } = setup();
+        const serverId = "tranquility";
+        const snapshotHash = "cd".repeat(32);
+
+        const content = new TextEncoder().encode("pseudo-effect");
+        const contentHash = await sha256Hex(content);
+
+        let res = await post("/content", {
+            entries: [
+                { family: "dogma_effects", content_hash: contentHash, content_b64: toBase64(content) },
+            ],
+        });
+        assert.equal(res.status, 200);
+
+        res = await post("/register", {
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entries: [{ family: "dogma_effects", entry_id: -64, content_hash: contentHash }],
+        });
+        assert.equal(res.status, 200);
+        assert.deepEqual(await res.json(), { ok: true, inserted: 1 });
+    });
+
+    it("rejects entry IDs outside the int32 range", async () => {
+        const { post } = setup();
+        const snapshotHash = "ef".repeat(32);
+        const contentHash = "ab".repeat(32);
+
+        for (const entryId of [-2147483649, 2147483648]) {
+            const res = await post("/register", {
+                server_id: "tranquility",
+                snapshot_hash: snapshotHash,
+                entries: [{ family: "types", entry_id: entryId, content_hash: contentHash }],
+            });
+            assert.equal(res.status, 400);
+        }
+    });
+});

--- a/worker/efa-platform-data-sync/tsconfig.json
+++ b/worker/efa-platform-data-sync/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ES2022",
+        "moduleResolution": "bundler",
+        "lib": ["ES2022"],
+        "types": ["@cloudflare/workers-types"],
+        "allowJs": true,
+        "checkJs": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "sourceMap": true,
+        "strict": true,
+        "noEmit": true,
+        "isolatedModules": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/worker/efa-platform-data-sync/wrangler.toml
+++ b/worker/efa-platform-data-sync/wrangler.toml
@@ -9,8 +9,7 @@ command = "./build.sh"
 [[d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "efa-platform-prod"
-# Fill in after `wrangler d1 create efa-platform-prod`.
-database_id = "00000000-0000-0000-0000-000000000000"
+database_id = "21ba756f-dbe2-4254-8d41-c75c3a5d2784"
 migrations_dir = "migrations"
 
 [[routes]]

--- a/worker/efa-platform-data-sync/wrangler.toml
+++ b/worker/efa-platform-data-sync/wrangler.toml
@@ -2,10 +2,6 @@ name = "efa-platform-data-sync"
 compatibility_date = "2026-08-01"
 main = "src/index.ts"
 
-[build]
-# The Git integration's build command runs ./build.sh.
-command = "./build.sh"
-
 [[d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "efa-platform-prod"

--- a/worker/efa-platform-data-sync/wrangler.toml
+++ b/worker/efa-platform-data-sync/wrangler.toml
@@ -1,0 +1,18 @@
+name = "efa-platform-data-sync"
+compatibility_date = "2026-08-01"
+main = "src/index.ts"
+
+[build]
+# The Git integration's build command runs ./build.sh.
+command = "./build.sh"
+
+[[d1_databases]]
+binding = "PLATFORM_DB"
+database_name = "efa-platform-prod"
+# Fill in after `wrangler d1 create efa-platform-prod`.
+database_id = "00000000-0000-0000-0000-000000000000"
+migrations_dir = "migrations"
+
+[[routes]]
+pattern = "api.efa-tech.dev/platform/storage/data-sync/*"
+zone_name = "efa-tech.dev"


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform data synchronization for publishing snapshot content and localized metadata to a D1-backed service.
  * Added authenticated health, content upload, registration, completion, and snapshot status APIs.
  * Added validation, batching, deduplication, retries, dry-run support, and snapshot completeness tracking.
  * Added release workflow integration with configurable synchronization credentials and endpoints.

* **Documentation**
  * Added setup, deployment, configuration, API, and local development documentation.

* **Tests**
  * Added comprehensive coverage for synchronization, validation, batching, error handling, and snapshot registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->