### PR TITLE
feat(snapshot-ts): add Svelte fit snapshot display package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         if: matrix.suite == 'dart' || matrix.suite == 'dart-web'
         run: nix develop .#dart --command bash -c 'flutter pub get'
       - name: Install JS dependencies
-        if: matrix.suite == 'site'
+        if: matrix.suite == 'site' || matrix.suite == 'snapshot-ts'
         run: nix develop .#js --command bash -c 'pnpm install'
       - name: Fetch native CI data
         if: matrix.suite == 'dart' || matrix.suite == 'dart-web'

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
         "useIgnoreFile": true
     },
     "files": {
-        "includes": ["site/**/*", "worker/**/*"],
+        "includes": ["site/**/*", "worker/**/*", "packages/efa_fit_snapshot_ts/**/*"],
         "ignoreUnknown": false
     },
     "formatter": {
@@ -40,7 +40,7 @@
     },
     "overrides": [
         {
-            "includes": ["site/**/*.svelte"],
+            "includes": ["site/**/*.svelte", "packages/efa_fit_snapshot_ts/**/*.svelte"],
             "linter": {
                 "rules": {
                     "style": {

--- a/bootstrap/ci/codegen.py
+++ b/bootstrap/ci/codegen.py
@@ -112,6 +112,7 @@ LANGUAGE_STEPS = {
     "python": ["protobuf"],
     "dart": ["protobuf", "frb", "dart_build_runner", "l10n"],
     "site": ["protobuf_ts"],
+    "snapshot-ts": ["protobuf_ts"],
     "all": ["protobuf", "protobuf_ts", "frb", "dart_build_runner", "l10n"],
 }
 

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -85,7 +85,7 @@ def register_ci_commands(cli_group: click.Group) -> None:
     @ci.command("lint")
     @click.option(
         "--lang",
-        type=click.Choice(["all", "python", "dart", "rust", "site", "l10n"]),
+        type=click.Choice(["all", "python", "dart", "rust", "site", "snapshot-ts", "l10n"]),
         default="all",
         help="Limit linting to a specific language (default: all).",
     )
@@ -96,7 +96,7 @@ def register_ci_commands(cli_group: click.Group) -> None:
     @ci.command("codegen")
     @click.option(
         "--lang",
-        type=click.Choice(["all", "python", "dart", "site"]),
+        type=click.Choice(["all", "python", "dart", "site", "snapshot-ts"]),
         default="all",
         help="Generate code for specific language (default: all).",
     )

--- a/bootstrap/ci/lint.py
+++ b/bootstrap/ci/lint.py
@@ -12,7 +12,7 @@ from bootstrap.utils import execute_command
 from bootstrap.utils import get_command
 
 
-__all__ = ["run_lint", "run_site_checks"]
+__all__ = ["run_lint", "run_site_checks", "run_snapshot_ts_checks"]
 
 
 def run_lint(
@@ -118,6 +118,13 @@ def run_lint(
         pnpm = get_command("pnpm")
         run_site_checks(pnpm, no_check=no_check, check_only=check_only, dry_run=dry_run)
 
+    if (
+        lang in ("all", "snapshot-ts")
+        and Path("packages/efa_fit_snapshot_ts/package.json").exists()
+    ):
+        pnpm = get_command("pnpm")
+        run_snapshot_ts_checks(pnpm, no_check=no_check, check_only=check_only, dry_run=dry_run)
+
     if lang in ("all", "l10n") and (not no_check or check_only):
         from bootstrap.ci.lint_l10n import run_l10n_lint
 
@@ -153,3 +160,46 @@ def run_site_checks(
 
         _echo("pnpm --filter efa-tech check")
         execute_command([pnpm, "--filter", "efa-tech", "check"], "SVELTE CHECK OUTPUT", dry_run)
+
+
+def run_snapshot_ts_checks(
+    pnpm: str, *, no_check: bool = False, check_only: bool = False, dry_run: bool = False
+) -> None:
+    """Format and lint the snapshot TypeScript package (biome + svelte-check).
+
+    check_only=True: read-only verification (CI mode); exits non-zero on failures.
+    check_only=False: auto-fix mode; formatters modify in-place.
+    """
+
+    def _echo(cmd_str: str) -> None:
+        click.echo(styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + cmd_str)
+
+    if check_only:
+        _echo("pnpm biome format packages/efa_fit_snapshot_ts/")
+        execute_command(
+            [pnpm, "biome", "format", "packages/efa_fit_snapshot_ts/"],
+            "BIOME FORMAT OUTPUT",
+            dry_run,
+        )
+    else:
+        _echo("pnpm biome format --write packages/efa_fit_snapshot_ts/")
+        execute_command(
+            [pnpm, "biome", "format", "--write", "packages/efa_fit_snapshot_ts/"],
+            "BIOME FORMAT OUTPUT",
+            dry_run,
+        )
+
+    if not no_check or check_only:
+        _echo("pnpm biome check packages/efa_fit_snapshot_ts/")
+        execute_command(
+            [pnpm, "biome", "check", "packages/efa_fit_snapshot_ts/"],
+            "BIOME CHECK OUTPUT",
+            dry_run,
+        )
+
+        _echo("pnpm --filter efa-fit-snapshot-ts check")
+        execute_command(
+            [pnpm, "--filter", "efa-fit-snapshot-ts", "check"],
+            "SNAPSHOT TS CHECK OUTPUT",
+            dry_run,
+        )

--- a/bootstrap/ci/suites.py
+++ b/bootstrap/ci/suites.py
@@ -61,6 +61,22 @@ SUITE_DEFINITIONS = [
         "patterns": ["site/**", "pnpm-lock.yaml", "biome.json", "package.json"],
     },
     {
+        "suite": "snapshot-ts",
+        "shell": "js",
+        "lint_command": "uv run x.py ci lint --lang snapshot-ts",
+        "command": "true",
+        "codegen_command": "uv run x.py ci codegen --lang snapshot-ts",
+        "patterns": [
+            "packages/efa_fit_snapshot_ts/**",
+            "packages/efa_proto_ts/**",
+            "data/schema/**",
+            "pnpm-workspace.yaml",
+            "pnpm-lock.yaml",
+            "biome.json",
+            "package.json",
+        ],
+    },
+    {
         "suite": "workflows",
         "shell": "ci",
         "lint_command": "true",

--- a/flake.nix
+++ b/flake.nix
@@ -405,6 +405,7 @@
           };
 
           # Code generation shell: protobuf, FRB, dart build_runner, l10n
+          # (jsPackages: TS protobuf bindings via buf from node_modules)
           codegen = pkgs.mkShell {
             packages =
               pythonPackages
@@ -413,6 +414,7 @@
               ++ dartPackages
               ++ protobufPackages
               ++ frbPackages
+              ++ jsPackages
               ++ [ pkgs.libsecret ];
 
             inherit (localeEnv) LANG LC_ALL;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dev:redirect": "pnpm --filter issue-redirect dev",
     "check:redirect": "pnpm --filter issue-redirect check",
     "dev:email-filter": "pnpm --filter email-filter dev",
-    "check:email-filter": "pnpm --filter email-filter check"
+    "check:email-filter": "pnpm --filter email-filter check",
+    "check:snapshot-ts": "pnpm --filter efa-fit-snapshot-ts check"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.7"

--- a/packages/efa_fit_snapshot_ts/package.json
+++ b/packages/efa_fit_snapshot_ts/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "efa-fit-snapshot-ts",
+    "private": true,
+    "version": "0.1.0",
+    "type": "module",
+    "exports": {
+        ".": "./src/lib/index.ts"
+    },
+    "scripts": {
+        "check": "svelte-check --tsconfig ./tsconfig.json"
+    },
+    "dependencies": {
+        "@bufbuild/protobuf": "^2.14.0",
+        "efa-proto-ts": "workspace:*"
+    },
+    "devDependencies": {
+        "svelte": "^5.56.9",
+        "svelte-check": "^4.7.5",
+        "typescript": "^6.0.3"
+    },
+    "peerDependencies": {
+        "svelte": "^5.0.0"
+    }
+}

--- a/packages/efa_fit_snapshot_ts/src/lib/FitSnapshotView.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/FitSnapshotView.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+import type { FitSnapshot } from "efa-proto-ts/fit_snapshot_pb";
+import CharacterColumn from "./columns/CharacterColumn.svelte";
+import EquipmentColumn from "./columns/EquipmentColumn.svelte";
+import StatisticsColumn from "./columns/StatisticsColumn.svelte";
+import { setSnapshotContext, type TypeIconResolver } from "./context.svelte";
+import { resolveSnapshotName, translateSnapshot } from "./i18n";
+
+interface Props {
+    /** Decoded `fit.FitSnapshot` protobuf message (see `efa-proto-ts/fit_snapshot_pb`). */
+    snapshot: FitSnapshot;
+    /**
+     * Component-level BCP-47 locale (e.g. `"en"`, `"zh"`, `"zh-CN"`). Drives both the
+     * component chrome translations and the resolution of snapshot `names` maps.
+     */
+    locale?: string;
+    /** Overrides type-icon resolution; defaults to the public EVE image server. */
+    iconResolver?: TypeIconResolver;
+    /** Whether to show the fit name/description header above the columns. */
+    showHeader?: boolean;
+}
+
+let { snapshot, locale = "en", iconResolver, showHeader = true }: Props = $props();
+
+setSnapshotContext(
+    () => locale,
+    () => iconResolver,
+);
+
+const shipName = $derived(snapshot.ship?.type?.names ?? {});
+</script>
+
+<div class="efa-snapshot">
+    {#if showHeader && snapshot.header}
+        <header class="efa-snapshot-header">
+            <h2 class="efa-snapshot-title">
+                {translateSnapshot(locale, "fitPageTitle", {
+                    fitName: snapshot.header.fitName,
+                    shipName: resolveSnapshotName(shipName, locale),
+                })}
+            </h2>
+            {#if snapshot.header.description}
+                <p class="efa-snapshot-description">{snapshot.header.description}</p>
+            {/if}
+        </header>
+    {/if}
+    <div class="efa-snapshot-columns">
+        <section class="efa-frame efa-col-character">
+            <CharacterColumn {snapshot} />
+        </section>
+        <section class="efa-frame efa-col-equipment">
+            <EquipmentColumn {snapshot} />
+        </section>
+        {#if snapshot.statistics}
+            <section class="efa-frame efa-col-stats">
+                <StatisticsColumn {snapshot} />
+            </section>
+        {/if}
+    </div>
+</div>
+
+<style>
+    .efa-snapshot {
+        --efa-bg: #0c1213;
+        --efa-deep: #0a1a2a;
+        --efa-surface: #12202a;
+        --efa-surface-alt: #1a2e3a;
+        --efa-border: #22404f;
+        --efa-text: #e0f4ff;
+        --efa-text-dim: #9db8c6;
+        --efa-text-muted: #64808f;
+        --efa-accent: #30b2e6;
+        --efa-highlight: #4ed4ff;
+        --efa-success: #2e7d32;
+        --efa-danger: #ef5350;
+        --efa-state-active: #2e7d32;
+        --efa-state-online: #bdbdbd;
+        --efa-state-overload: #ef5350;
+        --efa-state-passive: #2d2d2d;
+        --efa-bar-track: #1a2e3a;
+
+        container-type: inline-size;
+        background: var(--efa-bg);
+        color: var(--efa-text);
+        font-size: 14px;
+        line-height: 1.4;
+        padding: 12px;
+        box-sizing: border-box;
+    }
+    .efa-snapshot *,
+    .efa-snapshot *::before,
+    .efa-snapshot *::after {
+        box-sizing: border-box;
+    }
+    .efa-snapshot-header {
+        padding: 4px 4px 12px;
+    }
+    .efa-snapshot-title {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 600;
+    }
+    .efa-snapshot-description {
+        margin: 4px 0 0;
+        font-size: 13px;
+        color: var(--efa-text-dim);
+        white-space: pre-wrap;
+    }
+    .efa-snapshot-columns {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 12px;
+        align-items: start;
+    }
+    .efa-frame {
+        background: var(--efa-surface);
+        border: 1px solid var(--efa-border);
+        padding: 8px 0;
+        min-width: 0;
+    }
+
+    @container (max-width: 875.98px) {
+        .efa-col-equipment {
+            order: 1;
+        }
+        .efa-col-character {
+            order: 2;
+        }
+        .efa-col-stats {
+            order: 3;
+        }
+    }
+
+    @container (min-width: 876px) {
+        .efa-snapshot-columns {
+            grid-template-columns: 1fr 1fr;
+        }
+        .efa-col-equipment {
+            grid-column: 1;
+            grid-row: 1 / span 2;
+        }
+        .efa-col-character {
+            grid-column: 2;
+            grid-row: 1;
+        }
+        .efa-col-stats {
+            grid-column: 2;
+            grid-row: 2;
+        }
+    }
+
+    @container (min-width: 1284px) {
+        .efa-snapshot-columns {
+            grid-template-columns: 1fr 1fr 1fr;
+        }
+        .efa-col-character {
+            grid-column: 1;
+            grid-row: 1;
+        }
+        .efa-col-equipment {
+            grid-column: 2;
+            grid-row: 1;
+        }
+        .efa-col-stats {
+            grid-column: 3;
+            grid-row: 1;
+        }
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/columns/CharacterColumn.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/columns/CharacterColumn.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+import { type FitSnapshot, SnapshotCharacter_Builtin } from "efa-proto-ts/fit_snapshot_pb";
+import Glyph from "../components/Glyph.svelte";
+import SectionHeader from "../components/SectionHeader.svelte";
+import StateIcon from "../components/StateIcon.svelte";
+import TypeIcon from "../components/TypeIcon.svelte";
+import { snapshotDisplay } from "../context.svelte";
+import ModuleRow from "../rows/ModuleRow.svelte";
+
+interface Props {
+    snapshot: FitSnapshot;
+}
+
+let { snapshot }: Props = $props();
+
+const ctx = snapshotDisplay();
+
+const characterName = $derived.by(() => {
+    const character = snapshot.character;
+    if (!character) return "";
+    if (Object.keys(character.names).length > 0) return ctx.name(character.names);
+    switch (character.builtin) {
+        case SnapshotCharacter_Builtin.ALL_5:
+            return ctx.t("skillProfileAll5");
+        case SnapshotCharacter_Builtin.ALL_0:
+            return ctx.t("skillProfileAll0");
+        case SnapshotCharacter_Builtin.ALPHA_MAX:
+            return ctx.t("skillProfileAlphaMax");
+        default:
+            return "";
+    }
+});
+</script>
+
+<div class="efa-column">
+    <div class="efa-character-header">
+        <Glyph name="person" size={22} />
+        <span class="efa-character-name">{characterName}</span>
+    </div>
+    <hr class="efa-divider" />
+
+    <SectionHeader title={ctx.t("implantSlot")} />
+    {#each snapshot.implants as implant (implant.slotIndex)}
+        {#if implant.item}
+            <ModuleRow module={implant.item} />
+        {:else}
+            <div class="efa-row">
+                <span class="efa-empty-icon">
+                    <Glyph name="implant" size={20} />
+                </span>
+                <div class="efa-row-body">
+                    <div class="efa-empty-title">
+                        {ctx.t("slotEmpty", { slotName: ctx.t("implantSlot") })}
+                    </div>
+                </div>
+                <div class="efa-row-trailing">{implant.slotIndex}</div>
+            </div>
+        {/if}
+    {/each}
+
+    <SectionHeader title={ctx.t("boosterSlot")} />
+    {#if snapshot.boosters.length === 0}
+        <div class="efa-section-empty">
+            {ctx.t("slotEmpty", { slotName: ctx.t("boosterSlot") })}
+        </div>
+    {/if}
+    {#each snapshot.boosters as booster (booster.slotIndex)}
+        <div class="efa-row">
+            <StateIcon state={booster.state}>
+                {#if booster.type}
+                    <TypeIcon typeId={booster.type.typeId} size={31} />
+                {/if}
+            </StateIcon>
+            <div class="efa-row-body">
+                <div class="efa-row-title">
+                    {booster.type ? ctx.name(booster.type.names) : ""}
+                </div>
+                <div class="efa-row-subtitle">{ctx.t("boosterSlot")} {booster.slotIndex}</div>
+            </div>
+        </div>
+    {/each}
+</div>
+
+<style>
+    .efa-column {
+        display: flex;
+        flex-direction: column;
+    }
+    .efa-character-header {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 12px 14px;
+        color: var(--efa-text, #e0f4ff);
+    }
+    .efa-character-name {
+        font-weight: 600;
+    }
+    .efa-divider {
+        border: none;
+        border-top: 1px solid var(--efa-border, #22404f);
+        margin: 0;
+    }
+    .efa-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 14px;
+        min-height: 48px;
+        box-sizing: border-box;
+    }
+    .efa-row-body {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+    .efa-row-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .efa-row-subtitle {
+        font-size: 13px;
+        color: var(--efa-text-dim, #9db8c6);
+    }
+    .efa-row-trailing {
+        flex-shrink: 0;
+        color: var(--efa-text-dim, #9db8c6);
+        font-variant-numeric: tabular-nums;
+    }
+    .efa-empty-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 35px;
+        height: 35px;
+        flex-shrink: 0;
+        border: 2px solid var(--efa-state-passive, #2d2d2d);
+        border-radius: 2px;
+        color: var(--efa-text-muted, #64808f);
+        box-sizing: border-box;
+    }
+    .efa-empty-title {
+        color: var(--efa-text-muted, #64808f);
+    }
+    .efa-section-empty {
+        padding: 10px 14px;
+        color: var(--efa-text-muted, #64808f);
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/columns/EquipmentColumn.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/columns/EquipmentColumn.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+import { Subsystem_SubsystemType } from "efa-proto-ts/fit_pb";
+import {
+    type FitSnapshot,
+    SnapshotFighter_SquadronGroup,
+    SnapshotStatistics_Cargo_HoldKind,
+} from "efa-proto-ts/fit_snapshot_pb";
+import CapacityCounter from "../components/CapacityCounter.svelte";
+import Glyph from "../components/Glyph.svelte";
+import SectionHeader from "../components/SectionHeader.svelte";
+import { snapshotDisplay } from "../context.svelte";
+import { commaSeparated } from "../format";
+import type { GlyphName } from "../glyphs";
+import DroneRow from "../rows/DroneRow.svelte";
+import EmptySlotRow from "../rows/EmptySlotRow.svelte";
+import FighterRow from "../rows/FighterRow.svelte";
+import ModuleRow from "../rows/ModuleRow.svelte";
+import TacticalModeRow from "../rows/TacticalModeRow.svelte";
+import Rack from "./Rack.svelte";
+
+interface Props {
+    snapshot: FitSnapshot;
+}
+
+let { snapshot }: Props = $props();
+
+const ctx = snapshotDisplay();
+
+function subsystemPlaceholder(type: Subsystem_SubsystemType): GlyphName {
+    switch (type) {
+        case Subsystem_SubsystemType.CORE:
+            return "subsystem-core";
+        case Subsystem_SubsystemType.DEFENSIVE:
+            return "subsystem-defensive";
+        case Subsystem_SubsystemType.OFFENSIVE:
+            return "subsystem-offensive";
+        case Subsystem_SubsystemType.PROPULSION:
+            return "subsystem-propulsion";
+        default:
+            return "subsystem";
+    }
+}
+
+const layout = $derived(snapshot.ship?.layout);
+
+const usedTurret = $derived(
+    snapshot.highSlots.filter((slot) => slot.item?.isTurret === true).length,
+);
+const usedLauncher = $derived(
+    snapshot.highSlots.filter((slot) => slot.item?.isLauncher === true).length,
+);
+
+const stats = $derived(snapshot.statistics);
+
+const fighters = $derived(snapshot.fighters);
+const light = $derived(
+    fighters.filter((f) => f.group === SnapshotFighter_SquadronGroup.LIGHT).length,
+);
+const heavy = $derived(
+    fighters.filter((f) => f.group === SnapshotFighter_SquadronGroup.HEAVY).length,
+);
+const support = $derived(
+    fighters.filter((f) => f.group === SnapshotFighter_SquadronGroup.SUPPORT).length,
+);
+const fighterBay = $derived(
+    stats?.cargo?.holds.find((h) => h.kind === SnapshotStatistics_Cargo_HoldKind.FIGHTER_BAY),
+);
+</script>
+
+<div class="efa-column">
+    {#if snapshot.tacticalMode}
+        <SectionHeader title={ctx.t("tacticalMode")} />
+        <TacticalModeRow mode={snapshot.tacticalMode} />
+    {/if}
+
+    <Rack title={ctx.t("highSlot")} slots={snapshot.highSlots} placeholder="slot-high">
+        {#snippet trailing()}
+            {#if (layout?.turretHardpoints ?? 0) > 0 || usedTurret > 0}
+                <span class="efa-hardpoint">
+                    <Glyph name="turret" size={16} />
+                    {usedTurret}/{layout?.turretHardpoints ?? 0}
+                </span>
+            {/if}
+            {#if (layout?.launcherHardpoints ?? 0) > 0 || usedLauncher > 0}
+                <span class="efa-hardpoint">
+                    <Glyph name="launcher" size={16} />
+                    {usedLauncher}/{layout?.launcherHardpoints ?? 0}
+                </span>
+            {/if}
+        {/snippet}
+    </Rack>
+
+    <Rack title={ctx.t("midSlot")} slots={snapshot.mediumSlots} placeholder="slot-medium" />
+    <Rack title={ctx.t("lowSlot")} slots={snapshot.lowSlots} placeholder="slot-low" />
+    <Rack title={ctx.t("rigSlot")} slots={snapshot.rigSlots} placeholder="slot-rig" />
+
+    {#if snapshot.subsystemSlots.length > 0}
+        <SectionHeader title={ctx.t("subsystemSlot")} />
+        {#each snapshot.subsystemSlots as slot (slot.index)}
+            {#if slot.item}
+                <ModuleRow module={slot.item} />
+            {:else}
+                <EmptySlotRow
+                    index={slot.index}
+                    slotName={ctx.t("subsystemSlot")}
+                    placeholder={subsystemPlaceholder(slot.subsystemType)}
+                />
+            {/if}
+        {/each}
+    {/if}
+
+    {#if snapshot.serviceSlots.length > 0}
+        <Rack
+            title={ctx.t("serviceSlot")}
+            slots={snapshot.serviceSlots}
+            placeholder="slot-service"
+        />
+    {/if}
+
+    <SectionHeader title={ctx.t("drone")}>
+        {#snippet trailing()}
+            {#if stats?.drones && (stats.drones.bayCapacityM3 > 0 || stats.drones.bayUsedM3 > 0)}
+                <CapacityCounter
+                    count={Math.round(stats.drones.bayUsedM3)}
+                    total={Math.round(stats.drones.bayCapacityM3)}
+                    suffix="m³"
+                />
+            {/if}
+        {/snippet}
+    </SectionHeader>
+    {#if snapshot.drones.length === 0}
+        <div class="efa-section-empty">{ctx.t("slotEmpty", { slotName: ctx.t("drone") })}</div>
+    {/if}
+    {#each snapshot.drones as drone (drone.type?.typeId)}
+        <DroneRow {drone} />
+    {/each}
+
+    {#if (layout?.fighterTubes ?? 0) > 0}
+        <SectionHeader title={ctx.t("fighter")} />
+        <div class="efa-fighter-counters">
+            {#if heavy > 0}
+                <span>H {heavy}</span>
+            {/if}
+            {#if light > 0}
+                <span>L {light}</span>
+            {/if}
+            {#if support > 0}
+                <span>S {support}</span>
+            {/if}
+            <CapacityCounter
+                count={fighters.length}
+                total={layout?.fighterTubes ?? 0}
+                suffix="x"
+            />
+            {#if fighterBay}
+                <span>{commaSeparated(Math.round(fighterBay.capacityM3))} m³</span>
+            {/if}
+        </div>
+        <hr class="efa-divider" />
+        {#if fighters.length === 0}
+            <div class="efa-section-empty">
+                {ctx.t("slotEmpty", { slotName: ctx.t("fighter") })}
+            </div>
+        {/if}
+        {#each fighters as fighter (fighter.type?.typeId)}
+            <FighterRow {fighter} />
+        {/each}
+    {/if}
+</div>
+
+<style>
+    .efa-column {
+        display: flex;
+        flex-direction: column;
+    }
+    .efa-hardpoint {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        font-variant-numeric: tabular-nums;
+    }
+    .efa-fighter-counters {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 10px 4px;
+        font-size: 13px;
+        color: var(--efa-text-dim, #9db8c6);
+        font-variant-numeric: tabular-nums;
+    }
+    .efa-divider {
+        border: none;
+        border-top: 1px solid var(--efa-border, #22404f);
+        margin: 4px 0;
+    }
+    .efa-section-empty {
+        padding: 10px 14px;
+        color: var(--efa-text-muted, #64808f);
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/columns/Rack.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/columns/Rack.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import type { SnapshotSlot } from "efa-proto-ts/fit_snapshot_pb";
+import type { Snippet } from "svelte";
+import SectionHeader from "../components/SectionHeader.svelte";
+import { snapshotDisplay } from "../context.svelte";
+import type { GlyphName } from "../glyphs";
+import EmptySlotRow from "../rows/EmptySlotRow.svelte";
+import ModuleRow from "../rows/ModuleRow.svelte";
+
+interface Props {
+    title: string;
+    slots: SnapshotSlot[];
+    placeholder: GlyphName;
+    trailing?: Snippet;
+}
+
+let { title, slots, placeholder, trailing }: Props = $props();
+
+const ctx = snapshotDisplay();
+</script>
+
+<SectionHeader {title} {trailing} />
+{#each slots as slot (slot.index)}
+    {#if slot.item}
+        <ModuleRow module={slot.item} />
+    {:else}
+        <EmptySlotRow index={slot.index} slotName={title} {placeholder} />
+    {/if}
+{/each}
+{#if slots.length === 0}
+    <div class="efa-rack-empty">{ctx.t("slotEmpty", { slotName: title })}</div>
+{/if}
+
+<style>
+    .efa-rack-empty {
+        padding: 10px 14px;
+        color: var(--efa-text-muted, #64808f);
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/columns/StatisticsColumn.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/columns/StatisticsColumn.svelte
@@ -1,0 +1,434 @@
+<script lang="ts">
+import {
+    type FitSnapshot,
+    type SnapshotStatistics_Cargo_HoldKind as HoldKindType,
+    SnapshotStatistics_Cargo_HoldKind,
+    type SnapshotStatistics_DefenseLayer,
+} from "efa-proto-ts/fit_snapshot_pb";
+import CompareRow from "../components/CompareRow.svelte";
+import Glyph from "../components/Glyph.svelte";
+import ResonanceBox from "../components/ResonanceBox.svelte";
+import ResourceBar from "../components/ResourceBar.svelte";
+import TypeIcon from "../components/TypeIcon.svelte";
+import { snapshotDisplay } from "../context.svelte";
+import { commaSeparated, formatDuration, toMaxDecimals } from "../format";
+import type { GlyphName } from "../glyphs";
+
+interface Props {
+    snapshot: FitSnapshot;
+}
+
+let { snapshot }: Props = $props();
+
+const ctx = snapshotDisplay();
+
+const stats = $derived(snapshot.statistics);
+const ship = $derived(snapshot.ship?.type);
+const profile = $derived(snapshot.damageProfile);
+
+const capacitor = $derived(stats?.capacitor);
+const capPercent = $derived(
+    capacitor?.isStable === true ? Math.min(Math.max(capacitor.stableFraction * 100, 0), 100) : 0,
+);
+const capDelta = $derived((capacitor?.peakRechargeRate ?? 0) - (capacitor?.peakUseRate ?? 0));
+
+const hpTotal = $derived(
+    (stats?.shield?.hp ?? 0) + (stats?.armor?.hp ?? 0) + (stats?.hull?.hp ?? 0),
+);
+const ehpTotal = $derived(
+    (stats?.shield?.ehp ?? 0) + (stats?.armor?.ehp ?? 0) + (stats?.hull?.ehp ?? 0),
+);
+const maxEhpGlyph: GlyphName = $derived.by(() => {
+    const shield = stats?.shield?.ehp ?? 0;
+    const armor = stats?.armor?.ehp ?? 0;
+    const hull = stats?.hull?.ehp ?? 0;
+    if (shield >= armor && shield >= hull) return "hp-shield";
+    return armor >= hull ? "hp-armor" : "hp-hull";
+});
+
+const defenseLayers: { glyph: GlyphName; layer: SnapshotStatistics_DefenseLayer }[] = $derived.by(
+    () => {
+        const layers: { glyph: GlyphName; layer: SnapshotStatistics_DefenseLayer }[] = [];
+        if (stats?.shield) layers.push({ glyph: "hp-shield", layer: stats.shield });
+        if (stats?.armor) layers.push({ glyph: "hp-armor", layer: stats.armor });
+        if (stats?.hull) layers.push({ glyph: "hp-hull", layer: stats.hull });
+        return layers;
+    },
+);
+
+const maxSensor: { glyph: GlyphName; value: number } = $derived.by(() => {
+    const targeting = stats?.targeting;
+    const radar = targeting?.radarStrength ?? 0;
+    const ladar = targeting?.ladarStrength ?? 0;
+    const magnetometric = targeting?.magnetometricStrength ?? 0;
+    const gravimetric = targeting?.gravimetricStrength ?? 0;
+    if (radar >= ladar && radar >= magnetometric && radar >= gravimetric) {
+        return { glyph: "sensor-radar", value: radar };
+    }
+    if (ladar >= magnetometric && ladar >= gravimetric) {
+        return { glyph: "sensor-ladar", value: ladar };
+    }
+    if (magnetometric >= gravimetric) {
+        return { glyph: "sensor-magnetometric", value: magnetometric };
+    }
+    return { glyph: "sensor-gravimetric", value: gravimetric };
+});
+
+const HOLD_GLYPHS: Record<HoldKindType, GlyphName> = {
+    [SnapshotStatistics_Cargo_HoldKind.FLEET_HANGAR]: "hold-fleet",
+    [SnapshotStatistics_Cargo_HoldKind.SHIP_MAINTENANCE_BAY]: "hold-ship",
+    [SnapshotStatistics_Cargo_HoldKind.FIGHTER_BAY]: "drone-bandwidth",
+    [SnapshotStatistics_Cargo_HoldKind.MINING_HOLD]: "hold-mining",
+    [SnapshotStatistics_Cargo_HoldKind.GAS_HOLD]: "hold-gas",
+    [SnapshotStatistics_Cargo_HoldKind.MINERAL_HOLD]: "hold-mineral",
+    [SnapshotStatistics_Cargo_HoldKind.ICE_HOLD]: "hold-ice",
+    [SnapshotStatistics_Cargo_HoldKind.COMMAND_CENTER_HOLD]: "hold-command",
+    [SnapshotStatistics_Cargo_HoldKind.PLANETARY_COMMODITIES_HOLD]: "hold-planetary",
+    [SnapshotStatistics_Cargo_HoldKind.FUEL_BAY]: "hold-fuel",
+    [SnapshotStatistics_Cargo_HoldKind.AMMO_HOLD]: "alpha",
+    [SnapshotStatistics_Cargo_HoldKind.QUAFE_BAY]: "cargo",
+};
+
+function holdGlyph(kind: HoldKindType): GlyphName {
+    return HOLD_GLYPHS[kind] ?? "cargo";
+}
+</script>
+
+{#if stats}
+    <div class="efa-column">
+        <div class="efa-ship-header">
+            {#if ship}
+                <TypeIcon typeId={ship.typeId} size={40} />
+                <span class="efa-ship-name">{ctx.name(ship.names)}</span>
+            {/if}
+        </div>
+        <hr class="efa-divider" />
+
+        {#if capacitor}
+            <div class="efa-stat-row">
+                <Glyph name="capacitor" size={28} />
+                <div class="efa-stat-body">
+                    <div class="efa-stat-line">
+                        {#if !capacitor.isStable && capacitor.depletesInS > 0}
+                            <span class="efa-danger">{formatDuration(capacitor.depletesInS)}</span>
+                        {:else if capacitor.isStable}
+                            <span class="efa-success">
+                                {ctx.t("capacitorStable", { percent: capPercent.toFixed(1) })}
+                            </span>
+                        {:else}
+                            <span class="efa-danger">{ctx.t("capacitorUnstable")}</span>
+                        {/if}
+                        <span class="efa-sep">|</span>
+                        <span class:efa-danger={capDelta < 0} class:efa-success={capDelta >= 0}>
+                            {capDelta < 0 ? "-" : "+"}{toMaxDecimals(Math.abs(capDelta), 2)} GJ/s
+                        </span>
+                        <span class="efa-sep">|</span>
+                        <span>{Math.round(capacitor.capacityGj)} GJ</span>
+                    </div>
+                    <ResourceBar
+                        used={capPercent}
+                        all={100}
+                        warning={false}
+                        dangerTrack={!capacitor.isStable}
+                    />
+                </div>
+            </div>
+        {/if}
+
+        {#if stats.weapons}
+            <div class="efa-stat-row">
+                <Glyph name="alpha" size={28} />
+                <div class="efa-stat-body">
+                    <div class="efa-stat-line">
+                        <span>{stats.weapons.dpsTotal.toFixed(1)}/s</span>
+                        <span class="efa-sep">|</span>
+                        <span>{stats.weapons.dpsWithReload.toFixed(1)}/s</span>
+                        <span class="efa-sep">|</span>
+                        <span>{stats.weapons.alphaVolley.toFixed(1)}</span>
+                    </div>
+                </div>
+            </div>
+        {/if}
+
+        {#if stats.resources}
+            <div class="efa-resources">
+                <CompareRow
+                    icon="cpu"
+                    used={stats.resources.cpuUsed}
+                    all={stats.resources.cpuTotal}
+                    unit="tf"
+                />
+                <CompareRow
+                    icon="power"
+                    used={stats.resources.powergridUsed}
+                    all={stats.resources.powergridTotal}
+                    unit="MW"
+                />
+                <div class="efa-resources-split">
+                    <CompareRow
+                        icon="rig"
+                        used={stats.resources.calibrationUsed}
+                        all={stats.resources.calibrationTotal}
+                        warning={false}
+                    />
+                    <CompareRow
+                        icon="drone-bandwidth"
+                        used={stats.resources.droneBandwidthUsed}
+                        all={stats.resources.droneBandwidthTotal}
+                        unit="MB/s"
+                        warning={false}
+                    />
+                </div>
+            </div>
+        {/if}
+
+        {#if stats.shield && stats.armor && stats.hull}
+            <div class="efa-stat-row">
+                <Glyph name={maxEhpGlyph} size={36} />
+                <div class="efa-stat-body">
+                    <div class="efa-stat-line">
+                        <span>{Math.round(hpTotal)} HP</span>
+                        <span class="efa-sep">|</span>
+                        <span>{Math.round(ehpTotal)} EHP</span>
+                    </div>
+                </div>
+            </div>
+            <table class="efa-defense">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>HP</th>
+                        <th>EHP</th>
+                        <th><Glyph name="resist-em" size={20} color="#4d9fff" /></th>
+                        <th><Glyph name="resist-thermal" size={20} color="#e5484d" /></th>
+                        <th><Glyph name="resist-kinetic" size={20} color="#9aa4af" /></th>
+                        <th><Glyph name="resist-explosive" size={20} color="#f5a623" /></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each defenseLayers as { glyph, layer } (glyph)}
+                        <tr>
+                            <td><Glyph name={glyph} size={20} /></td>
+                            <td>{Math.round(layer.hp)}</td>
+                            <td>{Math.round(layer.ehp)}</td>
+                            <td>
+                                <ResonanceBox ratio={1 - (layer.resistances?.em ?? 0)} type="em" />
+                            </td>
+                            <td>
+                                <ResonanceBox
+                                    ratio={1 - (layer.resistances?.thermal ?? 0)}
+                                    type="thermal"
+                                />
+                            </td>
+                            <td>
+                                <ResonanceBox
+                                    ratio={1 - (layer.resistances?.kinetic ?? 0)}
+                                    type="kinetic"
+                                />
+                            </td>
+                            <td>
+                                <ResonanceBox
+                                    ratio={1 - (layer.resistances?.explosive ?? 0)}
+                                    type="explosive"
+                                />
+                            </td>
+                        </tr>
+                    {/each}
+                    {#if profile}
+                        <tr>
+                            <td><Glyph name="turret" size={20} /></td>
+                            <td></td>
+                            <td></td>
+                            <td><ResonanceBox ratio={1 - profile.em} type="em" /></td>
+                            <td><ResonanceBox ratio={1 - profile.thermal} type="thermal" /></td>
+                            <td><ResonanceBox ratio={1 - profile.kinetic} type="kinetic" /></td>
+                            <td><ResonanceBox ratio={1 - profile.explosive} type="explosive" /></td>
+                        </tr>
+                    {/if}
+                </tbody>
+            </table>
+        {/if}
+
+        {#if stats.mobility && stats.targeting}
+            <table class="efa-pairs">
+                <tbody>
+                    <tr>
+                        <td><Glyph name="speed" size={20} /></td>
+                        <td>{toMaxDecimals(stats.mobility.maxVelocityMs, 1)} m/s</td>
+                        <td></td>
+                        <td><Glyph name="warp" size={20} /></td>
+                        <td>{toMaxDecimals(stats.mobility.warpSpeedAuS, 1)} AU/s</td>
+                    </tr>
+                    <tr>
+                        <td><Glyph name="target-range" size={20} /></td>
+                        <td>{Math.round(stats.targeting.maxTargetRangeM / 1000)} km</td>
+                        <td></td>
+                        <td><Glyph name="scan-resolution" size={20} /></td>
+                        <td>{Math.round(stats.targeting.scanResolutionMm)} mm</td>
+                    </tr>
+                    <tr>
+                        <td><Glyph name="lock-num" size={20} /></td>
+                        <td>{stats.targeting.maxLockedTargets}</td>
+                        <td></td>
+                        <td><Glyph name={maxSensor.glyph} size={20} /></td>
+                        <td>{toMaxDecimals(maxSensor.value, 1)}</td>
+                    </tr>
+                    <tr>
+                        <td><Glyph name="align-time" size={20} /></td>
+                        <td>{toMaxDecimals(stats.mobility.alignTimeS, 2)} s</td>
+                        <td></td>
+                        <td><Glyph name="signature" size={20} /></td>
+                        <td>{toMaxDecimals(stats.mobility.signatureRadiusM, 0)} m</td>
+                    </tr>
+                </tbody>
+            </table>
+        {/if}
+
+        {#if stats.drones}
+            <table class="efa-pairs">
+                <tbody>
+                    <tr>
+                        <td><Glyph name="drone" size={20} /></td>
+                        <td>{stats.drones.maxActiveDrones}</td>
+                        <td></td>
+                        <td><Glyph name="drone-range" size={20} /></td>
+                        <td>{toMaxDecimals(stats.drones.controlRangeM / 1000, 1)} km</td>
+                    </tr>
+                </tbody>
+            </table>
+        {/if}
+
+        {#if stats.cargo}
+            <div class="efa-cargo">
+                <div class="efa-stat-row">
+                    <Glyph name="mass" size={28} />
+                    <div class="efa-stat-body">
+                        <div class="efa-stat-line">{commaSeparated(stats.cargo.massKg)} kg</div>
+                    </div>
+                </div>
+                <div class="efa-stat-row">
+                    <Glyph name="cargo" size={28} />
+                    <div class="efa-stat-body">
+                        <div class="efa-stat-line">{commaSeparated(stats.cargo.capacityM3)} m³</div>
+                    </div>
+                </div>
+                {#each stats.cargo.holds as hold (hold.kind)}
+                    <div class="efa-stat-row">
+                        <span class="efa-hold-icons">
+                            <Glyph name="cargo" size={28} />
+                            <Glyph name={holdGlyph(hold.kind)} size={28} />
+                        </span>
+                        <div class="efa-stat-body">
+                            <div class="efa-stat-line">
+                                {commaSeparated(hold.capacityM3)} m³
+                            </div>
+                        </div>
+                    </div>
+                {/each}
+            </div>
+        {/if}
+    </div>
+{/if}
+
+<style>
+    .efa-column {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding-bottom: 8px;
+    }
+    .efa-ship-header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 14px 8px;
+    }
+    .efa-ship-name {
+        font-weight: 700;
+        text-align: center;
+    }
+    .efa-divider {
+        border: none;
+        border-top: 1px solid var(--efa-border, #22404f);
+        margin: 0;
+    }
+    .efa-stat-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 2px 20px;
+    }
+    .efa-stat-body {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+    .efa-stat-line {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 6px;
+        font-variant-numeric: tabular-nums;
+    }
+    .efa-sep {
+        color: var(--efa-text-muted, #64808f);
+    }
+    .efa-success {
+        color: var(--efa-success, #2e7d32);
+    }
+    .efa-danger {
+        color: var(--efa-danger, #ef5350);
+    }
+    .efa-resources {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        padding: 0 20px;
+    }
+    .efa-resources-split {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+    }
+    .efa-defense,
+    .efa-pairs {
+        width: calc(100% - 40px);
+        margin: 0 20px;
+        border-collapse: collapse;
+        font-variant-numeric: tabular-nums;
+    }
+    .efa-defense th {
+        font-weight: 400;
+        color: var(--efa-text-dim, #9db8c6);
+    }
+    .efa-defense th,
+    .efa-defense td,
+    .efa-pairs td {
+        text-align: center;
+        vertical-align: middle;
+        padding: 2px;
+    }
+    .efa-defense th:first-child,
+    .efa-defense td:first-child,
+    .efa-pairs td:first-child,
+    .efa-pairs td:nth-child(4) {
+        width: 28px;
+    }
+    .efa-pairs td:nth-child(2),
+    .efa-pairs td:nth-child(5) {
+        text-align: end;
+    }
+    .efa-cargo {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+    .efa-hold-icons {
+        display: inline-flex;
+        gap: 6px;
+        flex-shrink: 0;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/CapacityCounter.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/CapacityCounter.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+import { commaSeparated } from "../format";
+
+interface Props {
+    count: number;
+    total: number;
+    suffix?: string;
+}
+
+let { count, total, suffix = "" }: Props = $props();
+</script>
+
+<span class="efa-capacity-counter">
+    {commaSeparated(count)} / {commaSeparated(total)}{suffix ? ` ${suffix}` : ""}
+</span>
+
+<style>
+    .efa-capacity-counter {
+        white-space: nowrap;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/CompareRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/CompareRow.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+import { commaSeparated, toMaxDecimals } from "../format";
+import type { GlyphName } from "../glyphs";
+import Glyph from "./Glyph.svelte";
+import ResourceBar from "./ResourceBar.svelte";
+
+interface Props {
+    icon: GlyphName;
+    used: number;
+    all: number;
+    unit?: string;
+    warning?: boolean;
+    iconSize?: number;
+}
+
+let { icon, used, all, unit, warning = true, iconSize = 28 }: Props = $props();
+</script>
+
+<div class="efa-compare-row">
+    <Glyph name={icon} size={iconSize} />
+    <div class="efa-compare-body">
+        <div class="efa-compare-text" class:efa-compare-over={warning && used > all}>
+            {commaSeparated(Math.round(used * 10) / 10)} / {toMaxDecimals(all, 1)}{unit
+                ? ` ${unit}`
+                : ""}
+        </div>
+        <ResourceBar {used} {all} {warning} />
+    </div>
+</div>
+
+<style>
+    .efa-compare-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-width: 0;
+    }
+    .efa-compare-body {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+    .efa-compare-text {
+        text-align: end;
+        font-variant-numeric: tabular-nums;
+    }
+    .efa-compare-over {
+        color: var(--efa-danger, #ef5350);
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/Glyph.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/Glyph.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { GLYPHS, type GlyphName } from "../glyphs";
+
+interface Props {
+    name: GlyphName;
+    size?: number;
+    color?: string;
+}
+
+let { name, size = 24, color }: Props = $props();
+</script>
+
+<svg
+    class="efa-glyph"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    style:color
+    aria-hidden="true"
+>
+    {@html GLYPHS[name] ?? ""}
+</svg>
+
+<style>
+    .efa-glyph {
+        display: inline-block;
+        flex-shrink: 0;
+        vertical-align: middle;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/RelatedValues.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/RelatedValues.svelte
@@ -10,7 +10,7 @@ let { values }: Props = $props();
 
 {#if values.length > 0}
     <div class="efa-related-values">
-        {#each values as value (value.text)}
+        {#each values as value, i (i)}
             <span class="efa-related-value">{value.text}</span>
         {/each}
     </div>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/RelatedValues.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/RelatedValues.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import type { SnapshotDisplayValue } from "efa-proto-ts/fit_snapshot_pb";
+
+interface Props {
+    values: SnapshotDisplayValue[];
+}
+
+let { values }: Props = $props();
+</script>
+
+{#if values.length > 0}
+    <div class="efa-related-values">
+        {#each values as value (value.text)}
+            <span class="efa-related-value">{value.text}</span>
+        {/each}
+    </div>
+{/if}
+
+<style>
+    .efa-related-values {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 10px;
+        font-size: 13px;
+        color: var(--efa-text-dim, #9db8c6);
+        font-variant-numeric: tabular-nums;
+    }
+    .efa-related-value {
+        white-space: nowrap;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/ResonanceBox.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/ResonanceBox.svelte
@@ -1,0 +1,52 @@
+<script module lang="ts">
+export type DamageType = "em" | "thermal" | "kinetic" | "explosive";
+</script>
+
+<script lang="ts">
+interface Props {
+    /** Filled fraction, 0..1. */
+    ratio: number;
+    type: DamageType;
+    size?: number;
+}
+
+let { ratio, type, size = 16 }: Props = $props();
+
+const clamped = $derived(Math.min(Math.max(ratio, 0), 1));
+</script>
+
+<span
+    class="efa-resonance efa-resonance-{type}"
+    style:width="{size}px"
+    style:height="{size}px"
+    role="presentation"
+>
+    <span class="efa-resonance-fill" style:height="{clamped * 100}%"></span>
+</span>
+
+<style>
+    .efa-resonance {
+        display: inline-flex;
+        flex-direction: column-reverse;
+        border: 1px solid var(--efa-border, #22404f);
+        border-radius: 1px;
+        overflow: hidden;
+        box-sizing: border-box;
+    }
+    .efa-resonance-fill {
+        display: block;
+        width: 100%;
+    }
+    .efa-resonance-em .efa-resonance-fill {
+        background: #4d9fff;
+    }
+    .efa-resonance-thermal .efa-resonance-fill {
+        background: #e5484d;
+    }
+    .efa-resonance-kinetic .efa-resonance-fill {
+        background: #9aa4af;
+    }
+    .efa-resonance-explosive .efa-resonance-fill {
+        background: #f5a623;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/ResourceBar.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/ResourceBar.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+interface Props {
+    used: number;
+    all: number;
+    /** Over-budget usage turns the fill red. */
+    warning?: boolean;
+    /** Paints the track red (e.g. unstable capacitor). */
+    dangerTrack?: boolean;
+}
+
+let { used, all, warning = true, dangerTrack = false }: Props = $props();
+
+const fraction = $derived(all > 0 ? Math.min(Math.max(used / all, 0), 1) : 0);
+const over = $derived(warning && used > all);
+</script>
+
+<div class="efa-resource-bar" class:efa-resource-danger-track={dangerTrack} role="presentation">
+    <div
+        class="efa-resource-fill"
+        class:efa-resource-over={over}
+        style:width="{fraction * 100}%"
+    ></div>
+</div>
+
+<style>
+    .efa-resource-bar {
+        height: 6px;
+        border-radius: 3px;
+        background: var(--efa-bar-track, #1a2e3a);
+        overflow: hidden;
+    }
+    .efa-resource-danger-track {
+        background: color-mix(in srgb, var(--efa-danger, #ef5350) 30%, transparent);
+    }
+    .efa-resource-fill {
+        height: 100%;
+        border-radius: 3px;
+        background: var(--efa-accent, #30b2e6);
+    }
+    .efa-resource-over {
+        background: var(--efa-danger, #ef5350);
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/SectionHeader.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/SectionHeader.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+
+interface Props {
+    title: string;
+    trailing?: Snippet;
+}
+
+let { title, trailing }: Props = $props();
+</script>
+
+<header class="efa-section-header">
+    <span class="efa-section-title">{title}</span>
+    {#if trailing}
+        <span class="efa-section-trailing">{@render trailing()}</span>
+    {/if}
+</header>
+
+<style>
+    .efa-section-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 10px 14px 6px;
+        border-bottom: 1px solid var(--efa-border, #22404f);
+        margin-bottom: 2px;
+    }
+    .efa-section-title {
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--efa-accent, #30b2e6);
+    }
+    .efa-section-trailing {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 13px;
+        color: var(--efa-text-dim, #9db8c6);
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/StateIcon.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/StateIcon.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+import type { Slots_SlotState } from "efa-proto-ts/fit_pb";
+import { Slots_SlotState as SlotState } from "efa-proto-ts/fit_pb";
+import type { Snippet } from "svelte";
+
+interface Props {
+    state: Slots_SlotState;
+    shape?: "rect" | "circle";
+    size?: number;
+    children: Snippet;
+}
+
+let { state, shape = "rect", size = 35, children }: Props = $props();
+
+const stateClass = $derived(
+    state === SlotState.ACTIVE
+        ? "active"
+        : state === SlotState.ONLINE
+          ? "online"
+          : state === SlotState.OVERLOAD
+            ? "overload"
+            : "passive",
+);
+</script>
+
+<span
+    class="efa-state-icon efa-state-{stateClass}"
+    class:efa-state-circle={shape === "circle"}
+    style:width="{size}px"
+    style:height="{size}px"
+>
+    {@render children()}
+</span>
+
+<style>
+    .efa-state-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        border: 2px solid var(--efa-state-passive, #2d2d2d);
+        border-radius: 2px;
+        overflow: hidden;
+        box-sizing: border-box;
+    }
+    .efa-state-circle {
+        border-radius: 50%;
+    }
+    .efa-state-active {
+        border-color: var(--efa-state-active, #2e7d32);
+    }
+    .efa-state-online {
+        border-color: var(--efa-state-online, #bdbdbd);
+    }
+    .efa-state-overload {
+        border-color: var(--efa-state-overload, #ef5350);
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/TypeIcon.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/TypeIcon.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import { snapshotDisplay } from "../context.svelte";
+
+interface Props {
+    typeId: number;
+    size?: number;
+}
+
+let { typeId, size = 35 }: Props = $props();
+
+const ctx = snapshotDisplay();
+</script>
+
+<img
+    class="efa-type-icon"
+    src={ctx.typeIconUrl(typeId)}
+    width={size}
+    height={size}
+    alt=""
+    loading="lazy"
+    draggable="false"
+/>
+
+<style>
+    .efa-type-icon {
+        display: block;
+        border-radius: 2px;
+        object-fit: contain;
+        background: var(--efa-deep, #0a1a2a);
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/context.svelte.ts
+++ b/packages/efa_fit_snapshot_ts/src/lib/context.svelte.ts
@@ -1,0 +1,54 @@
+import { getContext, setContext } from "svelte";
+import {
+    resolveSnapshotName,
+    type SnapshotMessageKey,
+    type SnapshotTranslateParams,
+    translateSnapshot,
+} from "./i18n";
+
+/** Resolves a `type_id` to an image URL (defaults to the public EVE image server). */
+export type TypeIconResolver = (typeId: number) => string;
+
+export function defaultTypeIconUrl(typeId: number): string {
+    return `https://images.evetech.net/types/${typeId}/icon?size=64`;
+}
+
+/**
+ * Display-scoped configuration carried down the component tree, the Svelte
+ * counterpart of the Flutter `SnapshotDisplay` inherited widget plus the
+ * snapshot `Localizations`.
+ */
+export interface SnapshotDisplayContext {
+    /** Active BCP-47 locale of the component. */
+    readonly locale: string;
+    t(key: SnapshotMessageKey, params?: SnapshotTranslateParams): string;
+    /** Resolves a snapshot `names` map against the active locale. */
+    name(names: Record<string, string>): string;
+    typeIconUrl(typeId: number): string;
+}
+
+const CONTEXT_KEY = "efa-fit-snapshot-display";
+
+export function setSnapshotContext(
+    locale: () => string,
+    resolver?: () => TypeIconResolver | undefined,
+): void {
+    setContext<SnapshotDisplayContext>(CONTEXT_KEY, {
+        get locale() {
+            return locale();
+        },
+        t: (key, params) => translateSnapshot(locale(), key, params),
+        name: (names) => resolveSnapshotName(names, locale()),
+        typeIconUrl: (typeId) => resolver?.()?.(typeId) ?? defaultTypeIconUrl(typeId),
+    });
+}
+
+export function snapshotDisplay(): SnapshotDisplayContext {
+    const ctx = getContext<SnapshotDisplayContext | undefined>(CONTEXT_KEY);
+    if (!ctx) {
+        throw new Error(
+            "efa-fit-snapshot-ts: snapshot components must be rendered inside <FitSnapshotView>",
+        );
+    }
+    return ctx;
+}

--- a/packages/efa_fit_snapshot_ts/src/lib/format.ts
+++ b/packages/efa_fit_snapshot_ts/src/lib/format.ts
@@ -1,0 +1,19 @@
+/** Equivalent of Dart's `num.toStringAsMaxDecimals`. */
+export function toMaxDecimals(value: number, maxDecimals: number): string {
+    return value.toFixed(maxDecimals);
+}
+
+/** Thousands-grouped rounded integer, locale-independent (matches Dart `commaSeparated`). */
+export function commaSeparated(value: number): string {
+    return Math.round(value)
+        .toString()
+        .replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/** Equivalent of Dart's `Duration.format()`: `HH:MM:SS`, sign-prefixed when negative. */
+export function formatDuration(totalSeconds: number): string {
+    const sign = totalSeconds < 0 ? "-" : "";
+    const s = Math.abs(Math.round(totalSeconds));
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${sign}${pad(Math.floor(s / 3600))}:${pad(Math.floor((s % 3600) / 60))}:${pad(s % 60)}`;
+}

--- a/packages/efa_fit_snapshot_ts/src/lib/glyphs.ts
+++ b/packages/efa_fit_snapshot_ts/src/lib/glyphs.ts
@@ -1,0 +1,95 @@
+/**
+ * Inline SVG glyphs standing in for the app's bundled `EfaAssets` icon sheets.
+ * Each entry is inner markup for a 24x24, stroke-based (currentColor) icon.
+ */
+export const GLYPHS = {
+    person: '<circle cx="12" cy="8" r="4"/><path d="M5 21c0-4 3-7 7-7s7 3 7 7"/>',
+    implant: '<circle cx="12" cy="12" r="9"/><path d="M12 8v8M8 12h8"/>',
+    unknown:
+        '<circle cx="12" cy="12" r="9"/><path d="M9.5 9a2.5 2.5 0 0 1 5 .5c0 1.5-2.5 2-2.5 3.5"/><circle cx="12" cy="17" r="0.6" fill="currentColor"/>',
+
+    "slot-high": '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M8 15l4-6 4 6z"/>',
+    "slot-medium": '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M8 12h8"/>',
+    "slot-low": '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M8 9l4 6 4-6z"/>',
+    "slot-rig": '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M12 7l5 5-5 5-5-5z"/>',
+    "slot-service":
+        '<rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="12" cy="12" r="3"/><path d="M12 6v2M12 16v2M6 12h2M16 12h2"/>',
+
+    subsystem: '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9Z"/>',
+    "subsystem-core": '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9Z"/><circle cx="12" cy="12" r="2"/>',
+    "subsystem-defensive":
+        '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9Z"/><path d="M12 8l3.5 1.5v2.5c0 2.5-1.5 4-3.5 5-2-1-3.5-2.5-3.5-5V9.5Z"/>',
+    "subsystem-offensive":
+        '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9Z"/><circle cx="12" cy="12" r="2.5"/><path d="M12 7v2M12 15v2M7 12h2M15 12h2"/>',
+    "subsystem-propulsion":
+        '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9Z"/><path d="M8 12h7M12 8.5L15.5 12 12 15.5"/>',
+
+    "mode-defense":
+        '<path d="M12 3l7 3v5c0 5-3 8.5-7 10-4-1.5-7-5-7-10V6Z"/><path d="M9 11.5l2 2 4-4"/>',
+    "mode-speed": '<path d="M5 6l6 6-6 6M13 6l6 6-6 6"/>',
+    "mode-target": '<circle cx="12" cy="12" r="6"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/>',
+
+    capacitor: '<path fill="currentColor" stroke="none" d="M13 2 5 14h6l-2 8L19 9h-6Z"/>',
+    alpha: '<circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/>',
+    cpu: '<rect x="7" y="7" width="10" height="10" rx="1"/><rect x="10.5" y="10.5" width="3" height="3"/><path d="M9 7V4M12 7V4M15 7V4M9 20v-3M12 20v-3M15 20v-3M7 9H4M7 12H4M7 15H4M20 9h-3M20 12h-3M20 15h-3"/>',
+    power: '<circle cx="12" cy="12" r="9"/><path fill="currentColor" stroke="none" d="M12.8 6.5 9.2 13h2.6l-1.3 4.5L14.4 11h-2.6Z"/>',
+    rig: '<path d="M12 3l9 9-9 9-9-9Z"/><path d="M12 8l4 4-4 4-4-4Z"/>',
+    "drone-bandwidth":
+        '<circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="18" r="2"/><path d="M8 8l8 8M16 8l-8 8"/>',
+
+    "hp-shield":
+        '<path d="M12 3l7 3v5c0 5-3 8.5-7 10-4-1.5-7-5-7-10V6Z"/><path d="M8.5 11.5a3.5 3.5 0 0 1 7 0"/>',
+    "hp-armor": '<path d="M5 8l7-3 7 3M5 13l7-3 7 3M5 18l7-3 7 3"/>',
+    "hp-hull": '<path d="M12 3l6 18H6Z"/><path d="M12 8v6"/>',
+
+    turret: '<path d="M3 15h11"/><rect x="14" y="11" width="6" height="8" rx="1"/><path d="M9 21h11"/>',
+    launcher:
+        '<path d="M7 21V9M12 21V9M17 21V9"/><path d="M7 9L5.5 5 7 3l1.5 2Z"/><path d="M12 9l-1.5-4L12 3l1.5 2Z"/><path d="M17 9l-1.5-4L17 3l1.5 2Z"/>',
+
+    speed: '<path d="M5 6l6 6-6 6M13 6l6 6-6 6"/>',
+    warp: '<path d="M3 12h10M5 6.5l9 4M5 17.5l9-4"/><circle cx="17.5" cy="12" r="2.5"/>',
+    "target-range":
+        '<circle cx="12" cy="12" r="5"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/>',
+    "scan-resolution":
+        '<path d="M4.5 19a8.5 8.5 0 0 1 15 0M8 19a4.5 4.5 0 0 1 8 0"/><path d="M12 19l4.5-9"/><circle cx="12" cy="19" r="1" fill="currentColor" stroke="none"/>',
+    "lock-num":
+        '<path d="M8 4H4v16h4M16 4h4v16h-4"/><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"/>',
+
+    "sensor-radar":
+        '<path d="M6 15a7 7 0 0 1 12 0"/><path d="M12 15l5-9"/><circle cx="12" cy="15" r="1" fill="currentColor" stroke="none"/>',
+    "sensor-ladar": '<path d="M3 12c2-6 4-6 6 0s4 6 6 0 4-6 6 0"/>',
+    "sensor-magnetometric": '<path d="M7 3v8a5 5 0 0 0 10 0V3"/><path d="M7 8h4M13 8h4"/>',
+    "sensor-gravimetric":
+        '<circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="6.5"/><circle cx="12" cy="12" r="9.5"/>',
+
+    "align-time": '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3.5 2"/>',
+    signature: '<circle cx="12" cy="12" r="4"/><circle cx="12" cy="12" r="8"/>',
+    drone: '<circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="18" r="2"/><path d="M8 8l8 8M16 8l-8 8"/>',
+    "drone-range":
+        '<circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="6" cy="18" r="2"/><circle cx="18" cy="18" r="2"/><path d="M8 8l8 8M16 8l-8 8"/><path d="M3 12a9 9 0 0 1 9-9M21 12a9 9 0 0 1-9 9"/>',
+    mass: '<circle cx="12" cy="15" r="6"/><path d="M9.5 9.5a3 3 0 0 1 5 0"/>',
+    cargo: '<path d="M4 8l8-4 8 4v8l-8 4-8-4Z"/><path d="M4 8l8 4 8-4M12 12v8"/>',
+
+    "hold-fleet": '<path d="M3 10l6-3 6 3v6l-6 3-6-3Z"/><path d="M15 10l6-3v6"/>',
+    "hold-ship": '<path d="M12 3v3M4 16l8-10 8 10"/><path d="M4 16c2.5 3 13.5 3 16 0"/>',
+    "hold-fighter": '<path d="M3 11L21 3l-7 18-3-7Z"/><path d="M11 14L21 3"/>',
+    "hold-mining": '<path d="M5 20L14 10"/><path d="M8 5c4-2.5 9-1.5 11.5 2.5"/>',
+    "hold-gas": '<path d="M7 18a4 4 0 0 1-.5-7.97A5 5 0 0 1 16 8.5 3.75 3.75 0 0 1 18 18Z"/>',
+    "hold-mineral": '<path d="M7 4h10l4 5-9 11L3 9Z"/><path d="M3 9h18M9 4l3 5 3-5"/>',
+    "hold-ice": '<path d="M12 2v20M4.5 6l15 12M19.5 6l-15 12"/>',
+    "hold-command":
+        '<path d="M12 3l7 3v5c0 5-3 8.5-7 10-4-1.5-7-5-7-10V6Z"/><path fill="currentColor" stroke="none" d="M12 8l1.1 2.3 2.5.4-1.8 1.8.4 2.5-2.2-1.2-2.2 1.2.4-2.5-1.8-1.8 2.5-.4Z"/>',
+    "hold-planetary":
+        '<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c3.2 3.2 3.2 14.8 0 18-3.2-3.2-3.2-14.8 0-18"/>',
+    "hold-fuel": '<path d="M12 3C8.5 9 6.5 12 6.5 15a5.5 5.5 0 0 0 11 0C17.5 12 15.5 9 12 3Z"/>',
+    "hold-ammo": '<path d="M9 21h6v-8a3 3 0 0 0-6 0Z"/><path d="M9 17h6"/>',
+
+    "resist-em": '<path fill="currentColor" stroke="none" d="M13 2 5 14h6l-2 8L19 9h-6Z"/>',
+    "resist-thermal":
+        '<path d="M12 3C9 7 6.5 9.5 6.5 13a5.5 5.5 0 0 0 11 0C17.5 9.5 15 7 12 3Z"/><path d="M12 21a3 3 0 0 1-3-3c0-1.5 1.2-2.6 3-4.5 1.8 1.9 3 3 3 4.5a3 3 0 0 1-3 3Z"/>',
+    "resist-kinetic": '<path d="M12 4l8 8-8 8-8-8Z"/><circle cx="12" cy="12" r="2"/>',
+    "resist-explosive":
+        '<path d="M12 2l1.8 5.6L19 5l-3.4 4.8L21 12l-5.4 2.2L19 19l-5.2-2.6L12 22l-1.8-5.6L5 19l3.4-4.8L3 12l5.4-2.2L5 5l5.2 2.6Z"/>',
+} as const satisfies Record<string, string>;
+
+export type GlyphName = keyof typeof GLYPHS;

--- a/packages/efa_fit_snapshot_ts/src/lib/i18n.ts
+++ b/packages/efa_fit_snapshot_ts/src/lib/i18n.ts
@@ -1,0 +1,99 @@
+const en = {
+    fitPageTitle: "{fitName} - {shipName}",
+    highSlot: "High Slot",
+    midSlot: "Mid Slot",
+    lowSlot: "Low Slot",
+    rigSlot: "Rig Slot",
+    subsystemSlot: "Subsystem",
+    serviceSlot: "Service Slot",
+    tacticalMode: "Tactical Mode",
+    implantSlot: "Implant",
+    boosterSlot: "Booster",
+    drone: "Drone",
+    fighter: "Fighter",
+    slotEmpty: "{slotName} (Empty)",
+    skillProfileAll5: "All 5",
+    skillProfileAll0: "All 0",
+    skillProfileAlphaMax: "Alpha Max",
+    fighterAbilityTurret: "Turret",
+    fighterAbilityMissiles: "Missiles",
+    fighterAbilityAttackMissiles: "Attack Missiles",
+    fighterAbilityBomb: "Bomb",
+    capacitorStable: "{percent}% Stable",
+    capacitorUnstable: "Unstable",
+} as const;
+
+const zh: Record<keyof typeof en, string> = {
+    fitPageTitle: "{fitName} - {shipName}",
+    highSlot: "高能量槽",
+    midSlot: "中能量槽",
+    lowSlot: "低能量槽",
+    rigSlot: "改装件槽",
+    subsystemSlot: "子系统",
+    serviceSlot: "服务设施槽",
+    tacticalMode: "战术模式",
+    implantSlot: "植入体槽",
+    boosterSlot: "增效剂槽",
+    drone: "无人机",
+    fighter: "铁骑舰载机",
+    slotEmpty: "{slotName}（空）",
+    skillProfileAll5: "全 5",
+    skillProfileAll0: "全 0",
+    skillProfileAlphaMax: "Alpha 最高",
+    fighterAbilityTurret: "炮台",
+    fighterAbilityMissiles: "导弹",
+    fighterAbilityAttackMissiles: "攻击导弹",
+    fighterAbilityBomb: "炸弹",
+    capacitorStable: "{percent}% 稳定",
+    capacitorUnstable: "不稳定",
+};
+
+export type SnapshotMessageKey = keyof typeof en;
+
+export type SnapshotMessages = Record<SnapshotMessageKey, string>;
+
+/**
+ * Bundled translation tables keyed by BCP-47 locale. Consumers may register
+ * additional tables at runtime via {@link registerSnapshotLocale}.
+ */
+const tables: Record<string, SnapshotMessages> = { en, zh };
+
+export function registerSnapshotLocale(locale: string, messages: SnapshotMessages): void {
+    tables[locale] = messages;
+}
+
+export type SnapshotTranslateParams = Record<string, string | number>;
+
+/**
+ * Translates a component message for the given BCP-47 locale.
+ *
+ * Resolution order: exact language tag → language code → `"en"`. `{name}`
+ * placeholders are substituted from `params`.
+ */
+export function translateSnapshot(
+    locale: string,
+    key: SnapshotMessageKey,
+    params?: SnapshotTranslateParams,
+): string {
+    const language = locale.split("-")[0]?.toLowerCase() ?? "en";
+    const template = tables[locale]?.[key] ?? tables[language]?.[key] ?? en[key];
+    if (!params) return template;
+    return template.replace(/\{(\w+)\}/g, (match, name: string) =>
+        name in params ? String(params[name]) : match,
+    );
+}
+
+/**
+ * Resolves a display name from a snapshot `names` map (BCP-47 keyed).
+ *
+ * Order: exact language tag → language code → `"en"` → first entry.
+ */
+export function resolveSnapshotName(names: Record<string, string>, locale: string): string {
+    const keys = Object.keys(names);
+    if (keys.length === 0) return "";
+    if (names[locale] !== undefined) return names[locale];
+    const language = locale.split("-")[0]?.toLowerCase() ?? "en";
+    if (names[language] !== undefined) return names[language];
+    if (names.en !== undefined) return names.en;
+    return names[keys[0]];
+}

--- a/packages/efa_fit_snapshot_ts/src/lib/index.ts
+++ b/packages/efa_fit_snapshot_ts/src/lib/index.ts
@@ -1,0 +1,17 @@
+export { default as SnapshotCharacterColumn } from "./columns/CharacterColumn.svelte";
+export { default as SnapshotEquipmentColumn } from "./columns/EquipmentColumn.svelte";
+export { default as SnapshotStatisticsColumn } from "./columns/StatisticsColumn.svelte";
+export {
+    defaultTypeIconUrl,
+    type SnapshotDisplayContext,
+    type TypeIconResolver,
+} from "./context.svelte";
+export { default as FitSnapshotView } from "./FitSnapshotView.svelte";
+export { commaSeparated, formatDuration, toMaxDecimals } from "./format";
+export {
+    registerSnapshotLocale,
+    resolveSnapshotName,
+    type SnapshotMessageKey,
+    type SnapshotMessages,
+    translateSnapshot,
+} from "./i18n";

--- a/packages/efa_fit_snapshot_ts/src/lib/rows/DroneRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/rows/DroneRow.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+import type { SnapshotDrone } from "efa-proto-ts/fit_snapshot_pb";
+import StateIcon from "../components/StateIcon.svelte";
+import TypeIcon from "../components/TypeIcon.svelte";
+import { snapshotDisplay } from "../context.svelte";
+
+interface Props {
+    drone: SnapshotDrone;
+}
+
+let { drone }: Props = $props();
+
+const ctx = snapshotDisplay();
+</script>
+
+<div class="efa-row">
+    <StateIcon state={drone.state}>
+        {#if drone.type}
+            <TypeIcon typeId={drone.type.typeId} size={31} />
+        {/if}
+    </StateIcon>
+    <div class="efa-row-body">
+        <div class="efa-row-title">{drone.type ? ctx.name(drone.type.names) : ""}</div>
+    </div>
+    <div class="efa-row-trailing">x {drone.quantity}</div>
+</div>
+
+<style>
+    .efa-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 14px;
+        min-height: 48px;
+        box-sizing: border-box;
+    }
+    .efa-row-body {
+        flex: 1;
+        min-width: 0;
+    }
+    .efa-row-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .efa-row-trailing {
+        flex-shrink: 0;
+        color: var(--efa-text-dim, #9db8c6);
+        font-variant-numeric: tabular-nums;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/rows/EmptySlotRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/rows/EmptySlotRow.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+import Glyph from "../components/Glyph.svelte";
+import { snapshotDisplay } from "../context.svelte";
+import type { GlyphName } from "../glyphs";
+
+interface Props {
+    index: number;
+    slotName: string;
+    placeholder: GlyphName;
+}
+
+let { index, slotName, placeholder }: Props = $props();
+
+const ctx = snapshotDisplay();
+</script>
+
+<div class="efa-row efa-row-empty">
+    <span class="efa-empty-icon">
+        <Glyph name={placeholder} size={22} />
+    </span>
+    <div class="efa-row-body">
+        <div class="efa-row-title efa-empty-title">{ctx.t("slotEmpty", { slotName })}</div>
+    </div>
+    <div class="efa-row-trailing">{index + 1}</div>
+</div>
+
+<style>
+    .efa-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 14px;
+        min-height: 48px;
+        box-sizing: border-box;
+    }
+    .efa-empty-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 35px;
+        height: 35px;
+        flex-shrink: 0;
+        border: 2px solid var(--efa-state-passive, #2d2d2d);
+        border-radius: 2px;
+        color: var(--efa-text-muted, #64808f);
+        box-sizing: border-box;
+    }
+    .efa-row-body {
+        flex: 1;
+        min-width: 0;
+    }
+    .efa-empty-title {
+        color: var(--efa-text-muted, #64808f);
+    }
+    .efa-row-trailing {
+        flex-shrink: 0;
+        color: var(--efa-text-dim, #9db8c6);
+        font-variant-numeric: tabular-nums;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/rows/FighterRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/rows/FighterRow.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+import { type SnapshotFighter, SnapshotFighter_Ability } from "efa-proto-ts/fit_snapshot_pb";
+import RelatedValues from "../components/RelatedValues.svelte";
+import StateIcon from "../components/StateIcon.svelte";
+import TypeIcon from "../components/TypeIcon.svelte";
+import { snapshotDisplay } from "../context.svelte";
+import type { SnapshotMessageKey } from "../i18n";
+
+interface Props {
+    fighter: SnapshotFighter;
+}
+
+let { fighter }: Props = $props();
+
+const ctx = snapshotDisplay();
+
+const ABILITY_LABELS: Record<SnapshotFighter_Ability, SnapshotMessageKey> = {
+    [SnapshotFighter_Ability.TURRET]: "fighterAbilityTurret",
+    [SnapshotFighter_Ability.MISSILES]: "fighterAbilityMissiles",
+    [SnapshotFighter_Ability.ATTACK_MISSILES]: "fighterAbilityAttackMissiles",
+    [SnapshotFighter_Ability.BOMB]: "fighterAbilityBomb",
+};
+
+function abilityLabel(ability: SnapshotFighter_Ability): string {
+    const key = ABILITY_LABELS[ability];
+    return key ? ctx.t(key) : String(ability);
+}
+</script>
+
+<div class="efa-row">
+    <StateIcon state={fighter.state}>
+        {#if fighter.type}
+            <TypeIcon typeId={fighter.type.typeId} size={31} />
+        {/if}
+    </StateIcon>
+    <div class="efa-row-body">
+        <div class="efa-row-title">{fighter.type ? ctx.name(fighter.type.names) : ""}</div>
+        {#if fighter.abilities.length > 0}
+            <div class="efa-abilities">
+                {#each fighter.abilities as ability (ability)}
+                    <span class="efa-chip">{abilityLabel(ability)}</span>
+                {/each}
+            </div>
+        {/if}
+        {#if fighter.relatedValues.length > 0}
+            <RelatedValues values={fighter.relatedValues} />
+        {/if}
+    </div>
+    <div class="efa-row-trailing">x {fighter.quantity} / {fighter.maxSquadronSize}</div>
+</div>
+
+<style>
+    .efa-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 14px;
+        min-height: 48px;
+        box-sizing: border-box;
+    }
+    .efa-row-body {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+    .efa-row-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .efa-abilities {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 6px;
+    }
+    .efa-chip {
+        font-size: 11px;
+        padding: 1px 8px;
+        border: 1px solid var(--efa-border, #22404f);
+        border-radius: 999px;
+        color: var(--efa-text-dim, #9db8c6);
+        white-space: nowrap;
+    }
+    .efa-row-trailing {
+        flex-shrink: 0;
+        color: var(--efa-text-dim, #9db8c6);
+        font-variant-numeric: tabular-nums;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/rows/ModuleRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/rows/ModuleRow.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+import type { SnapshotModule } from "efa-proto-ts/fit_snapshot_pb";
+import type { Snippet } from "svelte";
+import RelatedValues from "../components/RelatedValues.svelte";
+import StateIcon from "../components/StateIcon.svelte";
+import TypeIcon from "../components/TypeIcon.svelte";
+import { snapshotDisplay } from "../context.svelte";
+
+interface Props {
+    module: SnapshotModule;
+    trailing?: Snippet;
+}
+
+let { module, trailing }: Props = $props();
+
+const ctx = snapshotDisplay();
+
+const type = $derived(module.type);
+const charge = $derived(module.charge);
+</script>
+
+<div class="efa-row">
+    <StateIcon state={module.state}>
+        {#if type}
+            <TypeIcon typeId={type.typeId} size={31} />
+        {/if}
+    </StateIcon>
+    <div class="efa-row-body">
+        <div class="efa-row-title">{type ? ctx.name(type.names) : ""}</div>
+        {#if charge?.type}
+            <div class="efa-row-subtitle efa-charge">
+                {#if charge.quantity > 0}
+                    <span>{charge.quantity} x</span>
+                {/if}
+                <TypeIcon typeId={charge.type.typeId} size={16} />
+                <span class="efa-charge-name">{ctx.name(charge.type.names)}</span>
+            </div>
+        {/if}
+        {#if module.relatedValues.length > 0}
+            <RelatedValues values={module.relatedValues} />
+        {/if}
+    </div>
+    {#if trailing}
+        <div class="efa-row-trailing">{@render trailing()}</div>
+    {/if}
+</div>
+
+<style>
+    .efa-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 14px;
+        min-height: 48px;
+        box-sizing: border-box;
+    }
+    .efa-row-body {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+    .efa-row-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .efa-row-subtitle {
+        font-size: 13px;
+        color: var(--efa-text-dim, #9db8c6);
+    }
+    .efa-charge {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+    .efa-charge-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .efa-row-trailing {
+        flex-shrink: 0;
+        color: var(--efa-text-dim, #9db8c6);
+        font-variant-numeric: tabular-nums;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/src/lib/rows/TacticalModeRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/rows/TacticalModeRow.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+import { Slots_SlotState, TacticalMode_TacticalModeVariant } from "efa-proto-ts/fit_pb";
+import type { SnapshotTacticalMode } from "efa-proto-ts/fit_snapshot_pb";
+import Glyph from "../components/Glyph.svelte";
+import StateIcon from "../components/StateIcon.svelte";
+import { snapshotDisplay } from "../context.svelte";
+import type { GlyphName } from "../glyphs";
+
+interface Props {
+    mode: SnapshotTacticalMode;
+}
+
+let { mode }: Props = $props();
+
+const ctx = snapshotDisplay();
+
+const glyph: GlyphName = $derived(
+    mode.variant === TacticalMode_TacticalModeVariant.DEFENSE
+        ? "mode-defense"
+        : mode.variant === TacticalMode_TacticalModeVariant.SPEED
+          ? "mode-speed"
+          : mode.variant === TacticalMode_TacticalModeVariant.TARGET
+            ? "mode-target"
+            : "unknown",
+);
+</script>
+
+<div class="efa-row">
+    <StateIcon state={Slots_SlotState.ACTIVE} shape="circle">
+        <Glyph name={glyph} size={20} />
+    </StateIcon>
+    <div class="efa-row-body">
+        <div class="efa-row-title">{mode.type ? ctx.name(mode.type.names) : ""}</div>
+    </div>
+</div>
+
+<style>
+    .efa-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 14px;
+        min-height: 48px;
+        box-sizing: border-box;
+    }
+    .efa-row-body {
+        flex: 1;
+        min-width: 0;
+    }
+</style>

--- a/packages/efa_fit_snapshot_ts/tsconfig.json
+++ b/packages/efa_fit_snapshot_ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "strict": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "isolatedModules": true,
+        "verbatimModuleSyntax": true,
+        "types": []
+    },
+    "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,25 @@ importers:
         specifier: ^2.5.7
         version: 2.5.7
 
+  packages/efa_fit_snapshot_ts:
+    dependencies:
+      '@bufbuild/protobuf':
+        specifier: ^2.14.0
+        version: 2.14.0
+      efa-proto-ts:
+        specifier: workspace:*
+        version: link:../efa_proto_ts
+    devDependencies:
+      svelte:
+        specifier: ^5.56.9
+        version: 5.56.9
+      svelte-check:
+        specifier: ^4.7.5
+        version: 4.7.5(picomatch@4.0.5)(svelte@5.56.9)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   packages/efa_proto_ts:
     dependencies:
       '@bufbuild/protobuf':
@@ -84,10 +103,10 @@ importers:
         version: 0.9.10(prettier@3.9.6)(typescript@6.0.3)
       '@astrojs/cloudflare':
         specifier: ^14.2.1
-        version: 14.2.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))(yaml@2.9.0)
+        version: 14.2.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))(yaml@2.9.0)
       '@astrojs/svelte':
         specifier: ^9.0.1
-        version: 9.0.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9)(typescript@6.0.3)(yaml@2.9.0)
+        version: 9.0.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9)(typescript@6.0.3)(yaml@2.9.0)
       '@cloudflare/workers-types':
         specifier: ^5.20260818.1
         version: 5.20260818.1
@@ -96,7 +115,7 @@ importers:
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       astro:
         specifier: ^7.2.2
-        version: 7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+        version: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
       svelte:
         specifier: ^5.56.9
         version: 5.56.9
@@ -3789,12 +3808,12 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@14.2.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))(yaml@2.9.0)':
+  '@astrojs/cloudflare@14.2.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@astrojs/underscore-redirects': 1.0.4
       '@cloudflare/vite-plugin': 1.52.1(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))
-      astro: 7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
       piccolore: 0.1.3
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
       wrangler: 4.123.0(@cloudflare/workers-types@5.20260818.1)
@@ -4006,10 +4025,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@astrojs/svelte@9.0.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9)(typescript@6.0.3)(yaml@2.9.0)':
+  '@astrojs/svelte@9.0.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
-      astro: 7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
       svelte: 5.56.9
       svelte2tsx: 0.7.61(svelte@5.56.9)(typescript@6.0.3)
       typescript: 6.0.3
@@ -5468,7 +5487,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0):
+  astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       '@astrojs/internal-helpers': 0.10.2
@@ -5821,7 +5840,7 @@ snapshots:
 
   esrap@2.3.2:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.4.15
 
   estree-util-attach-comments@3.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "site/*"
   - "worker/*"
   - "packages/efa_proto_ts"
+  - "packages/efa_fit_snapshot_ts"
 
 allowBuilds:
   '@biomejs/biome': true


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive fit snapshot viewer displaying ship details, character information, equipment, drones, fighters, and statistics.
  * Added localized English and Chinese labels with configurable locale support.
  * Added customizable type-icon resolution and responsive layouts for narrow, medium, and wide displays.
  * Added reusable visual indicators for capacities, resources, damage resistances, module states, and empty slots.

* **Chores**
  * Added snapshot package validation and workspace tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->