### PR TITLE
feat(platform): render fit snapshots with efa-fit-snapshot-ts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^2.14.0
         version: 2.14.0
+      efa-fit-snapshot-ts:
+        specifier: workspace:*
+        version: link:../../packages/efa_fit_snapshot_ts
       efa-proto-ts:
         specifier: workspace:*
         version: link:../../packages/efa_proto_ts
@@ -103,10 +106,10 @@ importers:
         version: 0.9.10(prettier@3.9.6)(typescript@6.0.3)
       '@astrojs/cloudflare':
         specifier: ^14.2.1
-        version: 14.2.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))(yaml@2.9.0)
+        version: 14.2.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))(yaml@2.9.0)
       '@astrojs/svelte':
         specifier: ^9.0.1
-        version: 9.0.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9)(typescript@6.0.3)(yaml@2.9.0)
+        version: 9.0.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9)(typescript@6.0.3)(yaml@2.9.0)
       '@cloudflare/workers-types':
         specifier: ^5.20260818.1
         version: 5.20260818.1
@@ -115,7 +118,7 @@ importers:
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       astro:
         specifier: ^7.2.2
-        version: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+        version: 7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
       svelte:
         specifier: ^5.56.9
         version: 5.56.9
@@ -3808,12 +3811,12 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@14.2.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))(yaml@2.9.0)':
+  '@astrojs/cloudflare@14.2.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@astrojs/underscore-redirects': 1.0.4
       '@cloudflare/vite-plugin': 1.52.1(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.123.0(@cloudflare/workers-types@5.20260818.1))
-      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+      astro: 7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
       piccolore: 0.1.3
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
       wrangler: 4.123.0(@cloudflare/workers-types@5.20260818.1)
@@ -4025,10 +4028,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@astrojs/svelte@9.0.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9)(typescript@6.0.3)(yaml@2.9.0)':
+  '@astrojs/svelte@9.0.1(@types/node@24.13.3)(astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
-      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+      astro: 7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
       svelte: 5.56.9
       svelte2tsx: 0.7.61(svelte@5.56.9)(typescript@6.0.3)
       typescript: 6.0.3
@@ -5487,7 +5490,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0):
+  astro@7.2.2(@astrojs/markdown-remark@7.2.2(supports-color@10.0.0))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       '@astrojs/internal-helpers': 0.10.2

--- a/site/platform/package.json
+++ b/site/platform/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@bufbuild/protobuf": "^2.14.0",
+        "efa-fit-snapshot-ts": "workspace:*",
         "efa-proto-ts": "workspace:*"
     },
     "devDependencies": {

--- a/site/platform/src/components/PostContent.svelte
+++ b/site/platform/src/components/PostContent.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import { fromJson, type JsonValue } from "@bufbuild/protobuf";
+import { FitSnapshotView } from "efa-fit-snapshot-ts";
+import { FitSnapshotSchema } from "efa-proto-ts/fit_snapshot_pb";
 import { localizedName } from "../lib/d1";
 import { locale, t } from "../lib/i18n.svelte";
 
@@ -7,7 +10,7 @@ interface SnapshotView {
     shipNames: Record<string, string>;
     requestId: string;
     fitHash: string;
-    snapshotJson: string;
+    snapshotJson: JsonValue;
 }
 
 interface Props {
@@ -15,9 +18,11 @@ interface Props {
 }
 
 const { snapshot }: Props = $props();
+
+const fitSnapshot = $derived(snapshot ? fromJson(FitSnapshotSchema, snapshot.snapshotJson) : null);
 </script>
 
-{#if snapshot}
+{#if snapshot && fitSnapshot}
     <header class="mb-6">
         <h1 class="text-2xl font-bold text-console-text">
             {snapshot.fitName || t("fits.untitled")}
@@ -32,13 +37,16 @@ const { snapshot }: Props = $props();
             fit: {snapshot.fitHash}
         </p>
     </header>
-    <section class="rounded border border-console-border bg-console-surface p-4">
-        <h2 class="mb-2 text-lg font-semibold text-console-text">
-            {t("fit.snapshotData")}
-        </h2>
-        <pre class="max-h-[36rem] overflow-auto rounded bg-console-deep p-3 text-xs text-console-text-dim">
-{snapshot.snapshotJson}</pre>
+    <section class="overflow-hidden rounded border border-console-border">
+        <FitSnapshotView snapshot={fitSnapshot} locale={locale.current} showHeader={false} />
     </section>
+    <details class="mt-4 rounded border border-console-border bg-console-surface p-4">
+        <summary class="cursor-pointer text-lg font-semibold text-console-text">
+            {t("fit.snapshotData")}
+        </summary>
+        <pre class="mt-2 max-h-[36rem] overflow-auto rounded bg-console-deep p-3 text-xs text-console-text-dim">
+{JSON.stringify(snapshot.snapshotJson, null, 2)}</pre>
+    </details>
 {:else}
     <p class="text-console-text-muted">{t("fit.notFound")}</p>
 {/if}

--- a/site/platform/src/pages/post/[id].astro
+++ b/site/platform/src/pages/post/[id].astro
@@ -26,7 +26,7 @@ const snapshot = stored
           shipNames: stored.snapshot.ship?.type?.names ?? {},
           requestId: stored.requestId,
           fitHash: stored.fitHash,
-          snapshotJson: JSON.stringify(toJson(FitSnapshotSchema, stored.snapshot), null, 2),
+          snapshotJson: toJson(FitSnapshotSchema, stored.snapshot),
       }
     : null;
 ---


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a structured fitness snapshot view for supported post data.
  - Snapshot details are now presented in a more readable, interactive format.
  - Added an expandable section for viewing the original snapshot JSON.

- **Bug Fixes**
  - Improved snapshot handling to ensure the visualized content appears only when the data is valid and can be parsed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->