### PR TITLE
feat(platform): bake content-addressed icon URLs into fit snapshots

### DIFF
--- a/data/schema/fit_snapshot.proto
+++ b/data/schema/fit_snapshot.proto
@@ -79,10 +79,12 @@ message SnapshotHeader {
 
 /// A displayable game entity with all checkout-resolved data inlined.
 ///
-/// `type_id` doubles as the image key for public CDNs (e.g. the EVE image
-/// server `types/{type_id}/icon`), so renderers without any registry can still
-/// show artwork. `icon` is a hint for consumers that do have the EVE icon
-/// sheets; it is never required.
+/// `icon_url` is the preferred artwork source: an absolute, immutable,
+/// content-addressed URL baked by the snapshot producer. When it is absent,
+/// `type_id` doubles as the fallback image key for public CDNs (e.g. the EVE
+/// image server `types/{type_id}/icon`), so renderers without any registry can
+/// still show artwork. `icon` is a hint for consumers that do have the EVE
+/// icon sheets; it is never required.
 message SnapshotType {
   required uint32 type_id = 1;
 
@@ -95,6 +97,12 @@ message SnapshotType {
 
   /// Tech-tier meta group, driving the corner overlay on the item icon.
   optional SnapshotMetaGroup meta_group = 4;
+
+  /// Absolute, immutable, content-addressed URL of this type's icon PNG on the
+  /// EFA asset store, baked by the snapshot builder. Absent ⇒ consumers fall
+  /// back to their default icon resolution (e.g. the public EVE image server
+  /// keyed by `type_id`).
+  optional string icon_url = 5;
 }
 
 message SnapshotMetaGroup {

--- a/packages/efa_fit_snapshot_ts/src/lib/FitSnapshotView.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/FitSnapshotView.svelte
@@ -14,7 +14,12 @@ interface Props {
      * component chrome translations and the resolution of snapshot `names` maps.
      */
     locale?: string;
-    /** Overrides type-icon resolution; defaults to the public EVE image server. */
+    /**
+     * Overrides type-icon resolution; defaults to the public EVE image server.
+     * Precedence per icon: the snapshot's baked `SnapshotType.icon_url`
+     * (content-addressed EFA CDN URL) first, then this resolver, then the
+     * bundled placeholder on load error.
+     */
     iconResolver?: TypeIconResolver;
     /** Resolves `SnapshotDisplayValue` icon hints (graphic/icon ids) to image URLs. */
     iconHintResolver?: IconHintResolver;

--- a/packages/efa_fit_snapshot_ts/src/lib/columns/CharacterColumn.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/columns/CharacterColumn.svelte
@@ -89,7 +89,7 @@ const characterName = $derived.by(() => {
         <div class="efa-row">
             <StateIcon state={booster.state}>
                 {#if booster.type}
-                    <TypeIcon typeId={booster.type.typeId} size={31} />
+                    <TypeIcon typeId={booster.type.typeId} url={booster.type.iconUrl} size={31} />
                 {/if}
             </StateIcon>
             <div class="efa-row-body">

--- a/packages/efa_fit_snapshot_ts/src/lib/columns/StatisticsColumn.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/columns/StatisticsColumn.svelte
@@ -94,7 +94,7 @@ function holdIcon(kind: HoldKindType): EfaIconName {
     <div class="efa-column">
         <div class="efa-ship-header">
             {#if ship}
-                <TypeIcon typeId={ship.typeId} size={40} />
+                <TypeIcon typeId={ship.typeId} url={ship.iconUrl} size={40} />
                 <span class="efa-ship-name">{ctx.name(ship.names)}</span>
             {/if}
         </div>

--- a/packages/efa_fit_snapshot_ts/src/lib/components/TypeIcon.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/components/TypeIcon.svelte
@@ -4,10 +4,16 @@ import EfaIcon from "./EfaIcon.svelte";
 
 interface Props {
     typeId: number;
+    /**
+     * Baked, content-addressed icon URL from the snapshot (`SnapshotType.icon_url`).
+     * Takes precedence over the context resolver; empty/absent falls back to
+     * `ctx.typeIconUrl(typeId)` (the public EVE image server by default).
+     */
+    url?: string;
     size?: number;
 }
 
-let { typeId, size = 35 }: Props = $props();
+let { typeId, url, size = 35 }: Props = $props();
 
 const ctx = snapshotDisplay();
 
@@ -15,8 +21,11 @@ let failed = $state(false);
 
 $effect(() => {
     void typeId;
+    void url;
     failed = false;
 });
+
+const src = $derived(url || ctx.typeIconUrl(typeId));
 </script>
 
 {#if failed}
@@ -24,7 +33,7 @@ $effect(() => {
 {:else}
     <img
         class="efa-type-icon"
-        src={ctx.typeIconUrl(typeId)}
+        {src}
         width={size}
         height={size}
         alt=""

--- a/packages/efa_fit_snapshot_ts/src/lib/rows/DroneRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/rows/DroneRow.svelte
@@ -16,7 +16,7 @@ const ctx = snapshotDisplay();
 <div class="efa-row">
     <StateIcon state={drone.state}>
         {#if drone.type}
-            <TypeIcon typeId={drone.type.typeId} size={31} />
+            <TypeIcon typeId={drone.type.typeId} url={drone.type.iconUrl} size={31} />
         {/if}
     </StateIcon>
     <div class="efa-row-body">

--- a/packages/efa_fit_snapshot_ts/src/lib/rows/FighterRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/rows/FighterRow.svelte
@@ -30,7 +30,7 @@ function abilityLabel(ability: SnapshotFighter_Ability): string {
 <div class="efa-row">
     <StateIcon state={fighter.state}>
         {#if fighter.type}
-            <TypeIcon typeId={fighter.type.typeId} size={31} />
+            <TypeIcon typeId={fighter.type.typeId} url={fighter.type.iconUrl} size={31} />
         {/if}
     </StateIcon>
     <div class="efa-row-body">

--- a/packages/efa_fit_snapshot_ts/src/lib/rows/ModuleRow.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/rows/ModuleRow.svelte
@@ -22,7 +22,7 @@ const charge = $derived(module.charge);
 <div class="efa-row">
     <StateIcon state={module.state}>
         {#if type}
-            <TypeIcon typeId={type.typeId} size={31} />
+            <TypeIcon typeId={type.typeId} url={type.iconUrl} size={31} />
         {/if}
     </StateIcon>
     <div class="efa-row-body">
@@ -32,7 +32,7 @@ const charge = $derived(module.charge);
                 {#if charge.quantity > 0}
                     <span>{charge.quantity} x</span>
                 {/if}
-                <TypeIcon typeId={charge.type.typeId} size={16} />
+                <TypeIcon typeId={charge.type.typeId} url={charge.type.iconUrl} size={16} />
                 <span class="efa-charge-name">{ctx.name(charge.type.names)}</span>
             </div>
         {/if}

--- a/worker/efa-platform-fit-storage/README.md
+++ b/worker/efa-platform-fit-storage/README.md
@@ -55,6 +55,19 @@ Error responses are JSON `{ "error": <code>, "message": <string> }` (+ an
   D1 database (`migrations/0001_init.sql`): one `fits` row per canonical hash
   (idempotent re-submits skip computation). The `posts` table in the same
   database is owned by `efa-platform-api`.
+- At submit time only, each used type's icon is resolved through the EFA
+  storage catalog chain (`src/icons.rs`:
+  `channels/heads/channels.json` → head `metadata.json` → generation
+  `resources.pb2` → the server's `ResourceIndex`) and baked into the snapshot
+  as `SnapshotType.icon_url` — an absolute, immutable, content-addressed blob
+  URL under `STORAGE_ORIGIN` (`efa/v2/assets/blobs/...`, `identHash =
+  SHA-256(resource_id)`; graphic IDs preferred over icon IDs, matching the
+  app). Resolution is best-effort and cached (Cloudflare Cache API plus
+  in-isolate memoization of the immutable, content-addressed bodies): any
+  failure — including a missing `STORAGE_ORIGIN` var — leaves `icon_url`
+  unset and consumers fall back to the public EVE image server keyed by
+  `type_id`. There is no rebake-on-read; pre-existing fits rely on the
+  fallback until re-submitted.
 - Statistics are a field-for-field port of the app's
   `lib/features/fit_io/snapshot_export.dart::_statistics` (`src/statistics.rs`).
 

--- a/worker/efa-platform-fit-storage/build.rs
+++ b/worker/efa-platform-fit-storage/build.rs
@@ -17,6 +17,8 @@ fn main() -> anyhow::Result<()> {
         "fit.proto",
         "utils.proto",
         "platform_data.proto",
+        "resource_index.proto",
+        "generation_resources.proto",
     ];
     for file in schema_files {
         println!(

--- a/worker/efa-platform-fit-storage/src/icons.rs
+++ b/worker/efa-platform-fit-storage/src/icons.rs
@@ -20,11 +20,15 @@
 //! no rebake-on-read.
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::pin;
+use std::task::Poll;
+use std::time::Duration;
 
 use prost::Message;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use worker::{Cache, Env, Fetch, Method, Request, Response, console_log};
+use worker::{Cache, Delay, Env, Fetch, Method, Request, Response, console_log};
 
 use crate::proto::efa_v2::GenerationResources;
 use crate::proto::efa_v2::ResourceIndex;
@@ -35,6 +39,33 @@ const HEAD_CACHE_TTL_S: u32 = 300;
 /// TTL for content-addressed refs/indexes (seconds); their URLs embed the
 /// generation/snapshot hash, so they are immutable.
 const IMMUTABLE_CACHE_TTL_S: u32 = 86_400;
+
+/// Wall-clock budget for the whole catalog chain. Cache misses reach the
+/// storage origin through `Fetch::Request(...).send()` / `resp.bytes()`,
+/// which carry no per-request timeout in the runtime, so an unresponsive
+/// origin would otherwise hold the fit submit open indefinitely. On expiry
+/// the in-flight future is dropped and resolution degrades to "no baked
+/// URL" like any other failure.
+const RESOLUTION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Race `fut` against a wall-clock budget, returning `None` on expiry. The
+/// losing future is dropped, which cancels the wait (the underlying
+/// runtime fetch may still settle in the background, but nothing awaits
+/// it).
+async fn with_timeout<F: Future>(budget: Duration, fut: F) -> Option<F::Output> {
+    let mut fut = pin!(fut);
+    let mut delay = pin!(Delay::from(budget));
+    std::future::poll_fn(|cx| {
+        if let Poll::Ready(out) = fut.as_mut().poll(cx) {
+            return Poll::Ready(Some(out));
+        }
+        if delay.as_mut().poll(cx).is_ready() {
+            return Poll::Ready(None);
+        }
+        Poll::Pending
+    })
+    .await
+}
 
 /// `channels/heads/channels.json`. The remote spec uses `defaultChannel`;
 /// `active` is the client's mapped key, accepted defensively.
@@ -235,16 +266,30 @@ async fn resolve_icon_urls_inner(
 ///
 /// Best-effort: any catalog-chain failure (including a missing
 /// `STORAGE_ORIGIN` var) yields an empty map; consumers then fall back to
-/// their default icon resolution. Never fails a fit submit.
+/// their default icon resolution. Never fails a fit submit. Bounded by
+/// [`RESOLUTION_TIMEOUT`] so an unresponsive origin cannot hold the submit
+/// open.
 pub async fn resolve_icon_urls(
     env: &Env,
     server_id: &str,
     metas: &HashMap<i32, PlatformTypeMeta>,
 ) -> HashMap<i32, String> {
-    match resolve_icon_urls_inner(env, server_id, metas).await {
-        Ok(urls) => urls,
-        Err(stage) => {
+    match with_timeout(
+        RESOLUTION_TIMEOUT,
+        resolve_icon_urls_inner(env, server_id, metas),
+    )
+    .await
+    {
+        Some(Ok(urls)) => urls,
+        Some(Err(stage)) => {
             console_log!("fit-storage: icon URL resolution failed ({stage}); baking no icon_url");
+            HashMap::new()
+        }
+        None => {
+            console_log!(
+                "fit-storage: icon URL resolution timed out after {}s; baking no icon_url",
+                RESOLUTION_TIMEOUT.as_secs()
+            );
             HashMap::new()
         }
     }

--- a/worker/efa-platform-fit-storage/src/icons.rs
+++ b/worker/efa-platform-fit-storage/src/icons.rs
@@ -1,0 +1,350 @@
+//! Submit-time baking of `SnapshotType.icon_url` from the EFA storage
+//! catalog chain.
+//!
+//! Resolution chain (mirrors the app's `RemoteCatalogService`):
+//!
+//! ```text
+//! efa/v2/channels/heads/channels.json            (defaultChannel)
+//!   → efa/v2/channels/heads/{channel}/metadata.json   (generationHash)
+//!   → efa/v2/channels/refs/{generationHash}/resources.pb2
+//!       (`GenerationResources`: server_id → snapshot_hash)
+//!   → efa/v2/assets/resources/{snapshotHash}/resources.pb2
+//!       (`ResourceIndex`: resource_id → content_hash)
+//!   → efa/v2/assets/blobs/{ident[0:2]}/{ident}/{content_hash}
+//!     where ident = SHA-256 hex of the resource_id URI
+//! ```
+//!
+//! Everything here is best-effort and runs **only** in the submit path: any
+//! failure degrades to "no baked URL" (the consumer's evetech fallback covers
+//! it) — a storage outage must never fail a fit submit. There is deliberately
+//! no rebake-on-read.
+
+use std::collections::HashMap;
+
+use prost::Message;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use worker::{Cache, Env, Fetch, Method, Request, Response, console_log};
+
+use crate::proto::efa_v2::GenerationResources;
+use crate::proto::efa_v2::ResourceIndex;
+use crate::proto::platform_data::PlatformTypeMeta;
+
+/// TTL for the mutable channel registry/head metadata (seconds).
+const HEAD_CACHE_TTL_S: u32 = 300;
+/// TTL for content-addressed refs/indexes (seconds); their URLs embed the
+/// generation/snapshot hash, so they are immutable.
+const IMMUTABLE_CACHE_TTL_S: u32 = 86_400;
+
+/// `channels/heads/channels.json`. The remote spec uses `defaultChannel`;
+/// `active` is the client's mapped key, accepted defensively.
+#[derive(Deserialize)]
+struct ChannelRegistry {
+    #[serde(rename = "defaultChannel", alias = "active")]
+    default_channel: String,
+}
+
+/// Channel selection, mirroring the app (`generation_nav.dart`): an empty
+/// `defaultChannel` falls back to `"testing"`.
+fn select_channel(registry: &ChannelRegistry) -> &str {
+    if registry.default_channel.is_empty() {
+        "testing"
+    } else {
+        &registry.default_channel
+    }
+}
+
+/// `channels/heads/{channel}/metadata.json`.
+#[derive(Deserialize)]
+struct HeadMeta {
+    #[serde(rename = "generationHash")]
+    generation_hash: String,
+}
+
+// In-isolate memoization of immutable, content-addressed bodies (refs and
+// resource indexes). Mutable head metadata is left to the Cache API so it can
+// expire. Same single-threaded-isolate argument as the prefetch cache.
+thread_local! {
+    static IMMUTABLE_CACHE: std::cell::RefCell<HashMap<String, Vec<u8>>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+fn catalog_url(origin: &str, path: &str) -> String {
+    format!("{}/efa/v2/{path}", origin.trim_end_matches('/'))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// `identHash = SHA-256(resource_id)` (lowercase hex), matching the app's
+/// `RepoHash.hashIdent`.
+fn ident_hash(resource_id: &str) -> String {
+    hex_lower(&Sha256::digest(resource_id.as_bytes()))
+}
+
+/// The content-addressed blob URL for a resource
+/// (`assets/blobs/{ident[0:2]}/{ident}/{content_hash}`).
+fn blob_url(origin: &str, resource_id: &str, content_hash: &str) -> String {
+    let ident = ident_hash(resource_id);
+    catalog_url(
+        origin,
+        &format!("assets/blobs/{}/{ident}/{content_hash}", &ident[..2]),
+    )
+}
+
+/// Candidate resource IDs of a type's icon, graphic first (matching the app's
+/// `ImageAssetService.resolve` preference).
+fn icon_resource_ids(meta: &PlatformTypeMeta) -> Vec<String> {
+    let mut ids = Vec::with_capacity(2);
+    if let Some(graphic_id) = meta.graphic_id {
+        ids.push(format!(
+            "resource://static/images/graphics/{graphic_id}.png"
+        ));
+    }
+    if let Some(icon_id) = meta.icon_id {
+        ids.push(format!("resource://static/images/icons/{icon_id}.png"));
+    }
+    ids
+}
+
+/// Server selection within a generation: the fit's own `server_id` where it
+/// matches, else `tranquility`, else the first entry.
+fn select_snapshot_hash<'a>(gen: &'a GenerationResources, server_id: &str) -> Option<&'a str> {
+    gen.entries
+        .iter()
+        .find(|e| e.server_id == server_id)
+        .or_else(|| gen.entries.iter().find(|e| e.server_id == "tranquility"))
+        .or_else(|| gen.entries.first())
+        .map(|e| e.snapshot_hash.as_str())
+}
+
+/// Fetch `url` through the Cloudflare Cache API, populating it on a miss.
+/// Content-addressed URLs additionally hit the in-isolate memoization.
+async fn fetch_cached(url: &str, ttl_s: u32, immutable: bool) -> Option<Vec<u8>> {
+    if immutable {
+        if let Some(bytes) = IMMUTABLE_CACHE.with(|c| c.borrow().get(url).cloned()) {
+            return Some(bytes);
+        }
+    }
+
+    let cache = Cache::default();
+    match cache.get(url, true).await {
+        Ok(Some(mut resp)) => return resp.bytes().await.ok(),
+        Ok(None) => {}
+        Err(e) => console_log!("fit-storage: icon cache get failed for {url}: {e}"),
+    }
+
+    let request = Request::new(url, Method::Get).ok()?;
+    let mut resp = Fetch::Request(request).send().await.ok()?;
+    if resp.status_code() != 200 {
+        return None;
+    }
+    let bytes = resp.bytes().await.ok()?;
+
+    // Best-effort cache population; a put failure only loses edge caching.
+    if let Ok(stored) = Response::from_bytes(bytes.clone()) {
+        let mut stored = stored;
+        if stored
+            .headers_mut()
+            .set("Cache-Control", &format!("public, max-age={ttl_s}"))
+            .is_ok()
+        {
+            let _ = cache.put(url, stored).await;
+        }
+    }
+    if immutable {
+        IMMUTABLE_CACHE.with(|c| c.borrow_mut().insert(url.to_string(), bytes.clone()));
+    }
+    Some(bytes)
+}
+
+async fn fetch_json<T: for<'de> Deserialize<'de>>(url: &str, ttl_s: u32) -> Option<T> {
+    let bytes = fetch_cached(url, ttl_s, false).await?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+async fn fetch_pb<M: Message + Default>(url: &str) -> Option<M> {
+    let bytes = fetch_cached(url, IMMUTABLE_CACHE_TTL_S, true).await?;
+    M::decode(&bytes[..]).ok()
+}
+
+async fn resolve_icon_urls_inner(
+    env: &Env,
+    server_id: &str,
+    metas: &HashMap<i32, PlatformTypeMeta>,
+) -> Result<HashMap<i32, String>, String> {
+    let origin = env
+        .var("STORAGE_ORIGIN")
+        .map_err(|_| "STORAGE_ORIGIN var not configured".to_string())?
+        .to_string();
+
+    let registry_url = catalog_url(&origin, "channels/heads/channels.json");
+    let registry: ChannelRegistry = fetch_json(&registry_url, HEAD_CACHE_TTL_S)
+        .await
+        .ok_or_else(|| format!("channel registry {registry_url}: fetch/parse failed"))?;
+    let head_url = catalog_url(
+        &origin,
+        &format!("channels/heads/{}/metadata.json", select_channel(&registry)),
+    );
+    let head: HeadMeta = fetch_json(&head_url, HEAD_CACHE_TTL_S)
+        .await
+        .ok_or_else(|| format!("head metadata {head_url}: fetch/parse failed"))?;
+    let gen_url = catalog_url(
+        &origin,
+        &format!("channels/refs/{}/resources.pb2", head.generation_hash),
+    );
+    let gen: GenerationResources = fetch_pb(&gen_url)
+        .await
+        .ok_or_else(|| format!("generation resources {gen_url}: fetch/decode failed"))?;
+    let snapshot_hash = select_snapshot_hash(&gen, server_id)
+        .ok_or_else(|| format!("generation resources {gen_url}: no server entries"))?;
+    let index_url = catalog_url(
+        &origin,
+        &format!("assets/resources/{snapshot_hash}/resources.pb2"),
+    );
+    let index: ResourceIndex = fetch_pb(&index_url)
+        .await
+        .ok_or_else(|| format!("resource index {index_url}: fetch/decode failed"))?;
+
+    let content_hashes: HashMap<&str, &str> = index
+        .entries
+        .iter()
+        .map(|e| (e.resource_id.as_str(), e.content_hash.as_str()))
+        .collect();
+
+    let mut urls = HashMap::new();
+    for (type_id, meta) in metas {
+        for resource_id in icon_resource_ids(meta) {
+            if let Some(content_hash) = content_hashes.get(resource_id.as_str()) {
+                urls.insert(*type_id, blob_url(&origin, &resource_id, content_hash));
+                break;
+            }
+        }
+    }
+    Ok(urls)
+}
+
+/// Resolve a baked, content-addressed icon URL for every type with metadata.
+///
+/// Best-effort: any catalog-chain failure (including a missing
+/// `STORAGE_ORIGIN` var) yields an empty map; consumers then fall back to
+/// their default icon resolution. Never fails a fit submit.
+pub async fn resolve_icon_urls(
+    env: &Env,
+    server_id: &str,
+    metas: &HashMap<i32, PlatformTypeMeta>,
+) -> HashMap<i32, String> {
+    match resolve_icon_urls_inner(env, server_id, metas).await {
+        Ok(urls) => urls,
+        Err(stage) => {
+            console_log!("fit-storage: icon URL resolution failed ({stage}); baking no icon_url");
+            HashMap::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::efa_v2::generation_resources;
+
+    fn meta(icon_id: Option<u32>, graphic_id: Option<u32>) -> PlatformTypeMeta {
+        PlatformTypeMeta {
+            type_id: 0,
+            name: Default::default(),
+            icon_id,
+            graphic_id,
+        }
+    }
+
+    #[test]
+    fn ident_hash_is_sha256_hex_of_resource_id() {
+        // Matches `RepoHash.hashIdent` (SHA-256 hex of the UTF-8 URI);
+        // expected value verified against `sha256sum`.
+        assert_eq!(
+            ident_hash("resource://static/images/icons/0.png"),
+            "f7a7af34e2dc355b898b3d80e061cb6e67fdf5328a6f0be5cc8c466082b0ef7b".to_string(),
+        );
+    }
+
+    #[test]
+    fn blob_url_layout() {
+        let url = blob_url(
+            "https://prod.storage.efa-tech.dev/",
+            "resource://static/images/icons/1.png",
+            "deadbeef",
+        );
+        let ident = ident_hash("resource://static/images/icons/1.png");
+        assert_eq!(
+            url,
+            format!(
+                "https://prod.storage.efa-tech.dev/efa/v2/assets/blobs/{}/{ident}/deadbeef",
+                &ident[..2]
+            )
+        );
+    }
+
+    #[test]
+    fn graphic_preferred_over_icon() {
+        let ids = icon_resource_ids(&meta(Some(7), Some(9)));
+        assert_eq!(
+            ids,
+            vec![
+                "resource://static/images/graphics/9.png".to_string(),
+                "resource://static/images/icons/7.png".to_string(),
+            ]
+        );
+        assert_eq!(
+            icon_resource_ids(&meta(Some(7), None)),
+            vec!["resource://static/images/icons/7.png".to_string()]
+        );
+        assert!(icon_resource_ids(&meta(None, None)).is_empty());
+    }
+
+    #[test]
+    fn empty_default_channel_falls_back_to_testing() {
+        // Mirrors the app (`generation_nav.dart`): the live prod registry
+        // ships `"defaultChannel": ""`.
+        let registry = ChannelRegistry {
+            default_channel: String::new(),
+        };
+        assert_eq!(select_channel(&registry), "testing");
+        let registry = ChannelRegistry {
+            default_channel: "stable".to_string(),
+        };
+        assert_eq!(select_channel(&registry), "stable");
+    }
+
+    #[test]
+    fn server_selection_prefers_fit_server() {
+        let entry = |server_id: &str, hash: &str| generation_resources::Entry {
+            server_id: server_id.to_string(),
+            snapshot_hash: hash.to_string(),
+        };
+        let gen = GenerationResources {
+            schema_version: 1,
+            entries: vec![entry("serenity", "aaa"), entry("tranquility", "bbb")],
+        };
+        assert_eq!(select_snapshot_hash(&gen, "serenity"), Some("aaa"));
+        assert_eq!(select_snapshot_hash(&gen, "tranquility"), Some("bbb"));
+        // Unknown fit server falls back to tranquility, then first entry.
+        assert_eq!(select_snapshot_hash(&gen, "other"), Some("bbb"));
+        let no_tq = GenerationResources {
+            schema_version: 1,
+            entries: vec![entry("serenity", "aaa")],
+        };
+        assert_eq!(select_snapshot_hash(&no_tq, "other"), Some("aaa"));
+        let empty = GenerationResources {
+            schema_version: 1,
+            entries: vec![],
+        };
+        assert_eq!(select_snapshot_hash(&empty, "other"), None);
+    }
+}

--- a/worker/efa-platform-fit-storage/src/lib.rs
+++ b/worker/efa-platform-fit-storage/src/lib.rs
@@ -5,6 +5,7 @@ mod d1;
 mod engine;
 mod error;
 mod hash;
+mod icons;
 mod prefetch;
 mod proto;
 mod provider;
@@ -115,9 +116,20 @@ async fn handle_submit(mut req: Request, env: Env) -> Result<Response, ApiError>
             );
         }
 
-        // 5d/5e. Assemble + store the snapshot.
+        // 5d/5e. Assemble + store the snapshot. Icon URLs are baked at submit
+        // time only, best-effort (storage outage ⇒ no `icon_url`, never a
+        // failed submit).
         let created_at_ms = Date::now().as_millis() as i64;
-        let snapshot = snapshot::assemble(&request, &canonical, &ship, &data, created_at_ms);
+        let icon_urls =
+            prefetch::resolve_icon_urls(&env, &request.server_id, &data.type_meta).await;
+        let snapshot = snapshot::assemble(
+            &request,
+            &canonical,
+            &ship,
+            &data,
+            &icon_urls,
+            created_at_ms,
+        );
         let inserted = d1::insert_fit(
             &fit_db,
             &fit_hash,

--- a/worker/efa-platform-fit-storage/src/prefetch.rs
+++ b/worker/efa-platform-fit-storage/src/prefetch.rs
@@ -391,6 +391,18 @@ where
     Ok(())
 }
 
+/// Resolve baked `icon_url`s for the fit's used types, alongside `type_meta`
+/// (submit path only). Best-effort: any catalog-chain failure yields an
+/// empty map and consumers fall back to their default icon resolution — a
+/// storage outage must never fail a fit submit.
+pub async fn resolve_icon_urls(
+    env: &worker::Env,
+    server_id: &str,
+    metas: &HashMap<i32, platform_data::PlatformTypeMeta>,
+) -> HashMap<i32, String> {
+    crate::icons::resolve_icon_urls(env, server_id, metas).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/worker/efa-platform-fit-storage/src/proto.rs
+++ b/worker/efa-platform-fit-storage/src/proto.rs
@@ -17,3 +17,10 @@ pub mod efos {
     #![allow(dead_code)]
     include!(concat!(env!("OUT_DIR"), "/efos.rs"));
 }
+
+/// Storage catalog chain (`data/schema/resource_index.proto` and
+/// `generation_resources.proto`, both `package efa.v2`).
+pub mod efa_v2 {
+    #![allow(dead_code)]
+    include!(concat!(env!("OUT_DIR"), "/efa.v2.rs"));
+}

--- a/worker/efa-platform-fit-storage/src/snapshot.rs
+++ b/worker/efa-platform-fit-storage/src/snapshot.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use eve_fit_os::calculate::Ship;
 use eve_fit_os::calculate::item::SlotType as EngineSlotType;
 use eve_fit_os::constant::patches::attr as patch;
@@ -11,7 +13,11 @@ use crate::proto::{fit as pb, utils};
 const EFFECT_LAUNCHER: i32 = 40;
 const EFFECT_TURRET: i32 = 42;
 
-fn snapshot_type(data: &SnapshotData, type_id: i32) -> pb::SnapshotType {
+fn snapshot_type(
+    data: &SnapshotData,
+    icon_urls: &HashMap<i32, String>,
+    type_id: i32,
+) -> pb::SnapshotType {
     let meta = data.type_meta.get(&type_id);
     pb::SnapshotType {
         type_id: type_id as u32,
@@ -27,6 +33,7 @@ fn snapshot_type(data: &SnapshotData, type_id: i32) -> pb::SnapshotType {
             }
         }),
         meta_group: None,
+        icon_url: icon_urls.get(&type_id).cloned(),
     }
 }
 
@@ -75,6 +82,7 @@ fn calculated_module(
 
 fn snapshot_module(
     data: &SnapshotData,
+    icon_urls: &HashMap<i32, String>,
     state: &pb::FitState,
     ship: &Ship,
     module: &pb::FitModule,
@@ -95,7 +103,7 @@ fn snapshot_module(
     let charge = module
         .charge_type_id
         .map(|charge_type_id| pb::SnapshotCharge {
-            r#type: snapshot_type(data, charge_type_id as i32),
+            r#type: snapshot_type(data, icon_urls, charge_type_id as i32),
             // Rounds loaded per module (dogma chargeAmount), read from the
             // module's calculated item — the patch attaches it to the module.
             quantity: calculated.map(|item| {
@@ -116,12 +124,12 @@ fn snapshot_module(
     };
 
     Some(pb::SnapshotModule {
-        r#type: snapshot_type(data, type_id),
+        r#type: snapshot_type(data, icon_urls, type_id),
         state: module.state,
         charge,
         is_turret: Some(is_turret),
         is_launcher: Some(is_launcher),
-        origin_type: origin_type_id.map(|base| snapshot_type(data, base)),
+        origin_type: origin_type_id.map(|base| snapshot_type(data, icon_urls, base)),
         related_values: Vec::new(),
     })
 }
@@ -143,6 +151,7 @@ pub fn assemble(
     state: &pb::FitState,
     ship: &Ship,
     data: &SnapshotData,
+    icon_urls: &HashMap<i32, String>,
     created_at_ms: i64,
 ) -> pb::FitSnapshot {
     let layout = state.layout;
@@ -152,7 +161,7 @@ pub fn assemble(
             .map(|index| pb::SnapshotSlot {
                 index,
                 item: find_module(state, slot_type, index)
-                    .and_then(|m| snapshot_module(data, state, ship, m)),
+                    .and_then(|m| snapshot_module(data, icon_urls, state, ship, m)),
             })
             .collect()
     };
@@ -165,7 +174,7 @@ pub fn assemble(
                 subsystem_type: module
                     .and_then(|m| m.subsystem_type)
                     .unwrap_or(pb::subsystem::SubsystemType::Unknown as i32),
-                item: module.and_then(|m| snapshot_module(data, state, ship, m)),
+                item: module.and_then(|m| snapshot_module(data, icon_urls, state, ship, m)),
             }
         })
         .collect();
@@ -176,7 +185,7 @@ pub fn assemble(
             .iter()
             .find(|mode| mode.type_id == selected)
             .map(|mode| pb::SnapshotTacticalMode {
-                r#type: snapshot_type(data, mode.type_id as i32),
+                r#type: snapshot_type(data, icon_urls, mode.type_id as i32),
                 variant: mode.variant,
             })
     });
@@ -185,7 +194,7 @@ pub fn assemble(
         .drones
         .iter()
         .map(|drone| pb::SnapshotDrone {
-            r#type: snapshot_type(data, drone.type_id as i32),
+            r#type: snapshot_type(data, icon_urls, drone.type_id as i32),
             state: drone.state,
             quantity: drone.quantity,
         })
@@ -195,7 +204,7 @@ pub fn assemble(
         .fighters
         .iter()
         .map(|fighter| pb::SnapshotFighter {
-            r#type: snapshot_type(data, fighter.type_id as i32),
+            r#type: snapshot_type(data, icon_urls, fighter.type_id as i32),
             // Fighters are always active (app convention, snapshot_export.dart).
             state: pb::slots::SlotState::Active as i32,
             quantity: fighter.quantity,
@@ -212,7 +221,7 @@ pub fn assemble(
             let implant = state.implants.iter().find(|i| i.slot_index == slot_index);
             let item = implant.and_then(|i| {
                 i.type_id.map(|type_id| pb::SnapshotModule {
-                    r#type: snapshot_type(data, type_id as i32),
+                    r#type: snapshot_type(data, icon_urls, type_id as i32),
                     state: i.state,
                     charge: None,
                     is_turret: Some(false),
@@ -230,7 +239,7 @@ pub fn assemble(
         .iter()
         .map(|booster| pb::SnapshotBooster {
             slot_index: booster.slot_index,
-            r#type: snapshot_type(data, booster.type_id as i32),
+            r#type: snapshot_type(data, icon_urls, booster.type_id as i32),
             state: booster.state,
         })
         .collect();
@@ -260,13 +269,13 @@ pub fn assemble(
             server_id: Some(request.server_id.clone()),
         },
         ship: pb::SnapshotShip {
-            r#type: snapshot_type(data, state.ship_type_id as i32),
+            r#type: snapshot_type(data, icon_urls, state.ship_type_id as i32),
             layout,
             available_tactical_modes: state
                 .available_tactical_modes
                 .iter()
                 .map(|mode| pb::SnapshotTacticalMode {
-                    r#type: snapshot_type(data, mode.type_id as i32),
+                    r#type: snapshot_type(data, icon_urls, mode.type_id as i32),
                     variant: mode.variant,
                 })
                 .collect(),
@@ -436,7 +445,17 @@ mod tests {
         let data = data();
         let state = state();
         let ship = Ship::new(100);
-        let snapshot = assemble(&request(state.clone()), &state, &ship, &data, 999);
+        let icon_urls: HashMap<i32, String> = [(100, "https://cdn.example/icon.png".to_string())]
+            .into_iter()
+            .collect();
+        let snapshot = assemble(
+            &request(state.clone()),
+            &state,
+            &ship,
+            &data,
+            &icon_urls,
+            999,
+        );
 
         assert_eq!(snapshot.version, 1);
         let header = snapshot.header;
@@ -451,6 +470,20 @@ mod tests {
             Some("Test Ship")
         );
         assert_eq!(ship_type.icon.unwrap().icon_id, Some(42));
+        // Baked icon URL from the resolver map; unresolved types keep `None`.
+        assert_eq!(
+            ship_type.icon_url.as_deref(),
+            Some("https://cdn.example/icon.png")
+        );
+        assert!(
+            snapshot.high_slots[0]
+                .item
+                .as_ref()
+                .unwrap()
+                .r#type
+                .icon_url
+                .is_none()
+        );
 
         // Rack lists sized exactly to layout.
         assert_eq!(snapshot.high_slots.len(), 2);
@@ -513,7 +546,14 @@ mod tests {
         let data = data();
         let state = state();
         let ship = Ship::new(100);
-        let snapshot = assemble(&request(state.clone()), &state, &ship, &data, 999);
+        let snapshot = assemble(
+            &request(state.clone()),
+            &state,
+            &ship,
+            &data,
+            &HashMap::new(),
+            999,
+        );
         let bytes = snapshot.encode_to_vec();
         // Byte comparison: a bare (attribute-less) ship yields a NaN stable
         // fraction, which would fail message equality on NaN != NaN.

--- a/worker/efa-platform-fit-storage/wrangler.toml
+++ b/worker/efa-platform-fit-storage/wrangler.toml
@@ -21,13 +21,33 @@ database_id = "2369a517-b61a-4f16-bcd9-8341016fb1b4"
 [build]
 command = "export PATH=\"$HOME/.cargo/bin:$HOME/.local/bin:$PATH\" && worker-build --release"
 
+# Origin of the EFA storage catalog chain, used to bake content-addressed
+# `icon_url`s into stored snapshots at submit time (see src/icons.rs).
+[vars]
+STORAGE_ORIGIN = "https://prod.storage.efa-tech.dev"
+
 [observability]
 enabled = true
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = true
+persist = true
 head_sampling_rate = 1
 
 # Preview chain (spec §4.4): disposable data. Engine data (PLATFORM_DB) is
 # read-only and shared with production.
 [env.preview]
+
+# The storage catalog is read-only and shared with production.
+[env.preview.vars]
+STORAGE_ORIGIN = "https://prod.storage.efa-tech.dev"
 
 [[env.preview.d1_databases]]
 binding = "PLATFORM_DB"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Snapshot data now preserves immutable artwork URLs for ship, module, drone, fighter, charge, and other type icons.
  - Displays use snapshot-provided artwork when available, improving consistency over time.
  - Existing fallback behavior remains available when artwork cannot be resolved.

- **Bug Fixes**
  - Icon-loading failures no longer prevent fit submissions.
  - Missing or unavailable artwork gracefully falls back to standard type-based images.

- **Documentation**
  - Added guidance describing icon resolution, caching, fallback behavior, and snapshot artwork handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->