### PR TITLE
feat(platform): add registered fit links addressed by fit hash

### DIFF
--- a/apps/eve-fit-assistant/lib/features/fit_link/boot_probe_web.dart
+++ b/apps/eve-fit-assistant/lib/features/fit_link/boot_probe_web.dart
@@ -5,15 +5,20 @@ Uri? _pending;
 
 void probeFitLinkBootUrl() {
   final uri = Uri.base;
-  if (uri.path != fitLinkCanonicalPath) return;
+  if (uri.path != fitLinkCanonicalPath && uri.path != fitLinkRegisteredCanonicalPath) return;
   final Map<String, String> queryParameters;
   try {
     queryParameters = uri.queryParameters;
   } on FormatException {
     return;
   }
-  final payload = queryParameters[fitLinkPayloadParam];
-  if (payload == null || !payload.startsWith(efaFitLinkPayloadPrefix)) return;
+  final recognized = switch (uri.path) {
+    fitLinkRegisteredCanonicalPath => fitLinkHashPattern.hasMatch(
+      queryParameters[fitLinkHashParam] ?? "",
+    ),
+    _ => queryParameters[fitLinkPayloadParam]?.startsWith(efaFitLinkPayloadPrefix) ?? false,
+  };
+  if (!recognized) return;
   _pending = uri;
   web.window.history.replaceState(null, "", "/");
 }

--- a/apps/eve-fit-assistant/lib/features/fit_link/importer.dart
+++ b/apps/eve-fit-assistant/lib/features/fit_link/importer.dart
@@ -1,8 +1,14 @@
 import "package:efa_fit/efa_fit.dart";
+import "package:efa_proto/fit_request.pb.dart";
 import "package:eve_fit_assistant/config/logger.dart";
+import "package:eve_fit_assistant/features/fit_link/state_import.dart";
+import "package:eve_fit_assistant/features/platform/platform_api.dart";
+import "package:eve_fit_assistant/storage/character/manager.dart";
+import "package:eve_fit_assistant/storage/character/schema.dart";
 import "package:eve_fit_assistant/storage/fit/manager.dart";
 import "package:eve_fit_assistant/storage/fit/persistence.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
+import "package:eve_fit_assistant/storage/repo/models/checkout_ref.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 class FitLinkImporter {
@@ -10,22 +16,98 @@ class FitLinkImporter {
 
   final Ref ref;
 
-  Future<FitMetadata> import(Uri uri) {
-    final parsed = parseFitLinkUri(uri);
-    return _importParsed(uri, parsed);
+  Future<FitMetadata> import(Uri uri) => _importParsed(uri, parseFitLinkUri(uri));
+
+  Future<FitMetadata> importBootUri(Uri uri) => _importParsed(uri, parseFitLinkBootUri(uri));
+
+  Future<FitMetadata> _importParsed(Uri uri, FitLinkParseResult? parsed) async => switch (parsed) {
+    FitLinkRaw(:final payload) => _importRaw(payload),
+    FitLinkRegistered(:final fitHash) => _importRegistered(uri, fitHash),
+    null => throw FitLinkNotFoundException(uri),
+  };
+
+  Future<FitMetadata> _importRaw(String payload) async {
+    final fit = parsePayload(payload);
+    return ref.read(fitManagerProvider.notifier).importFit(fit);
   }
 
-  Future<FitMetadata> importBootUri(Uri uri) {
-    final parsed = parseFitLinkBootUri(uri);
-    return _importParsed(uri, parsed);
-  }
-
-  Future<FitMetadata> _importParsed(Uri uri, FitLinkParseResult? parsed) async {
-    if (parsed == null) {
+  /// Imports a registered fit link: the URL carries only the fit hash, so the
+  /// canonical state is retrieved from the platform API and converted back
+  /// into a [FitStorage] (see `fitStateToStorage`).
+  Future<FitMetadata> _importRegistered(Uri uri, String fitHash) async {
+    final api = ref.read(platformApiClientProvider);
+    final state = await api.getFitState(fitHash);
+    if (state == null) {
       throw FitLinkNotFoundException(uri);
     }
-    final fit = parsePayload(parsed.payload);
-    return ref.read(fitManagerProvider.notifier).importFit(fit);
+    final header = (await _tryGetSnapshot(api, fitHash))?.header;
+    final characterId = await _resolveCharacterId(state);
+    final converted = fitStateToStorage(state, characterId: characterId);
+    final metadata = FitMetadata(
+      // Placeholders; FitManager.importFit assigns the id, stamps the active
+      // checkout, and refreshes the timestamps.
+      fitId: "",
+      shipTypeId: state.shipTypeId,
+      name: header?.fitName ?? "",
+      lastModified: DateTime.now().millisecondsSinceEpoch,
+      description: header?.description ?? "",
+      checkoutRef: const CheckoutRef(checkoutId: "", serverId: ""),
+    );
+    return ref
+        .read(fitManagerProvider.notifier)
+        .importFit(
+          FitStorage(
+            metadata: metadata,
+            body: converted.body,
+            dynamicRegistry: converted.dynamicRegistry,
+          ),
+        );
+  }
+
+  /// The snapshot carries the display metadata (name, description) the state
+  /// lacks; the import still proceeds when it cannot be retrieved.
+  Future<FitSnapshot?> _tryGetSnapshot(PlatformApiClient api, String fitHash) async {
+    try {
+      return await api.getFitSnapshot(fitHash);
+    } on Object catch (e) {
+      warning("Registered fit import: snapshot metadata unavailable for $fitHash: $e");
+      return null;
+    }
+  }
+
+  /// Registered fits carry an explicit skill map instead of a local character
+  /// reference. Built-in profiles map back to their predefined ids (by the
+  /// display-name convention of `FitUploadRequestBuilder`); a character id
+  /// that already exists locally is reused; anything else is recreated as a
+  /// new custom character from the uploaded skills.
+  Future<String> _resolveCharacterId(FitState state) async {
+    final character = state.hasCharacter() ? state.character : null;
+    final characterId = character != null && character.hasCharacterId()
+        ? character.characterId
+        : "";
+    if (CharacterRegistryManager.isBuiltInCharacterId(characterId)) return characterId;
+    if (characterId.isNotEmpty &&
+        ref.read(characterRegistryManagerProvider).characters.containsKey(characterId)) {
+      return characterId;
+    }
+    if (characterId.isEmpty) {
+      final builtin = switch (character?.names["en"]) {
+        "All 5" => predefinedMaxCharacterId,
+        "All 0" => predefinedZeroCharacterId,
+        "Alpha Max" => predefinedAlphaMaxCharacterId,
+        _ => null,
+      };
+      if (builtin != null) return builtin;
+    }
+    final name = character?.names["en"];
+    final created = await ref
+        .read(characterRegistryManagerProvider.notifier)
+        .importCharacter(
+          name: name == null || name.trim().isEmpty ? "Imported Character" : name.trim(),
+          skills: {for (final skill in state.skills) skill.typeId: skill.level},
+        );
+    info("Registered fit import: created character ${created.characterId} (${created.name})");
+    return created.characterId;
   }
 
   FitStorage parsePayload(String payload) {

--- a/apps/eve-fit-assistant/lib/features/fit_link/state_import.dart
+++ b/apps/eve-fit-assistant/lib/features/fit_link/state_import.dart
@@ -1,0 +1,132 @@
+import "dart:math";
+
+import "package:efa_proto/fit_request.pb.dart" hide FitDynamicItem;
+import "package:efa_proto/fit_snapshot.pb.dart";
+import "package:eve_fit_assistant/storage/fit/schema.dart";
+import "package:eve_fit_assistant/utils/native_convert.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:fpdart/fpdart.dart";
+
+/// The result of converting a canonical `FitState` (retrieved from the
+/// platform fit storage by fit hash) back into storage models.
+typedef FitStateConversion = ({FitStorageBody body, FitDynamicRegistry dynamicRegistry});
+
+/// Inverse of `buildFitUploadRequest` (`lib/features/fit_io/upload_request.dart`).
+///
+/// The mutator type of dynamic items is not part of the wire format, so
+/// imported abyssal items carry `modifierTypeId = 0` and cannot be re-rolled.
+FitStateConversion fitStateToStorage(FitState state, {required String characterId}) {
+  final dynamicRegistry = FitDynamicRegistry(
+    dynamicItems: IMap.fromEntries([
+      for (final item in state.dynamicItems)
+        MapEntry(
+          item.dynamicId,
+          FitDynamicItem(
+            dynamicItemId: item.dynamicId,
+            originTypeId: item.baseTypeId,
+            typeId: item.hasTypeId() ? item.typeId : item.baseTypeId,
+            modifierTypeId: 0,
+            dynamicAttributes: IMap.fromEntries([
+              for (final attribute in item.attributes)
+                MapEntry(attribute.attributeId, attribute.value),
+            ]),
+          ),
+        ),
+    ]),
+  );
+
+  FitStorageItemId moduleItemId(FitModule module) => switch (module.whichItem()) {
+    FitModule_Item.dynamicId => FitStorageItemId.dynamic(dynamicId: module.dynamicId),
+    _ => FitStorageItemId.item(id: module.typeId),
+  };
+
+  IList<Option<FitModuleItem>> buildRack(SlotType slotType, int layoutSize) {
+    final modules = state.modules.where((module) => module.slotType == slotType);
+    final size = modules.fold(layoutSize, (size, module) => max(size, module.index + 1));
+    final rack = List<Option<FitModuleItem>>.filled(size, const Option<FitModuleItem>.none());
+    for (final module in modules) {
+      rack[module.index] = Option.of(
+        FitModuleItem(
+          itemId: moduleItemId(module),
+          state: module.state.dartImpl,
+          charge: module.hasChargeTypeId()
+              ? Option.of(FitChargeItem(typeId: module.chargeTypeId))
+              : const Option<FitChargeItem>.none(),
+        ),
+      );
+    }
+    return IList(rack);
+  }
+
+  final implants = [...state.implants]..sort((a, b) => a.slotIndex.compareTo(b.slotIndex));
+
+  return (
+    body: FitStorageBody(
+      shipTypeId: state.shipTypeId,
+      characterId: characterId,
+      damageProfile: FitDamageProfile(
+        em: state.damageProfile.em,
+        explosive: state.damageProfile.explosive,
+        kinetic: state.damageProfile.kinetic,
+        thermal: state.damageProfile.thermal,
+      ),
+      slots: FitStorageSlots(
+        high: buildRack(SlotType.HIGH, state.layout.highSlots),
+        medium: buildRack(SlotType.MEDIUM, state.layout.mediumSlots),
+        low: buildRack(SlotType.LOW, state.layout.lowSlots),
+        rig: buildRack(SlotType.RIG, state.layout.rigSlots),
+        subsystem: buildRack(SlotType.SUBSYSTEM, state.layout.subsystemSlots),
+        service: buildRack(SlotType.SERVICE, state.layout.serviceSlots),
+        tacticalMode: state.hasTacticalModeTypeId()
+            ? Option.of(state.tacticalModeTypeId)
+            : const Option<int>.none(),
+      ),
+      drones: IList([
+        for (final drone in state.drones)
+          FitDroneItem(
+            itemId: FitStorageItemId.item(id: drone.typeId),
+            state: drone.state.dartImpl,
+            quantity: drone.quantity,
+          ),
+      ]),
+      fighters: IList([
+        for (final (index, fighter) in state.fighters.indexed)
+          FitFighterItem(
+            itemId: FitStorageItemId.item(id: fighter.typeId),
+            groupId: index,
+            quantity: fighter.quantity,
+            fighterAbility: fighter.abilities.fold(0, (bits, ability) => bits | ability.bitMask),
+          ),
+      ]),
+      implants: IList([
+        for (final implant in implants)
+          if (implant.hasTypeId())
+            FitImplantItem(
+              itemId: FitStorageItemId.item(id: implant.typeId),
+              state: implant.state.dartImpl,
+            ),
+      ]),
+      boosters: IList([
+        for (final booster in state.boosters)
+          FitBoosterItem(
+            itemId: FitStorageItemId.item(id: booster.typeId),
+            index: booster.slotIndex,
+            state: booster.state.dartImpl,
+          ),
+      ]),
+    ),
+    dynamicRegistry: dynamicRegistry,
+  );
+}
+
+extension on SnapshotFighter_Ability {
+  /// The engine input bitmask (1=TURRET, 2=MISSILES, 4=ATTACK_MISSILES,
+  /// 8=BOMB), mirroring the encoding in `buildFitUploadRequest`.
+  int get bitMask => switch (this) {
+    SnapshotFighter_Ability.TURRET => 0x01,
+    SnapshotFighter_Ability.MISSILES => 0x02,
+    SnapshotFighter_Ability.ATTACK_MISSILES => 0x04,
+    SnapshotFighter_Ability.BOMB => 0x08,
+    _ => 0,
+  };
+}

--- a/apps/eve-fit-assistant/lib/features/platform/platform_api.dart
+++ b/apps/eve-fit-assistant/lib/features/platform/platform_api.dart
@@ -2,6 +2,7 @@ import "dart:convert";
 import "dart:typed_data";
 
 import "package:dio/dio.dart";
+import "package:efa_proto/fit_request.pb.dart";
 import "package:efa_proto/fit_snapshot.pb.dart";
 import "package:eve_fit_assistant/features/remote_content/dio_factory.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -173,6 +174,18 @@ class PlatformApiClient {
   Future<FitSnapshot?> getFitSnapshot(String fitHash) async {
     try {
       return FitSnapshot.fromBuffer(await _getBytes("/platform/internal/fits/$fitHash/snapshot"));
+    } on PlatformApiException catch (e) {
+      if (e.isNotFound) return null;
+      rethrow;
+    }
+  }
+
+  /// The stored canonical fit state addressed directly by fit hash (§6.2);
+  /// null when the fit does not exist. Unlike the snapshot, the state is
+  /// full-fidelity and is what registered fit links import from.
+  Future<FitState?> getFitState(String fitHash) async {
+    try {
+      return FitState.fromBuffer(await _getBytes("/platform/internal/fits/$fitHash/state"));
     } on PlatformApiException catch (e) {
       if (e.isNotFound) return null;
       rethrow;

--- a/apps/eve-fit-assistant/lib/storage/character/manager.dart
+++ b/apps/eve-fit-assistant/lib/storage/character/manager.dart
@@ -243,6 +243,14 @@ class CharacterRegistryManager extends _$CharacterRegistryManager {
     );
   }
 
+  /// Creates a character from an explicit skill map, for fit imports whose
+  /// character does not exist locally (e.g. registered fit links).
+  Future<CharacterStorage> importCharacter({
+    required String name,
+    required Map<int, int> skills,
+    String description = "",
+  }) => _createCharacterFromSkills(name: name, description: description, skills: skills);
+
   Future<CharacterStorage> saveCharacter(CharacterStorage character, {bool touch = true}) async {
     if (isBuiltInCharacterId(character.characterId)) {
       throw StateError("Built-in characters cannot be modified: ${character.characterId}");

--- a/apps/eve-fit-assistant/test/features/fit_link/importer_test.dart
+++ b/apps/eve-fit-assistant/test/features/fit_link/importer_test.dart
@@ -3,16 +3,23 @@ library;
 
 import "dart:convert";
 import "dart:io";
+import "dart:typed_data";
 
 import "package:archive/archive.dart";
+import "package:dio/dio.dart";
 import "package:efa_fit/efa_fit.dart";
+import "package:efa_proto/fit.pb.dart";
+import "package:efa_proto/fit_request.pb.dart";
+import "package:efa_proto/fit_snapshot.pb.dart";
 import "package:eve_fit_assistant/config/logger.dart";
 import "package:eve_fit_assistant/features/fit_link/importer.dart";
+import "package:eve_fit_assistant/features/platform/platform_api.dart";
 import "package:eve_fit_assistant/storage/fit/manager.dart";
 import "package:eve_fit_assistant/storage/fit/persistence.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/storage/repo/models/checkout_ref.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:fixnum/fixnum.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:fpdart/fpdart.dart";
@@ -31,6 +38,83 @@ class _FakeFitManager extends FitManager {
 }
 
 final _refCaptureProvider = Provider<Ref>((Ref ref) => ref);
+
+const _fitHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this._onFetch);
+
+  final Future<ResponseBody> Function(RequestOptions options) _onFetch;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) => _onFetch(options);
+
+  @override
+  void close({bool force = false}) {}
+}
+
+FitState _makeFitState() => FitState(
+  shipTypeId: 12017,
+  layout: SnapshotShipLayout(
+    highSlots: 1,
+    mediumSlots: 0,
+    lowSlots: 0,
+    rigSlots: 0,
+    subsystemSlots: 0,
+    serviceSlots: 0,
+    turretHardpoints: 1,
+    launcherHardpoints: 0,
+    fighterTubes: 0,
+  ),
+  damageProfile: DamageProfile(em: 0.25, thermal: 0.25, kinetic: 0.25, explosive: 0.25),
+  modules: [
+    FitModule(typeId: 12001, slotType: SlotType.HIGH, index: 0, state: Slots_SlotState.ACTIVE),
+  ],
+  character: FitCharacter(names: [const MapEntry("en", "All 5")]),
+);
+
+FitSnapshot _makeSnapshot() => FitSnapshot(
+  version: 1,
+  header: SnapshotHeader(
+    fitName: "Registered Fit",
+    description: "From the platform",
+    lastModifiedMs: Int64(42),
+    createdAtMs: Int64(43),
+  ),
+);
+
+PlatformApiClient _fakeApiClient(FitState? state, FitSnapshot? snapshot) {
+  final dio = Dio(BaseOptions())
+    ..httpClientAdapter = _FakeAdapter((options) async {
+      if (options.path.endsWith("/state")) {
+        if (state == null) {
+          return ResponseBody.fromString(
+            jsonEncode({"error": "not_found", "message": "unknown fit hash"}),
+            404,
+            headers: {
+              Headers.contentTypeHeader: ["application/json"],
+            },
+          );
+        }
+        return ResponseBody.fromBytes(state.writeToBuffer(), 200);
+      }
+      if (snapshot == null) {
+        return ResponseBody.fromString(
+          jsonEncode({"error": "not_found", "message": "unknown fit hash"}),
+          404,
+          headers: {
+            Headers.contentTypeHeader: ["application/json"],
+          },
+        );
+      }
+      return ResponseBody.fromBytes(snapshot.writeToBuffer(), 200);
+    });
+  return PlatformApiClient(dio: dio);
+}
 
 FitStorage _makeFit() => const FitStorage(
   metadata: FitMetadata(
@@ -136,5 +220,70 @@ void main() {
       throwsA(isA<EfaFitFormatException>()),
     );
     expect(fitManager.imported, isEmpty);
+  });
+
+  group("registered links", () {
+    void overrideApi(PlatformApiClient client) {
+      container = ProviderContainer.test(
+        overrides: [
+          fitManagerProvider.overrideWith(() => fitManager),
+          platformApiClientProvider.overrideWithValue(client),
+        ],
+      );
+      importer = FitLinkImporter(container.read(_refCaptureProvider));
+    }
+
+    test("imports the state fetched by fit hash, named from the snapshot", () async {
+      overrideApi(_fakeApiClient(_makeFitState(), _makeSnapshot()));
+
+      final result = await importer.import(
+        Uri.parse("https://platform.efa-tech.dev/share/fit/registered?hash=$_fitHash"),
+      );
+
+      expect(result.fitId, "imported-id");
+      final imported = fitManager.imported.single;
+      expect(imported.metadata.name, "Registered Fit");
+      expect(imported.metadata.description, "From the platform");
+      expect(imported.body.shipTypeId, 12017);
+      expect(imported.body.characterId, "predefined_all_5");
+      expect(imported.body.slots.high, hasLength(1));
+      expect(
+        imported.body.slots.high[0].toNullable()?.itemId,
+        const FitStorageItemId.item(id: 12001),
+      );
+    });
+
+    test("imports via the efa scheme and boot URI forms", () async {
+      overrideApi(_fakeApiClient(_makeFitState(), null));
+
+      await importer.import(Uri.parse("efa://fit/registered?hash=$_fitHash"));
+      await importer.importBootUri(
+        Uri.parse("https://app.efa-tech.dev/fit/registered?hash=$_fitHash"),
+      );
+
+      expect(fitManager.imported, hasLength(2));
+      // Without the snapshot, the name placeholder is left to the manager.
+      expect(fitManager.imported.first.metadata.name, isEmpty);
+    });
+
+    test("an unknown fit hash throws FitLinkNotFoundException", () async {
+      overrideApi(_fakeApiClient(null, null));
+
+      await expectLater(
+        importer.import(Uri.parse("efa://fit/registered?hash=$_fitHash")),
+        throwsA(isA<FitLinkNotFoundException>()),
+      );
+      expect(fitManager.imported, isEmpty);
+    });
+
+    test("a malformed hash is rejected by the parser before any request", () async {
+      overrideApi(_fakeApiClient(_makeFitState(), _makeSnapshot()));
+
+      await expectLater(
+        importer.import(Uri.parse("efa://fit/registered?hash=abc")),
+        throwsA(isA<FitLinkNotFoundException>()),
+      );
+      expect(fitManager.imported, isEmpty);
+    });
   });
 }

--- a/apps/eve-fit-assistant/test/features/fit_link/state_import_test.dart
+++ b/apps/eve-fit-assistant/test/features/fit_link/state_import_test.dart
@@ -1,0 +1,242 @@
+@TestOn("vm")
+library;
+
+import "package:efa_proto/fit.pb.dart";
+import "package:efa_proto/fit_request.pb.dart" hide FitDynamicItem;
+import "package:efa_proto/fit_request.pb.dart"
+    as fit_request
+    show FitDynamicAttribute, FitDynamicItem;
+import "package:efa_proto/fit_snapshot.pb.dart";
+import "package:eve_fit_assistant/features/fit_link/state_import.dart";
+import "package:eve_fit_assistant/storage/fit/schema.dart";
+import "package:flutter_test/flutter_test.dart";
+
+SnapshotShipLayout _layout({
+  int high = 2,
+  int medium = 0,
+  int low = 0,
+  int rig = 0,
+  int subsystem = 0,
+  int service = 0,
+}) => SnapshotShipLayout(
+  highSlots: high,
+  mediumSlots: medium,
+  lowSlots: low,
+  rigSlots: rig,
+  subsystemSlots: subsystem,
+  serviceSlots: service,
+  turretHardpoints: 0,
+  launcherHardpoints: 0,
+  fighterTubes: 0,
+);
+
+DamageProfile _profile() => DamageProfile(em: 0.1, thermal: 0.2, kinetic: 0.3, explosive: 0.4);
+
+void main() {
+  group("fitStateToStorage", () {
+    test("maps the header fields and damage profile", () {
+      final converted = fitStateToStorage(
+        FitState(shipTypeId: 12017, layout: _layout(), damageProfile: _profile()),
+        characterId: "predefined_all_5",
+      );
+
+      expect(converted.body.shipTypeId, 12017);
+      expect(converted.body.characterId, "predefined_all_5");
+      expect(converted.body.damageProfile.em, 0.1);
+      expect(converted.body.damageProfile.thermal, 0.2);
+      expect(converted.body.damageProfile.kinetic, 0.3);
+      expect(converted.body.damageProfile.explosive, 0.4);
+      expect(converted.dynamicRegistry.dynamicItems, isEmpty);
+    });
+
+    test("places modules by rack and index, honoring the layout size", () {
+      final converted = fitStateToStorage(
+        FitState(
+          shipTypeId: 12017,
+          layout: _layout(high: 3, rig: 2),
+          damageProfile: _profile(),
+          modules: [
+            FitModule(
+              typeId: 12001,
+              slotType: SlotType.HIGH,
+              index: 1,
+              state: Slots_SlotState.ACTIVE,
+              chargeTypeId: 200,
+            ),
+            FitModule(
+              typeId: 12002,
+              slotType: SlotType.RIG,
+              index: 0,
+              state: Slots_SlotState.ONLINE,
+            ),
+          ],
+        ),
+        characterId: "predefined_all_5",
+      );
+
+      final high = converted.body.slots.high;
+      expect(high, hasLength(3));
+      expect(high[0].isNone(), isTrue);
+      final module = high[1].toNullable();
+      expect(module?.itemId, const FitStorageItemId.item(id: 12001));
+      expect(module?.state, FitItemState.active);
+      expect(module?.charge.toNullable()?.typeId, 200);
+      expect(high[2].isNone(), isTrue);
+
+      final rig = converted.body.slots.rig;
+      expect(rig, hasLength(2));
+      expect(rig[0].toNullable()?.itemId, const FitStorageItemId.item(id: 12002));
+      expect(rig[0].toNullable()?.state, FitItemState.online);
+      expect(converted.body.slots.tacticalMode.isNone(), isTrue);
+    });
+
+    test("extends racks beyond the layout when an index overflows", () {
+      final converted = fitStateToStorage(
+        FitState(
+          shipTypeId: 12017,
+          layout: _layout(high: 1),
+          damageProfile: _profile(),
+          modules: [
+            FitModule(
+              typeId: 12001,
+              slotType: SlotType.HIGH,
+              index: 2,
+              state: Slots_SlotState.PASSIVE,
+            ),
+          ],
+        ),
+        characterId: "predefined_all_5",
+      );
+
+      expect(converted.body.slots.high, hasLength(3));
+      expect(converted.body.slots.high[2].toNullable()?.state, FitItemState.passive);
+    });
+
+    test("restores dynamic items and dynamic module references", () {
+      final converted = fitStateToStorage(
+        FitState(
+          shipTypeId: 12017,
+          layout: _layout(high: 1),
+          damageProfile: _profile(),
+          modules: [
+            FitModule(
+              dynamicId: 7,
+              slotType: SlotType.HIGH,
+              index: 0,
+              state: Slots_SlotState.OVERLOAD,
+            ),
+          ],
+          dynamicItems: [
+            fit_request.FitDynamicItem(
+              dynamicId: 7,
+              baseTypeId: 12001,
+              typeId: 81001,
+              attributes: [
+                fit_request.FitDynamicAttribute(attributeId: 6, value: 1.5),
+                fit_request.FitDynamicAttribute(attributeId: -30, value: 0.8),
+              ],
+            ),
+          ],
+        ),
+        characterId: "predefined_all_5",
+      );
+
+      final item = converted.dynamicRegistry.dynamicItems[7];
+      expect(item, isNotNull);
+      expect(item!.originTypeId, 12001);
+      expect(item.typeId, 81001);
+      expect(item.dynamicAttributes[6], 1.5);
+      expect(item.dynamicAttributes[-30], 0.8);
+
+      final module = converted.body.slots.high[0].toNullable();
+      expect(module?.itemId, const FitStorageItemId.dynamic(dynamicId: 7));
+      expect(module?.state, FitItemState.overload);
+    });
+
+    test("falls back to the base type when a dynamic item has no mutated type", () {
+      final converted = fitStateToStorage(
+        FitState(
+          shipTypeId: 12017,
+          layout: _layout(),
+          damageProfile: _profile(),
+          dynamicItems: [fit_request.FitDynamicItem(dynamicId: 3, baseTypeId: 12001)],
+        ),
+        characterId: "predefined_all_5",
+      );
+
+      expect(converted.dynamicRegistry.dynamicItems[3]?.typeId, 12001);
+    });
+
+    test("maps the tactical mode", () {
+      final converted = fitStateToStorage(
+        FitState(
+          shipTypeId: 12017,
+          layout: _layout(),
+          damageProfile: _profile(),
+          tacticalModeTypeId: 62770,
+        ),
+        characterId: "predefined_all_5",
+      );
+
+      expect(converted.body.slots.tacticalMode.toNullable(), 62770);
+    });
+
+    test("maps drones, fighters, implants, and boosters", () {
+      final converted = fitStateToStorage(
+        FitState(
+          shipTypeId: 12017,
+          layout: _layout(),
+          damageProfile: _profile(),
+          drones: [FitDrone(typeId: 2456, state: Slots_SlotState.ACTIVE, quantity: 5)],
+          fighters: [
+            FitFighter(
+              typeId: 40552,
+              quantity: 2,
+              maxSquadronSize: 3,
+              group: SnapshotFighter_SquadronGroup.LIGHT,
+              abilities: [SnapshotFighter_Ability.TURRET, SnapshotFighter_Ability.ATTACK_MISSILES],
+            ),
+            FitFighter(
+              typeId: 23061,
+              quantity: 1,
+              maxSquadronSize: 1,
+              group: SnapshotFighter_SquadronGroup.HEAVY,
+              abilities: [SnapshotFighter_Ability.BOMB],
+            ),
+          ],
+          implants: [
+            FitImplant(slotIndex: 8, typeId: 13259, state: Slots_SlotState.ONLINE),
+            FitImplant(slotIndex: 1, typeId: 13219, state: Slots_SlotState.ONLINE),
+            FitImplant(slotIndex: 3, state: Slots_SlotState.PASSIVE),
+          ],
+          boosters: [FitBooster(slotIndex: 2, typeId: 28614, state: Slots_SlotState.ACTIVE)],
+        ),
+        characterId: "predefined_all_5",
+      );
+
+      final drone = converted.body.drones.single;
+      expect(drone.itemId, const FitStorageItemId.item(id: 2456));
+      expect(drone.state, FitItemState.active);
+      expect(drone.quantity, 5);
+
+      final fighters = converted.body.fighters;
+      expect(fighters, hasLength(2));
+      expect(fighters[0].groupId, 0);
+      expect(fighters[0].fighterAbility, 0x01 | 0x04);
+      expect(fighters[0].quantity, 2);
+      expect(fighters[1].groupId, 1);
+      expect(fighters[1].fighterAbility, 0x08);
+
+      // Implants are ordered by slot index; empty slots are dropped.
+      final implants = converted.body.implants;
+      expect(implants, hasLength(2));
+      expect(implants[0].itemId, const FitStorageItemId.item(id: 13219));
+      expect(implants[1].itemId, const FitStorageItemId.item(id: 13259));
+
+      final booster = converted.body.boosters.single;
+      expect(booster.itemId, const FitStorageItemId.item(id: 28614));
+      expect(booster.index, 2);
+      expect(booster.state, FitItemState.active);
+    });
+  });
+}

--- a/apps/eve-fit-assistant/test/features/platform/platform_api_test.dart
+++ b/apps/eve-fit-assistant/test/features/platform/platform_api_test.dart
@@ -5,6 +5,7 @@ import "dart:convert";
 import "dart:typed_data";
 
 import "package:dio/dio.dart";
+import "package:efa_proto/fit_request.pb.dart";
 import "package:efa_proto/fit_snapshot.pb.dart";
 import "package:eve_fit_assistant/features/platform/platform_api.dart";
 import "package:fixnum/fixnum.dart";
@@ -139,6 +140,42 @@ void main() {
         (options) async => _json({"error": "not_found", "message": "unknown fit hash"}, 404),
       );
       expect(await client.getFitSnapshot("missing"), isNull);
+    });
+  });
+
+  group("getFitState", () {
+    final stateBytes = FitState(
+      shipTypeId: 12017,
+      layout: SnapshotShipLayout(
+        highSlots: 1,
+        mediumSlots: 0,
+        lowSlots: 0,
+        rigSlots: 0,
+        subsystemSlots: 0,
+        serviceSlots: 0,
+        turretHardpoints: 0,
+        launcherHardpoints: 0,
+        fighterTubes: 0,
+      ),
+      damageProfile: DamageProfile(em: 0.25, thermal: 0.25, kinetic: 0.25, explosive: 0.25),
+    ).writeToBuffer();
+
+    test("addresses the by-hash state route and decodes the protobuf bytes", () async {
+      RequestOptions? captured;
+      final client = _clientWith((options) async {
+        captured = options;
+        return ResponseBody.fromBytes(stateBytes, 200);
+      });
+      final state = await client.getFitState("abc123");
+      expect(captured?.path, "https://api.efa-tech.dev/platform/internal/fits/abc123/state");
+      expect(state?.shipTypeId, 12017);
+    });
+
+    test("returns null on 404", () async {
+      final client = _clientWith(
+        (options) async => _json({"error": "not_found", "message": "unknown fit hash"}, 404),
+      );
+      expect(await client.getFitState("missing"), isNull);
     });
   });
 

--- a/packages/efa_fit/lib/src/efa_format.dart
+++ b/packages/efa_fit/lib/src/efa_format.dart
@@ -22,6 +22,7 @@ enum EfaFitFormatErrorCode {
   invalidCompression,
   decodedPayloadTooLarge,
   invalidJson,
+  invalidHash,
 }
 
 class EfaFitFormatException implements Exception {

--- a/packages/efa_fit/lib/src/link.dart
+++ b/packages/efa_fit/lib/src/link.dart
@@ -65,7 +65,7 @@ String buildFitLinkShareUrl(String payload) {
 
 String buildFitLinkRegisteredShareUrl(String fitHash) {
   if (!fitLinkHashPattern.hasMatch(fitHash)) {
-    throw const EfaFitFormatException(EfaFitFormatErrorCode.invalidBase64);
+    throw const EfaFitFormatException(EfaFitFormatErrorCode.invalidHash);
   }
   return "https://$fitLinkPlatformHost$fitLinkRegisteredPlatformPath?$fitLinkHashParam=$fitHash";
 }

--- a/packages/efa_fit/lib/src/link.dart
+++ b/packages/efa_fit/lib/src/link.dart
@@ -8,7 +8,14 @@ const String fitLinkNightlyHost = "app-preview.efa-tech.dev";
 const String fitLinkCanonicalPath = "/fit/raw";
 const String fitLinkPlatformPath = "/share/fit/raw";
 const String fitLinkPayloadParam = "payload";
+const String fitLinkRegisteredCanonicalPath = "/fit/registered";
+const String fitLinkRegisteredPlatformPath = "/share/fit/registered";
+const String fitLinkHashParam = "hash";
 const int maxFitLinkUrlLength = 8000;
+
+/// A registered fit hash is the lowercase hex sha256 of the canonical fit
+/// state (`worker/efa-platform-fit-storage/src/hash.rs`).
+final RegExp fitLinkHashPattern = RegExp(r"^[0-9a-f]{64}$");
 
 const List<String> fitLinkLegacyHttpsHosts = [
   fitLinkLegacyShareHost,
@@ -26,11 +33,25 @@ class FitLinkNotFoundException implements Exception {
   String toString() => "FitLinkNotFoundException($uri)";
 }
 
-class FitLinkParseResult {
-  const FitLinkParseResult({required this.payload, required this.queryParameters});
+sealed class FitLinkParseResult {
+  const FitLinkParseResult({required this.queryParameters});
+
+  final Map<String, String> queryParameters;
+}
+
+/// A raw fit link: the fit travels inside the URL itself (`?payload=EFA2:...`).
+class FitLinkRaw extends FitLinkParseResult {
+  const FitLinkRaw({required this.payload, required super.queryParameters});
 
   final String payload;
-  final Map<String, String> queryParameters;
+}
+
+/// A registered fit link: the URL carries only the content-addressed fit hash
+/// (`?hash=...`); the fit is retrieved from the platform API by the consumer.
+class FitLinkRegistered extends FitLinkParseResult {
+  const FitLinkRegistered({required this.fitHash, required super.queryParameters});
+
+  final String fitHash;
 }
 
 String buildFitLinkShareUrl(String payload) {
@@ -42,20 +63,41 @@ String buildFitLinkShareUrl(String payload) {
   return url;
 }
 
+String buildFitLinkRegisteredShareUrl(String fitHash) {
+  if (!fitLinkHashPattern.hasMatch(fitHash)) {
+    throw const EfaFitFormatException(EfaFitFormatErrorCode.invalidBase64);
+  }
+  return "https://$fitLinkPlatformHost$fitLinkRegisteredPlatformPath?$fitLinkHashParam=$fitHash";
+}
+
+/// The canonical fit path of [uri] (`/fit/raw` or `/fit/registered`),
+/// null when [uri] is not a recognized fit link.
 String? canonicalPathOf(Uri uri) {
   final scheme = uri.scheme.toLowerCase();
   if (scheme == efaScheme) {
     final combined = uri.hasAuthority ? "${uri.host}${uri.path}" : uri.path;
     final normalized = combined.startsWith("/") ? combined : "/$combined";
-    return normalized.toLowerCase() == fitLinkCanonicalPath ? fitLinkCanonicalPath : null;
+    return switch (normalized.toLowerCase()) {
+      fitLinkCanonicalPath => fitLinkCanonicalPath,
+      fitLinkRegisteredCanonicalPath => fitLinkRegisteredCanonicalPath,
+      _ => null,
+    };
   }
   if (scheme == "https") {
     final host = uri.host.toLowerCase();
     if (host == fitLinkPlatformHost) {
-      return uri.path == fitLinkPlatformPath ? fitLinkPlatformPath : null;
+      return switch (uri.path) {
+        fitLinkPlatformPath => fitLinkCanonicalPath,
+        fitLinkRegisteredPlatformPath => fitLinkRegisteredCanonicalPath,
+        _ => null,
+      };
     }
     if (fitLinkLegacyHttpsHosts.contains(host)) {
-      return uri.path == fitLinkCanonicalPath ? fitLinkCanonicalPath : null;
+      return switch (uri.path) {
+        fitLinkCanonicalPath => fitLinkCanonicalPath,
+        fitLinkRegisteredCanonicalPath => fitLinkRegisteredCanonicalPath,
+        _ => null,
+      };
     }
     return null;
   }
@@ -63,23 +105,34 @@ String? canonicalPathOf(Uri uri) {
 }
 
 FitLinkParseResult? parseFitLinkUri(Uri uri) {
-  if (canonicalPathOf(uri) == null) return null;
-  return _readQuery(uri);
+  final canonicalPath = canonicalPathOf(uri);
+  if (canonicalPath == null) return null;
+  return _readQuery(uri, canonicalPath);
 }
 
 FitLinkParseResult? parseFitLinkBootUri(Uri uri) {
-  if (uri.path != fitLinkCanonicalPath) return null;
-  return _readQuery(uri);
+  final canonicalPath = switch (uri.path) {
+    fitLinkCanonicalPath => fitLinkCanonicalPath,
+    fitLinkRegisteredCanonicalPath => fitLinkRegisteredCanonicalPath,
+    _ => null,
+  };
+  if (canonicalPath == null) return null;
+  return _readQuery(uri, canonicalPath);
 }
 
-FitLinkParseResult? _readQuery(Uri uri) {
+FitLinkParseResult? _readQuery(Uri uri, String canonicalPath) {
   final Map<String, String> queryParameters;
   try {
     queryParameters = uri.queryParameters;
   } on FormatException {
     return null;
   }
+  if (canonicalPath == fitLinkRegisteredCanonicalPath) {
+    final fitHash = queryParameters[fitLinkHashParam];
+    if (fitHash == null || !fitLinkHashPattern.hasMatch(fitHash)) return null;
+    return FitLinkRegistered(fitHash: fitHash, queryParameters: queryParameters);
+  }
   final payload = queryParameters[fitLinkPayloadParam];
   if (payload == null) return null;
-  return FitLinkParseResult(payload: payload, queryParameters: queryParameters);
+  return FitLinkRaw(payload: payload, queryParameters: queryParameters);
 }

--- a/packages/efa_fit/test/link_test.dart
+++ b/packages/efa_fit/test/link_test.dart
@@ -256,7 +256,16 @@ void main() {
     });
 
     test("buildFitLinkRegisteredShareUrl rejects malformed hashes", () {
-      expect(() => buildFitLinkRegisteredShareUrl("abc"), throwsA(isA<EfaFitFormatException>()));
+      expect(
+        () => buildFitLinkRegisteredShareUrl("abc"),
+        throwsA(
+          isA<EfaFitFormatException>().having(
+            (e) => e.code,
+            "code",
+            EfaFitFormatErrorCode.invalidHash,
+          ),
+        ),
+      );
     });
   });
 }

--- a/packages/efa_fit/test/link_test.dart
+++ b/packages/efa_fit/test/link_test.dart
@@ -8,19 +8,19 @@ void main() {
     test("accepts the efa scheme form", () {
       final result = parseFitLinkUri(Uri.parse("efa://fit/raw?payload=$payload"));
       expect(result, isNotNull);
-      expect(result!.payload, payload);
+      expect((result! as FitLinkRaw).payload, payload);
     });
 
     test("accepts the efa scheme without authority", () {
       final result = parseFitLinkUri(Uri.parse("efa:fit/raw?payload=$payload"));
       expect(result, isNotNull);
-      expect(result!.payload, payload);
+      expect((result! as FitLinkRaw).payload, payload);
     });
 
     test("efa scheme and path are case-insensitive", () {
       final result = parseFitLinkUri(Uri.parse("EFA://FIT/RAW?payload=$payload"));
       expect(result, isNotNull);
-      expect(result!.payload, payload);
+      expect((result! as FitLinkRaw).payload, payload);
     });
 
     test("accepts the platform host with the platform path", () {
@@ -28,14 +28,14 @@ void main() {
         Uri.parse("https://$fitLinkPlatformHost$fitLinkPlatformPath?payload=$payload"),
       );
       expect(result, isNotNull);
-      expect(result!.payload, payload);
+      expect((result! as FitLinkRaw).payload, payload);
     });
 
     test("accepts all legacy https hosts with the canonical path", () {
       for (final host in fitLinkLegacyHttpsHosts) {
         final result = parseFitLinkUri(Uri.parse("https://$host/fit/raw?payload=$payload"));
         expect(result, isNotNull, reason: host);
-        expect(result!.payload, payload);
+        expect((result! as FitLinkRaw).payload, payload);
       }
     });
 
@@ -88,7 +88,7 @@ void main() {
         Uri.parse("https://$fitLinkLegacyShareHost/fit/raw?payload=$payload&utm_source=x&foo=bar"),
       );
       expect(result, isNotNull);
-      expect(result!.payload, payload);
+      expect((result! as FitLinkRaw).payload, payload);
       expect(result.queryParameters["utm_source"], "x");
       expect(result.queryParameters["foo"], "bar");
     });
@@ -103,7 +103,7 @@ void main() {
     test("accepts the canonical path regardless of host", () {
       final result = parseFitLinkBootUri(Uri.parse("https://example.com/fit/raw?payload=$payload"));
       expect(result, isNotNull);
-      expect(result!.payload, payload);
+      expect((result! as FitLinkRaw).payload, payload);
     });
 
     test("rejects other paths", () {
@@ -165,7 +165,7 @@ void main() {
       final url = buildFitLinkShareUrl(payload);
       final result = parseFitLinkUri(Uri.parse(url));
       expect(result, isNotNull);
-      expect(result!.payload, payload);
+      expect((result! as FitLinkRaw).payload, payload);
     });
 
     test("rejects URLs longer than maxFitLinkUrlLength", () {
@@ -180,6 +180,83 @@ void main() {
           ),
         ),
       );
+    });
+  });
+
+  group("registered fit links", () {
+    const fitHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    test("accepts the efa scheme form", () {
+      final result = parseFitLinkUri(Uri.parse("efa://fit/registered?hash=$fitHash"));
+      expect(result, isA<FitLinkRegistered>());
+      expect((result! as FitLinkRegistered).fitHash, fitHash);
+    });
+
+    test("accepts the platform host with the registered platform path", () {
+      final result = parseFitLinkUri(
+        Uri.parse("https://$fitLinkPlatformHost$fitLinkRegisteredPlatformPath?hash=$fitHash"),
+      );
+      expect(result, isA<FitLinkRegistered>());
+      expect((result! as FitLinkRegistered).fitHash, fitHash);
+    });
+
+    test("accepts the app hosts with the registered canonical path", () {
+      for (final host in [fitLinkProdHost, fitLinkNightlyHost]) {
+        final result = parseFitLinkUri(
+          Uri.parse("https://$host$fitLinkRegisteredCanonicalPath?hash=$fitHash"),
+        );
+        expect(result, isA<FitLinkRegistered>(), reason: host);
+        expect((result! as FitLinkRegistered).fitHash, fitHash);
+      }
+    });
+
+    test("rejects registered paths on the wrong host", () {
+      expect(
+        parseFitLinkUri(Uri.parse("https://$fitLinkPlatformHost/fit/registered?hash=$fitHash")),
+        isNull,
+      );
+      expect(
+        parseFitLinkUri(
+          Uri.parse("https://$fitLinkLegacyShareHost/share/fit/registered?hash=$fitHash"),
+        ),
+        isNull,
+      );
+    });
+
+    test("rejects missing or malformed hashes", () {
+      expect(parseFitLinkUri(Uri.parse("efa://fit/registered")), isNull);
+      expect(parseFitLinkUri(Uri.parse("efa://fit/registered?hash=abc")), isNull);
+      expect(
+        parseFitLinkUri(Uri.parse("efa://fit/registered?hash=${fitHash.toUpperCase()}")),
+        isNull,
+      );
+      expect(parseFitLinkUri(Uri.parse("efa://fit/registered?hash=${fitHash}00")), isNull);
+    });
+
+    test("extra query parameters are preserved", () {
+      final result = parseFitLinkUri(Uri.parse("efa://fit/registered?hash=$fitHash&utm_source=x"));
+      expect(result, isA<FitLinkRegistered>());
+      expect(result!.queryParameters["utm_source"], "x");
+    });
+
+    test("boot probe accepts the registered canonical path on any host", () {
+      final result = parseFitLinkBootUri(
+        Uri.parse("https://example.com/fit/registered?hash=$fitHash"),
+      );
+      expect(result, isA<FitLinkRegistered>());
+      expect((result! as FitLinkRegistered).fitHash, fitHash);
+    });
+
+    test("built registered share URL round-trips through the parser", () {
+      final url = buildFitLinkRegisteredShareUrl(fitHash);
+      expect(url, "https://platform.efa-tech.dev/share/fit/registered?hash=$fitHash");
+      final result = parseFitLinkUri(Uri.parse(url));
+      expect(result, isA<FitLinkRegistered>());
+      expect((result! as FitLinkRegistered).fitHash, fitHash);
+    });
+
+    test("buildFitLinkRegisteredShareUrl rejects malformed hashes", () {
+      expect(() => buildFitLinkRegisteredShareUrl("abc"), throwsA(isA<EfaFitFormatException>()));
     });
   });
 }

--- a/site/platform/src/components/FitShareLanding.svelte
+++ b/site/platform/src/components/FitShareLanding.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onMount } from "svelte";
+import { isValidFitHash } from "../lib/fit-hash";
 import { isValidPayload } from "../lib/fit-payload";
 import { t } from "../lib/i18n.svelte";
 import {
@@ -7,6 +8,7 @@ import {
     DOWNLOAD_URL,
     readRememberedTarget,
     rememberTarget,
+    type ShareKind,
     type ShareTarget,
     targetUrl,
 } from "../lib/share-target";
@@ -14,6 +16,8 @@ import FitLinkNotFound from "./FitLinkNotFound.svelte";
 
 const REDIRECT_DELAY_MS = 750;
 const APP_FAILURE_TIMEOUT_MS = 2500;
+
+let { kind = "raw" }: { kind?: ShareKind } = $props();
 
 let checked = $state(false);
 let valid = $state(false);
@@ -47,7 +51,7 @@ function redirectTo(target: ShareTarget) {
     redirecting = true;
     stopTimers();
     redirectTimer = setTimeout(() => {
-        location.href = targetUrl(target, location.search);
+        location.href = targetUrl(target, location.search, kind);
         if (target === "app") watchAppLaunch();
     }, REDIRECT_DELAY_MS);
 }
@@ -99,7 +103,11 @@ function resetPreference() {
 }
 
 onMount(() => {
-    valid = isValidPayload(new URLSearchParams(location.search).get("payload"));
+    const params = new URLSearchParams(location.search);
+    valid =
+        kind === "registered"
+            ? isValidFitHash(params.get("hash"))
+            : isValidPayload(params.get("payload"));
     checked = true;
     if (!valid) return stopTimers;
     const remembered = readRememberedTarget();

--- a/site/platform/src/lib/fit-hash.ts
+++ b/site/platform/src/lib/fit-hash.ts
@@ -1,0 +1,7 @@
+// A registered fit hash is the lowercase hex sha256 of the canonical fit
+// state (worker/efa-platform-fit-storage/src/hash.rs).
+export const FIT_HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+export function isValidFitHash(hash: string | null): boolean {
+    return typeof hash === "string" && FIT_HASH_PATTERN.test(hash);
+}

--- a/site/platform/src/lib/share-target.ts
+++ b/site/platform/src/lib/share-target.ts
@@ -1,18 +1,25 @@
 export type ShareTarget = "app" | "web" | "nightly";
+export type ShareKind = "raw" | "registered";
 
-export const APP_URI_BASE = "efa://fit/raw";
+export const APP_URI_BASES: Record<ShareKind, string> = {
+    raw: "efa://fit/raw",
+    registered: "efa://fit/registered",
+};
 export const WEB_URL = "https://app.efa-tech.dev";
 export const NIGHTLY_URL = "https://app-preview.efa-tech.dev";
 export const DOWNLOAD_URL = "https://efa-tech.dev/download";
 
-export const WEB_FIT_PATH = "/fit/raw";
+export const WEB_FIT_PATHS: Record<ShareKind, string> = {
+    raw: "/fit/raw",
+    registered: "/fit/registered",
+};
 
 const TARGET_KEY = "efa-share-target";
 
-export function targetUrl(target: ShareTarget, search: string): string {
-    if (target === "app") return APP_URI_BASE + search;
+export function targetUrl(target: ShareTarget, search: string, kind: ShareKind): string {
+    if (target === "app") return APP_URI_BASES[kind] + search;
     const base = target === "nightly" ? NIGHTLY_URL : WEB_URL;
-    return base + WEB_FIT_PATH + search;
+    return base + WEB_FIT_PATHS[kind] + search;
 }
 
 export function readRememberedTarget(): ShareTarget | null {

--- a/site/platform/src/pages/share/fit/registered.astro
+++ b/site/platform/src/pages/share/fit/registered.astro
@@ -1,0 +1,14 @@
+---
+import FitShareLanding from "../../../components/FitShareLanding.svelte";
+import Base from "../../../layouts/Base.astro";
+
+Astro.response.headers.set("Cache-Control", "no-store");
+Astro.response.headers.set("Referrer-Policy", "no-referrer");
+Astro.response.headers.set("X-Content-Type-Options", "nosniff");
+Astro.response.headers.set("Content-Security-Policy", "frame-ancestors 'none'");
+---
+
+<Base titleKey="share.title">
+    <meta slot="head" name="referrer" content="no-referrer" />
+    <FitShareLanding kind="registered" client:load />
+</Base>

--- a/worker/efa-platform-api/src/index.ts
+++ b/worker/efa-platform-api/src/index.ts
@@ -6,6 +6,7 @@ import { Hono } from "hono";
 import {
     decodeCursor,
     encodeCursor,
+    FIT_HASH_PATTERN,
     normalizeBlob,
     resolveShipName,
     timingSafeEqual,
@@ -285,6 +286,9 @@ app.get("/posts/:id/snapshot", async (c) => {
 // §6.2: raw FitSnapshot protobuf bytes addressed directly by fit hash.
 app.get("/fits/:fitHash/snapshot", async (c) => {
     const fitHash = c.req.param("fitHash");
+    if (!FIT_HASH_PATTERN.test(fitHash)) {
+        return errorJson(400, "bad_request", "invalid fit hash");
+    }
     const row = await c.env.FIT_DB.prepare("SELECT snapshot FROM fits WHERE fit_hash = ?")
         .bind(fitHash)
         .first<{ snapshot: unknown }>();
@@ -299,6 +303,9 @@ app.get("/fits/:fitHash/snapshot", async (c) => {
 // character skills) and is what registered fit links import from.
 app.get("/fits/:fitHash/state", async (c) => {
     const fitHash = c.req.param("fitHash");
+    if (!FIT_HASH_PATTERN.test(fitHash)) {
+        return errorJson(400, "bad_request", "invalid fit hash");
+    }
     const row = await c.env.FIT_DB.prepare("SELECT fit_state FROM fits WHERE fit_hash = ?")
         .bind(fitHash)
         .first<{ fit_state: unknown }>();

--- a/worker/efa-platform-api/src/index.ts
+++ b/worker/efa-platform-api/src/index.ts
@@ -294,6 +294,20 @@ app.get("/fits/:fitHash/snapshot", async (c) => {
     return blobResponse(row.snapshot);
 });
 
+// §6.2: raw canonical FitState protobuf bytes addressed directly by fit hash.
+// Unlike the snapshot, the state is full-fidelity (dynamic items, custom
+// character skills) and is what registered fit links import from.
+app.get("/fits/:fitHash/state", async (c) => {
+    const fitHash = c.req.param("fitHash");
+    const row = await c.env.FIT_DB.prepare("SELECT fit_state FROM fits WHERE fit_hash = ?")
+        .bind(fitHash)
+        .first<{ fit_state: unknown }>();
+    if (!row) {
+        return errorJson(404, "not_found", "unknown fit hash");
+    }
+    return blobResponse(row.fit_state);
+});
+
 // §6.4: threads (stub).
 app.get("/posts/:id/threads", (c) => {
     return c.json({ threads: [] });

--- a/worker/efa-platform-api/src/util.ts
+++ b/worker/efa-platform-api/src/util.ts
@@ -4,6 +4,9 @@
 
 export const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Fit hashes are lowercase hex SHA-256 digests over the canonical fit bytes.
+export const FIT_HASH_PATTERN = /^[0-9a-f]{64}$/;
+
 // D1's documented type conversion reads BLOB columns back as plain number
 // arrays (Array.from over the stored bytes); other environments may yield an
 // ArrayBuffer or a view. Normalize every observed shape into bytes; null


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registered fit links using secure SHA-256 fit hashes.
  * Added registered fit-sharing URLs and a dedicated web landing page.
  * Fit imports can retrieve saved fits, metadata, and character skills automatically.
  * Added support for converting imported fits, including modules, drones, fighters, implants, boosters, and tactical settings.
  * Added an API endpoint for retrieving saved fit data.

* **Bug Fixes**
  * Improved link validation and handling of malformed or unavailable fits.
  * Preserved existing raw fit-link importing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->