### PR TITLE
refactor(ci): make CI/CD pipeline change-aware via monorepo package graph

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -14,8 +14,9 @@ templates.
 - Do not add secrets to workflow files. Publishing credentials belong in GitHub
   Environments as described by `RELEASING.md` and @docs/agents/ci-release.
 - Preserve the release-label contract: `V-Release`, `V-Test`, and `V-Tested Release`.
-- Web preview behavior depends on `bootstrap/ci/suites.py` (`WEB_PREVIEW_PATTERNS`) and the
-  `x.py ci web-affected` check; update both sides together when changing the trigger model.
+- Web preview behavior depends on the monorepo dependency graph in `bootstrap/monorepo/`
+  (web-relevant package closure and meta entries) and the `x.py ci web-affected` check;
+  update both sides together when changing the trigger model.
 
 ## Validation
 

--- a/apps/eve-fit-assistant/rust/lib/efa-chat/tests/test_fit_tools.rs
+++ b/apps/eve-fit-assistant/rust/lib/efa-chat/tests/test_fit_tools.rs
@@ -11,7 +11,11 @@ use eve_fit_os::fit::{
 use eve_fit_os::protobuf::Database;
 
 fn test_database() -> Database {
-    dotenvy::from_filename(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../../../packages/eve-fit-os/.env")).ok();
+    dotenvy::from_filename(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../../../packages/eve-fit-os/.env"
+    ))
+    .ok();
     let output_dir =
         std::env::var("OUTPUT_DIR").expect("OUTPUT_DIR must be set (see eve-fit-os/.env)");
     Database::init_from_root(format!("{output_dir}/pb2")).unwrap()

--- a/bootstrap/AGENTS.md
+++ b/bootstrap/AGENTS.md
@@ -12,6 +12,8 @@ Scope: Python workspace tooling in `bootstrap/`, including the implementation be
 - Generated protobuf modules under `bootstrap/data/schema/` are outputs; change
   `data/schema/` and regenerate instead of editing them.
 - CI/release behavior must stay aligned with `.github/workflows/` and `RELEASING.md`.
+- Change-aware CI/CD selection is driven by the package registry in `bootstrap/monorepo/`;
+  keep it in sync with the real manifests — `bootstrap/tests/test_monorepo.py` enforces this.
 
 ## Detail Docs
 

--- a/bootstrap/ci/__init__.py
+++ b/bootstrap/ci/__init__.py
@@ -9,8 +9,8 @@ from bootstrap.ci.diagnostics import redact_staged_files
 from bootstrap.ci.diagnostics import register_ci_diagnostics_commands
 from bootstrap.ci.lint import run_lint
 from bootstrap.ci.lint import run_site_checks
-from bootstrap.ci.suites import SUITE_DEFINITIONS
 from bootstrap.ci.suites import calculate_ci_matrix
+from bootstrap.ci.suites import full_matrix
 from bootstrap.ci.suites import glob_to_regex
 from bootstrap.ci.suites import match_any_pattern
 
@@ -18,9 +18,9 @@ from bootstrap.ci.suites import match_any_pattern
 __all__ = [
     "CODEGEN_STEPS",
     "LANGUAGE_STEPS",
-    "SUITE_DEFINITIONS",
     "calculate_ci_matrix",
     "collect_diagnostics",
+    "full_matrix",
     "glob_to_regex",
     "match_any_pattern",
     "redact_staged_files",

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -128,7 +128,9 @@ def register_ci_commands(cli_group: click.Group) -> None:
     )
     def ci_lint(lang: str, packages: str | None):
         """Check formatting and linting without modifying files."""
-        package_ids = tuple(p.strip() for p in packages.split(",") if p.strip()) or None
+        package_ids = None
+        if packages:
+            package_ids = tuple(p.strip() for p in packages.split(",") if p.strip()) or None
         run_lint(lang, no_check=False, check_only=True, dry_run=False, packages=package_ids)
 
     @ci.command("codegen")

--- a/bootstrap/ci/commands.py
+++ b/bootstrap/ci/commands.py
@@ -17,8 +17,8 @@ from bootstrap.ci.diagnostics import register_ci_diagnostics_commands
 from bootstrap.ci.lint import run_lint
 from bootstrap.ci.release import register_ci_release_commands
 from bootstrap.ci.release_github import register_github_release_command
-from bootstrap.ci.suites import SUITE_DEFINITIONS
 from bootstrap.ci.suites import calculate_ci_matrix
+from bootstrap.ci.suites import full_matrix
 from bootstrap.ci.suites import web_preview_affected
 from bootstrap.cli import runtime
 from bootstrap.cli.remote.helpers import validate_remote_channel
@@ -44,16 +44,7 @@ def register_ci_commands(cli_group: click.Group) -> None:
     def ci_matrix(from_file, full):
         """Calculate CI job matrix from changed files. Outputs JSON to stdout."""
         if full:
-            suites = [
-                {
-                    "suite": s["suite"],
-                    "shell": s["shell"],
-                    "lint_command": s["lint_command"],
-                    "command": s["command"],
-                    "codegen_command": s["codegen_command"],
-                }
-                for s in SUITE_DEFINITIONS
-            ]
+            suites = full_matrix()
         elif from_file:
             with open(from_file) as f:
                 files = [line.strip() for line in f if line.strip()]
@@ -62,6 +53,47 @@ def register_ci_commands(cli_group: click.Group) -> None:
             suites = []
 
         print(json.dumps(suites))
+
+    @ci.command("affected")
+    @click.option("--from-file", type=click.Path(exists=True), default=None)
+    @click.option("--base-ref", default=None, help="Diff against this git ref instead of a file.")
+    @click.option("--full", is_flag=True, default=False)
+    def ci_affected(from_file, base_ref, full):
+        """Resolve changed files to affected packages/suites. Outputs JSON to stdout."""
+        from bootstrap.monorepo import ALL_SUITES
+        from bootstrap.monorepo import changed_files_from_git
+        from bootstrap.monorepo import resolve_affected
+
+        if full:
+            affected = resolve_affected([])
+            payload = {
+                "full": True,
+                "files": [],
+                "packages": [],
+                "suites": list(ALL_SUITES),
+                "web": True,
+            }
+        else:
+            if from_file:
+                with open(from_file) as f:
+                    files = [line.strip() for line in f if line.strip()]
+            elif base_ref:
+                try:
+                    files = changed_files_from_git(base_ref)
+                except RuntimeError as exception:
+                    raise click.ClickException(str(exception)) from exception
+            else:
+                files = []
+            affected = resolve_affected(files)
+            payload = {
+                "full": affected.full,
+                "files": list(affected.files),
+                "packages": sorted(affected.packages),
+                "suites": sorted(affected.suites),
+                "web": affected.web,
+            }
+
+        print(json.dumps(payload))
 
     @ci.command("web-affected")
     @click.option("--from-file", type=click.Path(exists=True), default=None)
@@ -89,9 +121,15 @@ def register_ci_commands(cli_group: click.Group) -> None:
         default="all",
         help="Limit linting to a specific language (default: all).",
     )
-    def ci_lint(lang: str):
+    @click.option(
+        "--packages",
+        default=None,
+        help="Comma-separated monorepo package ids to restrict linting to.",
+    )
+    def ci_lint(lang: str, packages: str | None):
         """Check formatting and linting without modifying files."""
-        run_lint(lang, no_check=False, check_only=True, dry_run=False)
+        package_ids = tuple(p.strip() for p in packages.split(",") if p.strip()) or None
+        run_lint(lang, no_check=False, check_only=True, dry_run=False, packages=package_ids)
 
     @ci.command("codegen")
     @click.option(

--- a/bootstrap/ci/lint.py
+++ b/bootstrap/ci/lint.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from pathlib import Path
 
 import click
@@ -8,6 +10,8 @@ from colorama import Fore
 from colorama import Style
 
 from bootstrap.color import styled
+from bootstrap.constant import PROJECT_ROOT
+from bootstrap.monorepo import PACKAGES
 from bootstrap.utils import execute_command
 from bootstrap.utils import get_command
 
@@ -15,13 +19,57 @@ from bootstrap.utils import get_command
 __all__ = ["run_lint", "run_site_checks", "run_snapshot_ts_checks"]
 
 
+_PACKAGES_BY_ID = {p.id: p for p in PACKAGES}
+
+
+def _scoped_ids(packages: tuple[str, ...] | None, ecosystem: str) -> list[str] | None:
+    """Filter a package scope down to one ecosystem.
+
+    Returns ``None`` when unscoped (legacy full behavior) and a possibly
+    empty list when scoped (empty means: nothing to do for this ecosystem).
+    """
+    if packages is None:
+        return None
+    return sorted(p for p in packages if _PACKAGES_BY_ID[p].ecosystem == ecosystem)
+
+
+def _packages_with_script(ids: list[str], script: str) -> list[str]:
+    """Return the subset of pnpm package ids that define the given script."""
+    result = []
+    for package_id in ids:
+        manifest = PROJECT_ROOT / _PACKAGES_BY_ID[package_id].path / "package.json"
+        if not manifest.is_file():
+            continue
+        scripts = json.loads(manifest.read_text(encoding="utf-8")).get("scripts") or {}
+        if script in scripts:
+            result.append(package_id)
+    return result
+
+
+def _biome_targets(ids: list[str], prefix: str) -> list[str]:
+    """Render biome path arguments for the scoped packages under ``prefix``."""
+    return [
+        f"{_PACKAGES_BY_ID[p].path}/" for p in ids if _PACKAGES_BY_ID[p].path.startswith(prefix)
+    ]
+
+
 def run_lint(
-    lang: str, *, no_check: bool = False, check_only: bool = False, dry_run: bool = False
+    lang: str,
+    *,
+    no_check: bool = False,
+    check_only: bool = False,
+    dry_run: bool = False,
+    packages: tuple[str, ...] | None = None,
+    files: tuple[str, ...] | None = None,
 ) -> None:
-    """Shared lint/format logic parameterized by mode.
+    """Shared lint/format logic parameterized by mode and scope.
 
     check_only=True: read-only verification (CI mode); exits non-zero on failures.
     check_only=False: auto-fix mode; formatters modify in-place.
+
+    ``packages`` restricts the work to the given monorepo package ids (see
+    ``bootstrap.monorepo``); ``files`` restricts the Python checks to the
+    given changed files. Both default to the legacy full behavior.
     """
 
     def _echo(cmd_str: str) -> None:
@@ -30,100 +78,153 @@ def run_lint(
     uv = get_command("uv")
 
     if lang in ("all", "python"):
-        if not no_check or check_only:
+        python_files: list[str] | None = None
+        if files is not None:
+            python_files = [f for f in files if f.endswith(".py") and (PROJECT_ROOT / f).is_file()]
+        if python_files is None or python_files:
+            targets = python_files if python_files is not None else ["."]
+            if not no_check or check_only:
+                if check_only:
+                    _echo(f"uv run ruff check {' '.join(targets)}")
+                    execute_command(
+                        [uv, "run", "ruff", "check", *targets], "RUFF CHECK OUTPUT", dry_run
+                    )
+                else:
+                    _echo(f"uv run ruff check --fix {' '.join(targets)}")
+                    execute_command(
+                        [uv, "run", "ruff", "check", "--fix", *targets],
+                        "RUFF CHECK OUTPUT",
+                        dry_run,
+                    )
+
             if check_only:
-                _echo("uv run ruff check")
-                execute_command([uv, "run", "ruff", "check"], "RUFF CHECK OUTPUT", dry_run)
+                _echo(f"uv run ruff format --check {' '.join(targets)}")
+                execute_command(
+                    [uv, "run", "ruff", "format", "--check", *targets],
+                    "RUFF FORMAT OUTPUT",
+                    dry_run,
+                )
             else:
-                _echo("uv run ruff check --fix")
-                execute_command([uv, "run", "ruff", "check", "--fix"], "RUFF CHECK OUTPUT", dry_run)
+                _echo(f"uv run ruff format {' '.join(targets)}")
+                execute_command(
+                    [uv, "run", "ruff", "format", *targets], "RUFF FORMAT OUTPUT", dry_run
+                )
 
-        if check_only:
-            _echo("uv run ruff format --check")
-            execute_command([uv, "run", "ruff", "format", "--check"], "RUFF FORMAT OUTPUT", dry_run)
-        else:
-            _echo("uv run ruff format")
-            execute_command([uv, "run", "ruff", "format"], "RUFF FORMAT OUTPUT", dry_run)
-
-    if lang in ("all", "dart"):
+    dart_scope = _scoped_ids(packages, "dart")
+    if lang in ("all", "dart") and dart_scope != []:
         from bootstrap.cli.runtime import run_melos
         from bootstrap.docs import build_bundled_docs
         from bootstrap.docs import build_manual
 
-        _echo("build bundled docs")
-        if dry_run:
-            click.echo(styled([Style.BRIGHT, Fore.YELLOW], "[Dry-Run] Skipping build bundled docs"))
-        else:
-            try:
-                build_bundled_docs()
-                build_manual()
-            except (ValueError, TypeError, FileNotFoundError) as exception:
-                raise click.ClickException(str(exception)) from exception
+        # The bundled docs/manual are only analyzed as part of the app.
+        if dart_scope is None or "eve_fit_assistant" in dart_scope:
+            _echo("build bundled docs")
+            if dry_run:
+                click.echo(
+                    styled([Style.BRIGHT, Fore.YELLOW], "[Dry-Run] Skipping build bundled docs")
+                )
+            else:
+                try:
+                    build_bundled_docs()
+                    build_manual()
+                except (ValueError, TypeError, FileNotFoundError) as exception:
+                    raise click.ClickException(str(exception)) from exception
 
         if not no_check or check_only:
             if not check_only:
                 _echo("melos run app:fix")
-                run_melos("app:fix", "DART FIX OUTPUT")
+                run_melos("app:fix", "DART FIX OUTPUT", scope=dart_scope)
             _echo("melos run app:analyze")
-            run_melos("app:analyze", "DART ANALYZE OUTPUT")
+            run_melos("app:analyze", "DART ANALYZE OUTPUT", scope=dart_scope)
 
         if check_only:
             _echo("melos run app:format:check")
-            run_melos("app:format:check", "DART FORMAT OUTPUT")
+            run_melos("app:format:check", "DART FORMAT OUTPUT", scope=dart_scope)
         else:
             _echo("melos run app:format")
-            run_melos("app:format", "DART FORMAT OUTPUT")
+            run_melos("app:format", "DART FORMAT OUTPUT", scope=dart_scope)
 
-    if lang in ("all", "rust"):
+    rust_scope = _scoped_ids(packages, "rust")
+    if lang in ("all", "rust") and rust_scope != []:
         cargo = get_command("cargo")
-        if check_only:
-            _echo("cargo fmt --check --package rust_lib_eve_fit_assistant")
-            execute_command(
-                [cargo, "fmt", "--check", "--package", "rust_lib_eve_fit_assistant"],
-                "CARGO FMT OUTPUT",
-                dry_run,
-            )
-        else:
-            _echo("cargo fmt --package rust_lib_eve_fit_assistant")
-            execute_command(
-                [cargo, "fmt", "--package", "rust_lib_eve_fit_assistant"],
-                "CARGO FMT OUTPUT",
-                dry_run,
-            )
-
-        if not no_check or check_only:
+        # Unscoped keeps the legacy behavior (the FRB crate only).
+        crates = rust_scope if rust_scope is not None else ["rust_lib_eve_fit_assistant"]
+        for crate in crates:
             if check_only:
-                _echo("cargo clippy --package rust_lib_eve_fit_assistant")
+                _echo(f"cargo fmt --check --package {crate}")
                 execute_command(
-                    [cargo, "clippy", "--package", "rust_lib_eve_fit_assistant"],
-                    "CARGO CLIPPY OUTPUT",
+                    [cargo, "fmt", "--check", "--package", crate],
+                    "CARGO FMT OUTPUT",
                     dry_run,
                 )
             else:
-                _echo("cargo clippy --fix --allow-dirty --package rust_lib_eve_fit_assistant")
+                _echo(f"cargo fmt --package {crate}")
                 execute_command(
-                    [
-                        cargo,
-                        "clippy",
-                        "--fix",
-                        "--allow-dirty",
-                        "--package",
-                        "rust_lib_eve_fit_assistant",
-                    ],
-                    "CARGO CLIPPY OUTPUT",
+                    [cargo, "fmt", "--package", crate],
+                    "CARGO FMT OUTPUT",
                     dry_run,
                 )
 
+            if not no_check or check_only:
+                if check_only:
+                    _echo(f"cargo clippy --package {crate}")
+                    execute_command(
+                        [cargo, "clippy", "--package", crate],
+                        "CARGO CLIPPY OUTPUT",
+                        dry_run,
+                    )
+                else:
+                    _echo(f"cargo clippy --fix --allow-dirty --package {crate}")
+                    execute_command(
+                        [
+                            cargo,
+                            "clippy",
+                            "--fix",
+                            "--allow-dirty",
+                            "--package",
+                            crate,
+                        ],
+                        "CARGO CLIPPY OUTPUT",
+                        dry_run,
+                    )
+
+    ts_scope = _scoped_ids(packages, "ts")
     if lang in ("all", "site") and Path("site/package.json").exists():
         pnpm = get_command("pnpm")
-        run_site_checks(pnpm, no_check=no_check, check_only=check_only, dry_run=dry_run)
+        if ts_scope is None:
+            run_site_checks(pnpm, no_check=no_check, check_only=check_only, dry_run=dry_run)
+        else:
+            targets = _biome_targets(ts_scope, "site/")
+            if targets:
+                _run_biome(pnpm, targets, no_check=no_check, check_only=check_only, dry_run=dry_run)
+                for package_id in _packages_with_script(
+                    [p for p in ts_scope if _PACKAGES_BY_ID[p].path.startswith("site/")], "check"
+                ):
+                    _echo(f"pnpm --filter {package_id} check")
+                    execute_command(
+                        [pnpm, "--filter", package_id, "check"], "SITE CHECK OUTPUT", dry_run
+                    )
 
     if (
         lang in ("all", "snapshot-ts")
         and Path("packages/efa_fit_snapshot_ts/package.json").exists()
+        and ts_scope != []
     ):
         pnpm = get_command("pnpm")
-        run_snapshot_ts_checks(pnpm, no_check=no_check, check_only=check_only, dry_run=dry_run)
+        if ts_scope is None:
+            run_snapshot_ts_checks(pnpm, no_check=no_check, check_only=check_only, dry_run=dry_run)
+        else:
+            targets = _biome_targets(ts_scope, "packages/")
+            if targets:
+                _run_biome(pnpm, targets, no_check=no_check, check_only=check_only, dry_run=dry_run)
+                for package_id in _packages_with_script(
+                    [p for p in ts_scope if _PACKAGES_BY_ID[p].path.startswith("packages/")],
+                    "check",
+                ):
+                    _echo(f"pnpm --filter {package_id} check")
+                    execute_command(
+                        [pnpm, "--filter", package_id, "check"], "SNAPSHOT TS CHECK OUTPUT", dry_run
+                    )
 
     if lang in ("all", "l10n") and (not no_check or check_only):
         from bootstrap.ci.lint_l10n import run_l10n_lint
@@ -131,6 +232,33 @@ def run_lint(
         run_l10n_lint(dry_run=dry_run)
 
     click.echo(styled([Style.BRIGHT, Fore.GREEN], "Linting completed successfully."))
+
+
+def _run_biome(
+    pnpm: str,
+    targets: list[str],
+    *,
+    no_check: bool = False,
+    check_only: bool = False,
+    dry_run: bool = False,
+) -> None:
+    """Run biome format + check over the given path arguments."""
+
+    def _echo(cmd_str: str) -> None:
+        click.echo(styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + cmd_str)
+
+    if check_only:
+        _echo(f"pnpm biome format {' '.join(targets)}")
+        execute_command([pnpm, "biome", "format", *targets], "BIOME FORMAT OUTPUT", dry_run)
+    else:
+        _echo(f"pnpm biome format --write {' '.join(targets)}")
+        execute_command(
+            [pnpm, "biome", "format", "--write", *targets], "BIOME FORMAT OUTPUT", dry_run
+        )
+
+    if not no_check or check_only:
+        _echo(f"pnpm biome check {' '.join(targets)}")
+        execute_command([pnpm, "biome", "check", *targets], "BIOME CHECK OUTPUT", dry_run)
 
 
 def run_site_checks(
@@ -145,19 +273,9 @@ def run_site_checks(
     def _echo(cmd_str: str) -> None:
         click.echo(styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + cmd_str)
 
-    if check_only:
-        _echo("pnpm biome format site/")
-        execute_command([pnpm, "biome", "format", "site/"], "BIOME FORMAT OUTPUT", dry_run)
-    else:
-        _echo("pnpm biome format --write site/")
-        execute_command(
-            [pnpm, "biome", "format", "--write", "site/"], "BIOME FORMAT OUTPUT", dry_run
-        )
+    _run_biome(pnpm, ["site/"], no_check=no_check, check_only=check_only, dry_run=dry_run)
 
     if not no_check or check_only:
-        _echo("pnpm biome check site/")
-        execute_command([pnpm, "biome", "check", "site/"], "BIOME CHECK OUTPUT", dry_run)
-
         _echo("pnpm --filter efa-tech check")
         execute_command([pnpm, "--filter", "efa-tech", "check"], "SVELTE CHECK OUTPUT", dry_run)
 
@@ -174,29 +292,15 @@ def run_snapshot_ts_checks(
     def _echo(cmd_str: str) -> None:
         click.echo(styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + cmd_str)
 
-    if check_only:
-        _echo("pnpm biome format packages/efa_fit_snapshot_ts/")
-        execute_command(
-            [pnpm, "biome", "format", "packages/efa_fit_snapshot_ts/"],
-            "BIOME FORMAT OUTPUT",
-            dry_run,
-        )
-    else:
-        _echo("pnpm biome format --write packages/efa_fit_snapshot_ts/")
-        execute_command(
-            [pnpm, "biome", "format", "--write", "packages/efa_fit_snapshot_ts/"],
-            "BIOME FORMAT OUTPUT",
-            dry_run,
-        )
+    _run_biome(
+        pnpm,
+        ["packages/efa_fit_snapshot_ts/"],
+        no_check=no_check,
+        check_only=check_only,
+        dry_run=dry_run,
+    )
 
     if not no_check or check_only:
-        _echo("pnpm biome check packages/efa_fit_snapshot_ts/")
-        execute_command(
-            [pnpm, "biome", "check", "packages/efa_fit_snapshot_ts/"],
-            "BIOME CHECK OUTPUT",
-            dry_run,
-        )
-
         _echo("pnpm --filter efa-fit-snapshot-ts check")
         execute_command(
             [pnpm, "--filter", "efa-fit-snapshot-ts", "check"],

--- a/bootstrap/ci/suites.py
+++ b/bootstrap/ci/suites.py
@@ -1,226 +1,166 @@
+"""CI suite matrix generation on top of the monorepo dependency graph.
+
+Suite selection is derived from ``bootstrap.monorepo``: changed files are
+mapped to packages, closed over dependents, and each affected suite emits
+fully-resolved lint/test/codegen commands (scoped via ``--packages`` where
+applicable). Infrastructure changes escalate to a full, unscoped run.
+"""
+
 from __future__ import annotations
 
-import re
+from bootstrap.monorepo import ALL_SUITES
+from bootstrap.monorepo import PACKAGES
+from bootstrap.monorepo import AffectedSet
+from bootstrap.monorepo import resolve_affected
+from bootstrap.monorepo.patterns import glob_to_regex
+from bootstrap.monorepo.patterns import match_any_pattern
 
 
-SUITE_DEFINITIONS = [
-    {
-        "suite": "python",
-        "shell": "python",
-        "lint_command": "uv run x.py ci lint --lang python",
-        "command": "uv run x.py test python",
-        "codegen_command": "uv run x.py ci codegen --lang python",
-        "patterns": ["bootstrap/**", "data/**", "x.py", "pyproject.toml", "uv.lock"],
-    },
-    {
-        "suite": "dart",
-        "shell": "dart",
-        "lint_command": "uv run x.py ci lint --lang dart",
-        "command": "uv run x.py test dart",
-        "codegen_command": "uv run x.py ci codegen --lang dart",
-        "patterns": [
-            "apps/eve-fit-assistant/lib/**",
-            "apps/eve-fit-assistant/test/**",
-            "apps/eve-fit-assistant/rust/src/**",
-            "apps/eve-fit-assistant/rust/Cargo.toml",
-            "apps/eve-fit-assistant/pubspec.yaml",
-            "packages/**",
-            "Cargo.toml",
-            "Cargo.lock",
-            "pubspec.yaml",
-            "pubspec.lock",
-        ],
-    },
-    {
-        # Web-platform tests run alongside the Linux native dart suite: same
-        # triggers, same shell, same lint/codegen. No Rust/native data needed.
-        "suite": "dart-web",
-        "shell": "dart",
-        "lint_command": "uv run x.py ci lint --lang dart",
-        "command": "uv run x.py test web",
-        "codegen_command": "uv run x.py ci codegen --lang dart",
-        "patterns": [
-            "apps/eve-fit-assistant/lib/**",
-            "apps/eve-fit-assistant/test/**",
-            "apps/eve-fit-assistant/rust/src/**",
-            "apps/eve-fit-assistant/rust/Cargo.toml",
-            "apps/eve-fit-assistant/pubspec.yaml",
-            "packages/**",
-            "Cargo.toml",
-            "Cargo.lock",
-            "pubspec.yaml",
-            "pubspec.lock",
-        ],
-    },
-    {
-        "suite": "site",
-        "shell": "js",
-        "lint_command": "uv run x.py ci lint --lang site",
-        "command": "true",
-        "codegen_command": "true",
-        "patterns": ["site/**", "pnpm-lock.yaml", "biome.json", "package.json"],
-    },
-    {
-        "suite": "snapshot-ts",
-        "shell": "js",
-        "lint_command": "uv run x.py ci lint --lang snapshot-ts",
-        "command": "true",
-        "codegen_command": "uv run x.py ci codegen --lang snapshot-ts",
-        "patterns": [
-            "packages/efa_fit_snapshot_ts/**",
-            "packages/efa_proto_ts/**",
-            "data/schema/**",
-            "pnpm-workspace.yaml",
-            "pnpm-lock.yaml",
-            "biome.json",
-            "package.json",
-        ],
-    },
-    {
-        "suite": "worker",
-        "shell": "js",
-        "lint_command": "true",
-        "command": "pnpm test:js",
-        # The platform API worker's entrypoint imports the generated TS
-        # protobuf bindings, and the Vitest plugin loads that entrypoint.
-        "codegen_command": "uv run x.py ci codegen --lang snapshot-ts",
-        "patterns": [
-            "worker/**",
-            "packages/efa_proto_ts/**",
-            "data/schema/**",
-            "pnpm-workspace.yaml",
-            "pnpm-lock.yaml",
-            "biome.json",
-            "package.json",
-        ],
-    },
-    {
-        "suite": "workflows",
-        "shell": "ci",
-        "lint_command": "true",
-        "command": "uv run x.py ci zizmor",
-        "codegen_command": "true",
-        "patterns": [
-            ".github/workflows/**",
-            ".github/actions/**",
-            "flake.nix",
-            "flake.lock",
-        ],
-    },
-    {
-        "suite": "l10n",
-        "shell": "python",
-        "lint_command": "uv run x.py ci lint --lang l10n",
-        "command": "true",
-        "codegen_command": "true",
-        "patterns": [
-            "apps/eve-fit-assistant/l10n.yaml",
-            "apps/eve-fit-assistant/l10n/*.arb",
-            "packages/efa_fit_snapshot/l10n.yaml",
-            "packages/efa_fit_snapshot/l10n/*.arb",
-        ],
-    },
-    {
-        "suite": "ci",
-        "shell": "python",
-        "lint_command": "true",
-        "command": "true",
-        "codegen_command": "true",
-        "patterns": ["bootstrap/ci/**", "flake.nix", ".github/workflows/**"],
-    },
+__all__ = [
+    "calculate_ci_matrix",
+    "full_matrix",
+    "glob_to_regex",
+    "match_any_pattern",
+    "matrix_from_affected",
+    "web_preview_affected",
 ]
 
 
-# Paths that can change the Flutter web bundle (build/web) and therefore
-# require a web preview rebuild. Generated Dart output is gitignored, so the
-# sources feeding codegen (proto schemas, ARB files) are included as well.
-WEB_PREVIEW_PATTERNS = [
-    "flake.nix",
-    "flake.lock",
-    "Cargo.toml",
-    "Cargo.lock",
-    "packages/eve-fit-os",
-    "packages/eve-fit-os/**",
-    "apps/eve-fit-assistant/rust/**",
-    "apps/eve-fit-assistant/web/**",
-    "apps/eve-fit-assistant/lib/**",
-    "pubspec.yaml",
-    "pubspec.lock",
-    "apps/eve-fit-assistant/l10n.yaml",
-    "apps/eve-fit-assistant/l10n/*.arb",
-    "data/schema/**",
-    "bootstrap/**",
-    "x.py",
-    "pyproject.toml",
-    "uv.lock",
-    ".github/workflows/web-preview.yml",
-    ".github/workflows/site-nightly.yml",
-    ".github/actions/build-web/**",
-    ".github/actions/deploy-web-pages/**",
-    "ci/config/wrangler.*.toml",
-]
+_SUITE_SHELLS = {
+    "python": "python",
+    "dart": "dart",
+    "dart-web": "dart",
+    "site": "js",
+    "snapshot-ts": "js",
+    "worker": "js",
+    "workflows": "ci",
+    "l10n": "python",
+}
+
+_DART_PACKAGES = frozenset(p.id for p in PACKAGES if p.ecosystem == "dart")
+_TS_PACKAGES = frozenset(p.id for p in PACKAGES if p.ecosystem == "ts")
 
 
-def web_preview_affected(files: list[str]) -> bool:
-    """Check whether changed files require a web preview rebuild."""
-    return any(match_any_pattern(f, WEB_PREVIEW_PATTERNS) for f in files)
+def _packages_option(ids: set[str] | frozenset[str]) -> str:
+    """Render a ``--packages a,b,c`` CLI suffix (empty when unscoped)."""
+    return f" --packages {','.join(sorted(ids))}" if ids else ""
 
 
-def glob_to_regex(pattern: str) -> str:
-    """Convert a glob-style pattern to a prefix-anchored regex."""
-    parts = []
-    i = 0
-    while i < len(pattern):
-        c = pattern[i]
-        if c == "*":
-            if i + 1 < len(pattern) and pattern[i + 1] == "*":
-                parts.append(r".*")
-                i += 1
-            else:
-                parts.append(r"[^/]*")
-        elif c == "?":
-            parts.append(r"[^/]")
-        elif c == ".":
-            parts.append(r"\.")
-        else:
-            parts.append(re.escape(c))
-        i += 1
-    return "^" + "".join(parts) + "$"
+def _entry(suite: str, lint_command: str, command: str, codegen_command: str) -> dict:
+    return {
+        "suite": suite,
+        "shell": _SUITE_SHELLS[suite],
+        "lint_command": lint_command,
+        "command": command,
+        "codegen_command": codegen_command,
+    }
 
 
-def match_any_pattern(file_path: str, patterns: list[str]) -> bool:
-    """Check if a file path matches any of the given glob patterns."""
-    return any(re.match(glob_to_regex(pattern), file_path) for pattern in patterns)
+def _full_entry(suite: str) -> dict:
+    """Unscoped commands for a suite (full runs keep the legacy surface)."""
+    match suite:
+        case "python":
+            return _entry(
+                suite,
+                "uv run x.py ci lint --lang python",
+                "uv run x.py test python",
+                "uv run x.py ci codegen --lang python",
+            )
+        case "dart":
+            return _entry(
+                suite,
+                "uv run x.py ci lint --lang dart",
+                "uv run x.py test dart",
+                "uv run x.py ci codegen --lang dart",
+            )
+        case "dart-web":
+            return _entry(
+                suite,
+                "uv run x.py ci lint --lang dart",
+                "uv run x.py test web",
+                "uv run x.py ci codegen --lang dart",
+            )
+        case "site":
+            return _entry(suite, "uv run x.py ci lint --lang site", "true", "true")
+        case "snapshot-ts":
+            return _entry(
+                suite,
+                "uv run x.py ci lint --lang snapshot-ts",
+                "true",
+                "uv run x.py ci codegen --lang snapshot-ts",
+            )
+        case "worker":
+            return _entry(
+                suite, "true", "pnpm test:js", "uv run x.py ci codegen --lang snapshot-ts"
+            )
+        case "workflows":
+            return _entry(suite, "true", "uv run x.py ci zizmor", "true")
+        case "l10n":
+            return _entry(suite, "uv run x.py ci lint --lang l10n", "true", "true")
+    raise ValueError(f"Unknown suite: {suite}")
+
+
+def _scoped_entry(suite: str, affected: AffectedSet) -> dict:
+    """Fully-resolved commands scoped to the affected package set."""
+    dart = affected.packages & _DART_PACKAGES
+    ts = affected.packages & _TS_PACKAGES
+    match suite:
+        case "dart":
+            return _entry(
+                suite,
+                f"uv run x.py ci lint --lang dart{_packages_option(dart)}",
+                f"uv run x.py test dart{_packages_option(dart)}",
+                "uv run x.py ci codegen --lang dart",
+            )
+        case "dart-web":
+            return _entry(
+                suite,
+                f"uv run x.py ci lint --lang dart{_packages_option(dart)}",
+                "uv run x.py test web",
+                "uv run x.py ci codegen --lang dart",
+            )
+        case "site":
+            return _entry(
+                suite,
+                f"uv run x.py ci lint --lang site{_packages_option(ts)}",
+                "true",
+                "true",
+            )
+        case "snapshot-ts":
+            return _entry(
+                suite,
+                f"uv run x.py ci lint --lang snapshot-ts{_packages_option(ts)}",
+                "true",
+                "uv run x.py ci codegen --lang snapshot-ts",
+            )
+        case "worker":
+            return _entry(
+                suite,
+                "true",
+                f"uv run x.py test js{_packages_option(ts)}",
+                "uv run x.py ci codegen --lang snapshot-ts",
+            )
+        case _:
+            return _full_entry(suite)
+
+
+def matrix_from_affected(affected: AffectedSet) -> list[dict]:
+    """Build the CI job matrix for an already-resolved change set."""
+    if affected.full:
+        return full_matrix()
+    return [_scoped_entry(suite, affected) for suite in ALL_SUITES if suite in affected.suites]
+
+
+def full_matrix() -> list[dict]:
+    """The complete, unscoped CI job matrix."""
+    return [_full_entry(suite) for suite in ALL_SUITES]
 
 
 def calculate_ci_matrix(files: list[str]) -> list[dict]:
     """Determine which CI suites to run based on changed files."""
-    result = []
-    infra_changed = False
-    for suite_def in SUITE_DEFINITIONS:
-        if any(match_any_pattern(f, suite_def["patterns"]) for f in files):
-            if suite_def["suite"] == "ci":
-                infra_changed = True
-            else:
-                result.append(
-                    {
-                        "suite": suite_def["suite"],
-                        "shell": suite_def["shell"],
-                        "lint_command": suite_def["lint_command"],
-                        "command": suite_def["command"],
-                        "codegen_command": suite_def["codegen_command"],
-                    }
-                )
-    if infra_changed:
-        return [
-            {
-                "suite": s["suite"],
-                "shell": s["shell"],
-                "lint_command": s["lint_command"],
-                "command": s["command"],
-                "codegen_command": s["codegen_command"],
-            }
-            for s in SUITE_DEFINITIONS
-            if s["suite"] != "ci"
-        ]
-    return result
+    return matrix_from_affected(resolve_affected(files))
+
+
+def web_preview_affected(files: list[str]) -> bool:
+    """Check whether changed files require a web preview rebuild."""
+    return resolve_affected(files).web

--- a/bootstrap/cli/lint.py
+++ b/bootstrap/cli/lint.py
@@ -22,14 +22,61 @@ def register_lint_commands(cli_group: click.Group) -> None:
         default="all",
         help="Limit linting to a specific language (default: all).",
     )
-    def lint(no_check: bool, check_only: bool, lang: str):
+    @click.option(
+        "--changed",
+        is_flag=True,
+        default=False,
+        help="Only lint packages affected by changes since the base ref.",
+    )
+    @click.option(
+        "--base-ref",
+        default=None,
+        help="Git ref to diff against (default: merge-base with origin/dev).",
+    )
+    @click.option(
+        "--packages",
+        default=None,
+        help="Comma-separated monorepo package ids to restrict linting to.",
+    )
+    def lint(
+        no_check: bool,
+        check_only: bool,
+        lang: str,
+        changed: bool,
+        base_ref: str | None,
+        packages: str | None,
+    ):
         """Lint, fix and format code"""
         if no_check and check_only:
             raise click.ClickException("--no-check and --check cannot be used together.")
-        run_lint(lang, no_check=no_check, check_only=check_only, dry_run=runtime.is_dry_run())
+        package_ids, files = runtime.resolve_change_scope(changed, base_ref, packages)
+        run_lint(
+            lang,
+            no_check=no_check,
+            check_only=check_only,
+            dry_run=runtime.is_dry_run(),
+            packages=package_ids,
+            files=files,
+        )
 
     @cli_group.command("format")
+    @click.option(
+        "--changed",
+        is_flag=True,
+        default=False,
+        help="Only format packages affected by changes since the base ref.",
+    )
+    @click.option(
+        "--base-ref",
+        default=None,
+        help="Git ref to diff against (default: merge-base with origin/dev).",
+    )
+    @click.option(
+        "--packages",
+        default=None,
+        help="Comma-separated monorepo package ids to restrict formatting to.",
+    )
     @click.pass_context
-    def format_cmd(ctx: click.Context):
+    def format_cmd(ctx: click.Context, changed: bool, base_ref: str | None, packages: str | None):
         """Format the code. This is equivalent to `x lint --no-check`."""
-        ctx.invoke(lint, no_check=True)
+        ctx.invoke(lint, no_check=True, changed=changed, base_ref=base_ref, packages=packages)

--- a/bootstrap/cli/runtime.py
+++ b/bootstrap/cli/runtime.py
@@ -58,15 +58,20 @@ def run_melos(
     title: str,
     args: list[str] | None = None,
     live_stdout: bool = False,
+    scope: list[str] | None = None,
 ) -> str:
     """Run a melos script from the workspace root (see root pubspec.yaml).
 
     Extra ``args`` are appended after ``--`` and forwarded to the script's
-    command.
+    command. ``scope`` restricts the run to the named workspace packages,
+    overriding/further restricting the script's ``packageFilters`` (see
+    https://melos.invertase.dev/commands/run).
     """
     from bootstrap.utils import get_melos_command
 
     cmd = [*get_melos_command(), "run", script]
+    if scope:
+        cmd += [f"--scope={name}" for name in scope]
     if args:
         cmd += ["--", *args]
     return execute(cmd, title, live_stdout=live_stdout, cwd=PROJECT_ROOT)
@@ -197,3 +202,42 @@ def run_format() -> None:
     from bootstrap.ci.lint import run_lint
 
     run_lint("all", no_check=True, check_only=False, dry_run=_DRY_RUN)
+
+
+def resolve_change_scope(
+    changed: bool, base_ref: str | None, packages: str | None
+) -> tuple[tuple[str, ...] | None, tuple[str, ...] | None]:
+    """Resolve ``--changed``/``--packages`` CLI options into a work scope.
+
+    Returns ``(package ids, changed files)``; both are ``None`` for the legacy
+    full behavior. Infrastructure changes escalate to a full (unscoped) run.
+    """
+    from bootstrap.monorepo import changed_files_from_git
+    from bootstrap.monorepo import resolve_affected
+
+    if changed and packages:
+        raise click.ClickException("--changed and --packages cannot be used together.")
+    if packages:
+        ids = tuple(p.strip() for p in packages.split(",") if p.strip())
+        return (ids or None), None
+    if not changed:
+        return None, None
+
+    try:
+        files = changed_files_from_git(base_ref)
+    except RuntimeError as exception:
+        raise click.ClickException(str(exception)) from exception
+    affected = resolve_affected(files)
+    if affected.full:
+        click.echo(
+            styled(
+                [Style.BRIGHT, Fore.YELLOW],
+                "Infrastructure files changed; running the full pass.",
+            )
+        )
+        return None, tuple(affected.files)
+    click.echo(
+        styled([Style.BRIGHT, Fore.GREEN], "Affected packages: ")
+        + (", ".join(sorted(affected.packages)) or "(none)")
+    )
+    return tuple(sorted(affected.packages)), tuple(affected.files)

--- a/bootstrap/cli/test.py
+++ b/bootstrap/cli/test.py
@@ -12,13 +12,43 @@ from colorama import Style
 from bootstrap.cli import runtime
 from bootstrap.color import styled
 from bootstrap.constant import EFA_APP_ROOT
+from bootstrap.monorepo import PACKAGES
 from bootstrap.utils import get_command
+from bootstrap.utils import get_melos_command
 
 
 _TEST_ON = re.compile(r"@TestOn\(\s*[\"']([^\"']*)[\"']\s*\)")
 _PLATFORM_IMPORT = re.compile(r"""^import\s+["']dart:(?:io|ffi)["']""", re.MULTILINE)
 
 _WEB_SQLITE_ASSETS = ("db_worker.js", "sqlite3.wasm")
+
+_PACKAGES_BY_ID = {p.id: p for p in PACKAGES}
+
+# Shared click options for change-aware test selection.
+_SCOPE_OPTIONS = [
+    click.option(
+        "--changed",
+        is_flag=True,
+        default=False,
+        help="Only test packages affected by changes since the base ref.",
+    ),
+    click.option(
+        "--base-ref",
+        default=None,
+        help="Git ref to diff against (default: merge-base with origin/dev).",
+    ),
+    click.option(
+        "--packages",
+        default=None,
+        help="Comma-separated monorepo package ids to restrict testing to.",
+    ),
+]
+
+
+def _with_scope_options(func):
+    for option in _SCOPE_OPTIONS:
+        func = option(func)
+    return func
 
 
 def _is_vm_only_expression(expr: str) -> bool:
@@ -90,13 +120,42 @@ def register_test_commands(cli_group: click.Group) -> None:
         runtime.execute([uv, "run", "pytest", "bootstrap/tests/"], "PYTEST OUTPUT")
 
     @test.command("dart")
-    def test_dart():
-        """Run Flutter/Dart tests."""
-        click.echo(styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + "melos run app:test")
-        runtime.run_melos("app:test", "FLUTTER TEST OUTPUT")
+    @_with_scope_options
+    def test_dart(changed: bool, base_ref: str | None, packages: str | None):
+        """Run Flutter/Dart tests.
+
+        With ``--changed``/``--packages``, runs ``flutter test`` only in the
+        affected workspace packages that have test suites.
+        """
+        package_ids, _ = runtime.resolve_change_scope(changed, base_ref, packages)
+        scope = (
+            None
+            if package_ids is None
+            else sorted(p for p in package_ids if _PACKAGES_BY_ID[p].ecosystem == "dart")
+        )
+        if scope is None:
+            click.echo(
+                styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + "melos run app:test"
+            )
+            runtime.run_melos("app:test", "FLUTTER TEST OUTPUT")
+            return
+        testable = [p for p in scope if _PACKAGES_BY_ID[p].tests]
+        if not testable:
+            click.echo(styled([Style.BRIGHT, Fore.YELLOW], "No affected Dart packages with tests."))
+            return
+        click.echo(
+            styled([Style.BRIGHT, Fore.GREEN], "Executing command: ")
+            + f"melos exec --scope=<{len(testable)} affected> -- flutter test"
+        )
+        scopes = [f"--scope={p}" for p in testable]
+        runtime.execute(
+            [*get_melos_command(), "exec", *scopes, "--", "flutter", "test"],
+            "FLUTTER TEST OUTPUT",
+        )
 
     @test.command("web")
-    def test_web():
+    @_with_scope_options
+    def test_web(changed: bool, base_ref: str | None, packages: str | None):
         """Run Flutter/Dart tests on the web platform in headless Chrome.
 
         Suites are compiled to JS (no ``--wasm``): the flutter web test harness
@@ -106,7 +165,20 @@ def register_test_commands(cli_group: click.Group) -> None:
         excluded from the selection because the web test pipeline compiles
         every selected suite regardless of ``@TestOn``, and those suites import
         ``dart:ffi``-only libraries.
+
+        With ``--changed``/``--packages``, the run is skipped unless the app
+        package itself is affected.
         """
+        package_ids, _ = runtime.resolve_change_scope(changed, base_ref, packages)
+        if package_ids is not None and "eve_fit_assistant" not in package_ids:
+            click.echo(
+                styled(
+                    [Style.BRIGHT, Fore.YELLOW],
+                    "App package not affected; skipping web tests.",
+                )
+            )
+            return
+
         chrome = os.environ.get("CHROME_EXECUTABLE")
         if not chrome:
             for candidate in ("google-chrome", "chromium", "chrome"):
@@ -134,20 +206,47 @@ def register_test_commands(cli_group: click.Group) -> None:
         )
 
     @test.command("js")
-    def test_js():
-        """Run JS/TS tests (Vitest, incl. the Cloudflare Workers suites)."""
+    @_with_scope_options
+    def test_js(changed: bool, base_ref: str | None, packages: str | None):
+        """Run JS/TS tests (Vitest, incl. the Cloudflare Workers suites).
+
+        With ``--changed``/``--packages``, runs ``pnpm --filter <id> test``
+        only for the affected packages that define a test script.
+        """
+        package_ids, _ = runtime.resolve_change_scope(changed, base_ref, packages)
         pnpm = get_command("pnpm")
-        click.echo(styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + "pnpm test:js")
-        runtime.execute([pnpm, "test:js"], "VITEST OUTPUT")
+        if package_ids is None:
+            click.echo(styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + "pnpm test:js")
+            runtime.execute([pnpm, "test:js"], "VITEST OUTPUT")
+            return
+        testable = [
+            p
+            for p in package_ids
+            if p in _PACKAGES_BY_ID
+            and _PACKAGES_BY_ID[p].ecosystem == "ts"
+            and _PACKAGES_BY_ID[p].tests
+        ]
+        if not testable:
+            click.echo(styled([Style.BRIGHT, Fore.YELLOW], "No affected TS packages with tests."))
+            return
+        cmd = [pnpm]
+        for package_id in sorted(testable):
+            cmd += ["--filter", package_id]
+        cmd.append("test")
+        click.echo(styled([Style.BRIGHT, Fore.GREEN], "Executing command: ") + " ".join(cmd[1:]))
+        runtime.execute(cmd, "VITEST OUTPUT")
 
     @test.command("all")
-    def test_all():
+    @_with_scope_options
+    @click.pass_context
+    def test_all(ctx: click.Context, changed: bool, base_ref: str | None, packages: str | None):
         """Run all test suites (Python + Dart + Web + JS)."""
-        ctx = click.get_current_context()
+        package_ids, _ = runtime.resolve_change_scope(changed, base_ref, packages)
+        scope = ",".join(package_ids) if package_ids is not None else None
         ctx.invoke(test_python)
         click.echo()
-        ctx.invoke(test_dart)
+        ctx.invoke(test_dart, changed=False, base_ref=None, packages=scope)
         click.echo()
-        ctx.invoke(test_web)
+        ctx.invoke(test_web, changed=False, base_ref=None, packages=scope)
         click.echo()
-        ctx.invoke(test_js)
+        ctx.invoke(test_js, changed=False, base_ref=None, packages=scope)

--- a/bootstrap/cli/test.py
+++ b/bootstrap/cli/test.py
@@ -24,6 +24,18 @@ _WEB_SQLITE_ASSETS = ("db_worker.js", "sqlite3.wasm")
 
 _PACKAGES_BY_ID = {p.id: p for p in PACKAGES}
 
+# Paths whose changes make the Python test suite relevant (mirrors the
+# ``suites=("python",)`` meta entries in ``bootstrap.monorepo.packages``;
+# there is no Python package in the registry to scope by).
+_PYTHON_SCOPE_PREFIXES = ("bootstrap/", "data/")
+_PYTHON_SCOPE_FILES = ("x.py", "pyproject.toml", "uv.lock")
+
+
+def _python_scope_hit(files: tuple[str, ...]) -> bool:
+    """Whether any changed file affects the Python tooling/test suite."""
+    return any(f.startswith(_PYTHON_SCOPE_PREFIXES) or f in _PYTHON_SCOPE_FILES for f in files)
+
+
 # Shared click options for change-aware test selection.
 _SCOPE_OPTIONS = [
     click.option(
@@ -240,11 +252,17 @@ def register_test_commands(cli_group: click.Group) -> None:
     @_with_scope_options
     @click.pass_context
     def test_all(ctx: click.Context, changed: bool, base_ref: str | None, packages: str | None):
-        """Run all test suites (Python + Dart + Web + JS)."""
-        package_ids, _ = runtime.resolve_change_scope(changed, base_ref, packages)
+        """Run all test suites (Python + Dart + Web + JS).
+
+        With ``--changed``/``--packages``, the Dart/Web/JS runs are restricted
+        to the affected packages and the Python suite runs only when the
+        resolved scope is unscoped or includes Python-relevant changes.
+        """
+        package_ids, files = runtime.resolve_change_scope(changed, base_ref, packages)
         scope = ",".join(package_ids) if package_ids is not None else None
-        ctx.invoke(test_python)
-        click.echo()
+        if package_ids is None or (files is not None and _python_scope_hit(files)):
+            ctx.invoke(test_python)
+            click.echo()
         ctx.invoke(test_dart, changed=False, base_ref=None, packages=scope)
         click.echo()
         ctx.invoke(test_web, changed=False, base_ref=None, packages=scope)

--- a/bootstrap/monorepo/__init__.py
+++ b/bootstrap/monorepo/__init__.py
@@ -1,0 +1,36 @@
+"""Change-aware monorepo model: package registry, dependency graph, resolution.
+
+This package is the single source of truth for selecting what to lint, test,
+and build in response to a set of changed files. It is consumed by the CI
+matrix generator (``bootstrap.ci.suites``), the change-aware lint/test
+commands, and the web-preview gate.
+"""
+
+from __future__ import annotations
+
+from bootstrap.monorepo.graph import ALL_SUITES
+from bootstrap.monorepo.graph import AffectedSet
+from bootstrap.monorepo.graph import changed_files_from_git
+from bootstrap.monorepo.graph import resolve_affected
+from bootstrap.monorepo.graph import web_relevant_packages
+from bootstrap.monorepo.packages import META_ENTRIES
+from bootstrap.monorepo.packages import PACKAGES
+from bootstrap.monorepo.packages import MetaEntry
+from bootstrap.monorepo.packages import Package
+from bootstrap.monorepo.patterns import glob_to_regex
+from bootstrap.monorepo.patterns import match_any_pattern
+
+
+__all__ = [
+    "ALL_SUITES",
+    "META_ENTRIES",
+    "PACKAGES",
+    "AffectedSet",
+    "MetaEntry",
+    "Package",
+    "changed_files_from_git",
+    "glob_to_regex",
+    "match_any_pattern",
+    "resolve_affected",
+    "web_relevant_packages",
+]

--- a/bootstrap/monorepo/graph.py
+++ b/bootstrap/monorepo/graph.py
@@ -1,0 +1,206 @@
+"""Resolve changed files to affected packages, suites, and the web gate."""
+
+from __future__ import annotations
+
+import subprocess
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bootstrap.constant import PROJECT_ROOT
+from bootstrap.monorepo.packages import META_ENTRIES
+from bootstrap.monorepo.packages import PACKAGES
+from bootstrap.monorepo.patterns import match_any_pattern
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+# Canonical CI suite identifiers. The "ci" suite is intentionally absent: it
+# only exists as the full-run escalation encoded by MetaEntry(full=True).
+ALL_SUITES: tuple[str, ...] = (
+    "python",
+    "dart",
+    "dart-web",
+    "site",
+    "snapshot-ts",
+    "worker",
+    "workflows",
+    "l10n",
+)
+
+_PACKAGES_BY_ID = {p.id: p for p in PACKAGES}
+
+
+def _dependents_map() -> dict[str, set[str]]:
+    """Map each package id to the set of packages that depend on it."""
+    dependents: dict[str, set[str]] = {p.id: set() for p in PACKAGES}
+    for package in PACKAGES:
+        for dep in package.depends_on:
+            if dep not in dependents:
+                raise ValueError(f"Unknown dependency {dep!r} declared by {package.id!r}")
+            dependents[dep].add(package.id)
+    return dependents
+
+
+_DEPENDENTS = _dependents_map()
+
+
+@dataclass(frozen=True)
+class AffectedSet:
+    """Result of resolving a set of changed files."""
+
+    full: bool  # infrastructure escalation: run every suite
+    files: tuple[str, ...]  # normalized changed files
+    packages: frozenset[str]  # affected package ids (including dependents)
+    suites: frozenset[str]  # affected CI suites
+    web: bool  # the Flutter web bundle may be affected
+
+
+def packages_of_ecosystem(ecosystem: str) -> frozenset[str]:
+    return frozenset(p.id for p in PACKAGES if p.ecosystem == ecosystem)
+
+
+def _match_package(path: str) -> str | None:
+    """Return the id of the package whose directory contains ``path``."""
+    best: str | None = None
+    for package in PACKAGES:
+        # Nested packages (e.g. efa-chat inside the FRB crate): the most
+        # specific path wins.
+        if (path == package.path or path.startswith(package.path + "/")) and (
+            best is None or len(package.path) > len(_PACKAGES_BY_ID[best].path)
+        ):
+            best = package.id
+    return best
+
+
+def web_relevant_packages() -> frozenset[str]:
+    """Packages whose sources feed the Flutter web bundle.
+
+    Computed as the forward dependency closure of the Flutter app, which
+    includes its Dart dependencies and, via the documented cargokit edge,
+    the FRB Rust crates (and therefore ``eve-fit-os``).
+    """
+    seen: set[str] = set()
+    stack = ["eve_fit_assistant"]
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(_PACKAGES_BY_ID[current].depends_on)
+    return frozenset(seen)
+
+
+def resolve_affected(files: Iterable[str]) -> AffectedSet:
+    """Map changed files to the affected packages, suites, and web gate.
+
+    The affected package set is closed over dependents: a change to a base
+    package (e.g. ``efa_proto``) marks every package depending on it (e.g.
+    the app) as affected. Meta entries can additionally pull in whole
+    ecosystems, extra suites, or escalate to a full run.
+    """
+    normalized = tuple(dict.fromkeys(f.strip() for f in files if f.strip()))
+
+    full = False
+    web = False
+    direct: set[str] = set()
+    suites: set[str] = set()
+
+    for path in normalized:
+        matched = _match_package(path)
+        if matched is not None:
+            direct.add(matched)
+        for entry in META_ENTRIES:
+            if match_any_pattern(path, entry.patterns):
+                full = full or entry.full
+                web = web or entry.web
+                direct.update(entry.packages)
+                for ecosystem in entry.ecosystems:
+                    direct.update(packages_of_ecosystem(ecosystem))
+                suites.update(entry.suites)
+
+    # Close over dependents.
+    affected = set(direct)
+    stack = list(direct)
+    while stack:
+        current = stack.pop()
+        for dependent in _DEPENDENTS[current]:
+            if dependent not in affected:
+                affected.add(dependent)
+                stack.append(dependent)
+
+    for package_id in affected:
+        suites.update(_PACKAGES_BY_ID[package_id].suites)
+
+    web = web or full or bool(affected & web_relevant_packages())
+    if full:
+        suites.update(ALL_SUITES)
+
+    return AffectedSet(
+        full=full,
+        files=normalized,
+        packages=frozenset(affected),
+        suites=frozenset(suites),
+        web=web,
+    )
+
+
+def _git(args: list[str]) -> list[str]:
+    out = subprocess.run(
+        ["git", *args],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {out.stderr.strip()}")
+    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
+def changed_files_from_git(base_ref: str | None = None) -> list[str]:
+    """Collect files changed relative to ``base_ref`` plus uncommitted changes.
+
+    ``base_ref`` defaults to the merge-base of ``HEAD`` with ``origin/dev``.
+    Unstaged, staged, and untracked changes are included so local
+    ``--changed`` runs cover work in progress.
+    """
+    if base_ref is None:
+        candidates = ["origin/dev", "origin/main", "dev", "main"]
+        base_ref = next(
+            (ref for ref in candidates if _try_merge_base(ref) is not None),
+            None,
+        )
+        if base_ref is None:
+            raise RuntimeError("Could not determine a base ref; pass --base-ref explicitly.")
+        base = _try_merge_base(base_ref)
+        assert base is not None
+    else:
+        base = _try_merge_base(base_ref)
+        if base is None:
+            raise RuntimeError(f"Could not resolve merge-base with {base_ref!r}.")
+
+    files = set(_git(["diff", "--name-only", base, "HEAD"]))
+    files.update(_git(["diff", "--name-only"]))
+    files.update(_git(["diff", "--name-only", "--cached"]))
+    files.update(_git(["ls-files", "--others", "--exclude-standard"]))
+    return sorted(files)
+
+
+def _try_merge_base(ref: str) -> str | None:
+    out = subprocess.run(
+        ["git", "merge-base", ref, "HEAD"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip() or None

--- a/bootstrap/monorepo/packages.py
+++ b/bootstrap/monorepo/packages.py
@@ -1,0 +1,286 @@
+"""Static registry of monorepo packages and non-package blast radii.
+
+This module is the single source of truth for change-aware selection:
+changed files are mapped to packages, the dependency graph expands them to
+their dependents, and lint/test/suite commands are derived from the result.
+
+The registry is validated against the real manifests (root ``pubspec.yaml``
+workspace list, per-package ``pubspec.yaml``/``package.json``/``Cargo.toml``,
+and ``pnpm-workspace.yaml``) by ``bootstrap/tests/test_monorepo.py``. When
+adding or removing a package, update this file; the consistency tests will
+fail otherwise.
+
+Edges are declared from the dependent to its dependency, exactly as written
+in the manifests, plus one documented cross-language edge: the Flutter app
+depends on its FRB Rust crate through cargokit (``rust_builder``), which is
+not visible to pub.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Package:
+    """A lintable/testable package in the monorepo."""
+
+    id: str  # manifest name (pubspec name / package.json name / crate name)
+    path: str  # repo-relative package directory
+    ecosystem: str  # "dart" | "ts" | "rust"
+    depends_on: tuple[str, ...] = ()  # intra-repo edges (dependent -> dependency)
+    suites: tuple[str, ...] = ()  # CI suites this package directly feeds
+    tests: bool = False  # the package has its own test suite
+
+
+# Edges that are declared in the registry but intentionally absent from the
+# manifests (cross-language build wiring). The consistency tests allow
+# exactly these extras.
+ALLOWED_EXTRA_EDGES: frozenset[tuple[str, str]] = frozenset(
+    {
+        # cargokit (rust_builder) builds the FRB crate into the Flutter app.
+        ("eve_fit_assistant", "rust_lib_eve_fit_assistant"),
+    }
+)
+
+
+PACKAGES: tuple[Package, ...] = (
+    # ------------------------------------------------------------------ Dart
+    Package(
+        id="eve_fit_assistant",
+        path="apps/eve-fit-assistant",
+        ecosystem="dart",
+        depends_on=(
+            "efa_compat",
+            "efa_acl",
+            "efa_component",
+            "efa_constant",
+            "efa_fit",
+            "efa_platform_client",
+            "efa_proto",
+            "rust_lib_eve_fit_assistant",
+        ),
+        suites=("dart", "dart-web"),
+        tests=True,
+    ),
+    Package(
+        id="acl",
+        path="packages/acl/dart",
+        ecosystem="dart",
+        suites=("dart", "dart-web"),
+        tests=True,
+    ),
+    Package(
+        id="efa_acl",
+        path="packages/efa_acl/dart",
+        ecosystem="dart",
+        depends_on=("acl",),
+        suites=("dart", "dart-web"),
+        tests=True,
+    ),
+    Package(
+        id="efa_compat", path="packages/efa_compat", ecosystem="dart", suites=("dart", "dart-web")
+    ),
+    Package(
+        id="efa_component",
+        path="packages/efa_component",
+        ecosystem="dart",
+        suites=("dart", "dart-web"),
+        tests=True,
+    ),
+    Package(
+        id="efa_constant",
+        path="packages/efa_constant",
+        ecosystem="dart",
+        suites=("dart", "dart-web"),
+    ),
+    Package(
+        id="efa_fit",
+        path="packages/efa_fit",
+        ecosystem="dart",
+        depends_on=("efa_proto",),
+        suites=("dart", "dart-web"),
+        tests=True,
+    ),
+    Package(
+        id="efa_fit_snapshot",
+        path="packages/efa_fit_snapshot",
+        ecosystem="dart",
+        depends_on=("efa_component", "efa_fit", "efa_proto"),
+        suites=("dart", "dart-web"),
+        tests=True,
+    ),
+    Package(
+        id="efa_platform_client",
+        path="packages/efa_platform_client",
+        ecosystem="dart",
+        depends_on=("efa_proto",),
+        suites=("dart", "dart-web"),
+        tests=True,
+    ),
+    Package(
+        id="efa_proto", path="packages/efa_proto", ecosystem="dart", suites=("dart", "dart-web")
+    ),
+    # ------------------------------------------------------------------ Rust
+    Package(
+        id="rust_lib_eve_fit_assistant",
+        path="apps/eve-fit-assistant/rust",
+        ecosystem="rust",
+        depends_on=("efa-chat", "eve-fit-os"),
+        suites=("dart", "dart-web"),
+    ),
+    Package(
+        id="efa-chat",
+        path="apps/eve-fit-assistant/rust/lib/efa-chat",
+        ecosystem="rust",
+        depends_on=("eve-fit-os",),
+        suites=("dart", "dart-web"),
+    ),
+    Package(id="eve-fit-os", path="packages/eve-fit-os", ecosystem="rust"),
+    Package(id="release", path="worker/release", ecosystem="rust", suites=("worker",)),
+    Package(
+        id="efa-platform-fit-storage",
+        path="worker/efa-platform-fit-storage",
+        ecosystem="rust",
+        depends_on=("eve-fit-os",),
+        suites=("worker",),
+    ),
+    # ------------------------------------------------------------- TypeScript
+    Package(id="efa-tech", path="site/home", ecosystem="ts", suites=("site",)),
+    Package(id="manual", path="site/manual", ecosystem="ts", suites=("site",)),
+    Package(
+        id="efa-platform",
+        path="site/platform",
+        ecosystem="ts",
+        depends_on=(
+            "efa-acl-ts",
+            "efa-fit-snapshot-ts",
+            "efa-platform-client-ts",
+            "efa-proto-ts",
+        ),
+        suites=("site",),
+    ),
+    Package(
+        id="efa-platform-api",
+        path="worker/efa-platform-api",
+        ecosystem="ts",
+        depends_on=("efa-acl-ts", "efa-proto-ts"),
+        suites=("worker",),
+        tests=True,
+    ),
+    Package(
+        id="efa-platform-data-sync",
+        path="worker/efa-platform-data-sync",
+        ecosystem="ts",
+        suites=("worker",),
+        tests=True,
+    ),
+    Package(id="email-filter", path="worker/email-filter", ecosystem="ts", suites=("worker",)),
+    Package(id="issue-redirect", path="worker/issue-redirect", ecosystem="ts", suites=("worker",)),
+    Package(id="acl-ts", path="packages/acl/ts", ecosystem="ts", depends_on=("acl-tool",)),
+    Package(id="acl-tool", path="packages/acl/tool", ecosystem="ts"),
+    Package(id="efa-acl-ts", path="packages/efa_acl/ts", ecosystem="ts", depends_on=("acl-ts",)),
+    Package(id="efa-platform-client-ts", path="packages/efa_platform_client_ts", ecosystem="ts"),
+    Package(
+        id="efa-proto-ts", path="packages/efa_proto_ts", ecosystem="ts", suites=("snapshot-ts",)
+    ),
+    Package(
+        id="efa-fit-snapshot-ts",
+        path="packages/efa_fit_snapshot_ts",
+        ecosystem="ts",
+        depends_on=("efa-proto-ts",),
+        suites=("snapshot-ts",),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class MetaEntry:
+    """Non-package (or cross-package) paths with an explicit blast radius."""
+
+    id: str
+    patterns: tuple[str, ...]
+    packages: tuple[str, ...] = ()  # packages directly affected
+    ecosystems: tuple[str, ...] = ()  # every package of these ecosystems
+    suites: tuple[str, ...] = ()  # additional CI suites affected
+    full: bool = False  # escalate to a full CI run
+    web: bool = False  # affects the Flutter web bundle
+
+
+META_ENTRIES: tuple[MetaEntry, ...] = (
+    # Infrastructure changes fail safe: run everything.
+    MetaEntry(
+        id="infra-ci",
+        patterns=("bootstrap/ci/**", "flake.nix", ".github/workflows/**"),
+        full=True,
+    ),
+    # Python tooling feeds the codegen pipeline that produces the web bundle.
+    MetaEntry(
+        id="python-tooling",
+        patterns=("bootstrap/**", "x.py", "pyproject.toml", "uv.lock"),
+        suites=("python",),
+        web=True,
+    ),
+    # Protobuf schemas generate code consumed by Dart and TS packages.
+    MetaEntry(
+        id="data-schema",
+        patterns=("data/schema/**",),
+        packages=("efa_proto", "efa-proto-ts"),
+        suites=("python",),
+        web=True,
+    ),
+    MetaEntry(
+        id="data-raw",
+        patterns=("data/**",),
+        suites=("python",),
+    ),
+    # Workspace-level manifests affect their whole ecosystem.
+    MetaEntry(
+        id="dart-root",
+        patterns=("pubspec.yaml", "pubspec.lock"),
+        ecosystems=("dart",),
+        web=True,
+    ),
+    MetaEntry(
+        id="rust-root",
+        patterns=("Cargo.toml", "Cargo.lock"),
+        ecosystems=("rust",),
+        web=True,
+    ),
+    MetaEntry(
+        id="ts-root",
+        patterns=("pnpm-workspace.yaml", "pnpm-lock.yaml", "biome.json", "package.json"),
+        ecosystems=("ts",),
+    ),
+    MetaEntry(
+        id="flake-lock",
+        patterns=("flake.lock",),
+        suites=("workflows",),
+        web=True,
+    ),
+    MetaEntry(
+        id="github-actions",
+        patterns=(".github/**",),
+        suites=("workflows",),
+    ),
+    MetaEntry(
+        id="l10n",
+        patterns=(
+            "apps/eve-fit-assistant/l10n.yaml",
+            "apps/eve-fit-assistant/l10n/*.arb",
+            "packages/efa_fit_snapshot/l10n.yaml",
+            "packages/efa_fit_snapshot/l10n/*.arb",
+        ),
+        suites=("l10n",),
+    ),
+    # Web delivery plumbing (Cloudflare Pages) only affects the web bundle.
+    MetaEntry(
+        id="web-delivery",
+        patterns=(
+            ".github/actions/build-web/**",
+            ".github/actions/deploy-web-pages/**",
+            "ci/config/wrangler.*.toml",
+        ),
+        web=True,
+    ),
+)

--- a/bootstrap/monorepo/packages.py
+++ b/bootstrap/monorepo/packages.py
@@ -208,10 +208,19 @@ class MetaEntry:
 
 
 META_ENTRIES: tuple[MetaEntry, ...] = (
-    # Infrastructure changes fail safe: run everything.
+    # Infrastructure changes fail safe: run everything. This includes the
+    # selection sources themselves (the monorepo registry/graph and the CLI
+    # scope resolver): a defect in the code that decides what CI runs must
+    # not merge with suites unrun.
     MetaEntry(
         id="infra-ci",
-        patterns=("bootstrap/ci/**", "flake.nix", ".github/workflows/**"),
+        patterns=(
+            "bootstrap/ci/**",
+            "bootstrap/monorepo/**",
+            "bootstrap/cli/runtime.py",
+            "flake.nix",
+            ".github/workflows/**",
+        ),
         full=True,
     ),
     # Python tooling feeds the codegen pipeline that produces the web bundle.

--- a/bootstrap/monorepo/patterns.py
+++ b/bootstrap/monorepo/patterns.py
@@ -1,0 +1,32 @@
+"""Glob-style path matching helpers (prefix-anchored, ``**`` = any depth)."""
+
+from __future__ import annotations
+
+import re
+
+
+def glob_to_regex(pattern: str) -> str:
+    """Convert a glob-style pattern to a prefix-anchored regex."""
+    parts = []
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < len(pattern) and pattern[i + 1] == "*":
+                parts.append(r".*")
+                i += 1
+            else:
+                parts.append(r"[^/]*")
+        elif c == "?":
+            parts.append(r"[^/]")
+        elif c == ".":
+            parts.append(r"\.")
+        else:
+            parts.append(re.escape(c))
+        i += 1
+    return "^" + "".join(parts) + "$"
+
+
+def match_any_pattern(file_path: str, patterns: list[str] | tuple[str, ...]) -> bool:
+    """Check if a file path matches any of the given glob patterns."""
+    return any(re.match(glob_to_regex(pattern), file_path) for pattern in patterns)

--- a/bootstrap/tests/test_ci_suites.py
+++ b/bootstrap/tests/test_ci_suites.py
@@ -1,31 +1,28 @@
 from __future__ import annotations
 
-from bootstrap.ci.suites import SUITE_DEFINITIONS
-from bootstrap.ci.suites import WEB_PREVIEW_PATTERNS
 from bootstrap.ci.suites import calculate_ci_matrix
+from bootstrap.ci.suites import full_matrix
 from bootstrap.ci.suites import web_preview_affected
+from bootstrap.monorepo import ALL_SUITES
 
 
 def _suite_names(files: list[str]) -> set[str]:
     return {entry["suite"] for entry in calculate_ci_matrix(files)}
 
 
-def _suite_def(name: str) -> dict:
-    return next(s for s in SUITE_DEFINITIONS if s["suite"] == name)
+def _suite_entry(files: list[str], name: str) -> dict:
+    return next(e for e in calculate_ci_matrix(files) if e["suite"] == name)
 
 
-def test_dart_web_mirrors_dart_triggers_and_environment():
-    dart = _suite_def("dart")
-    dart_web = _suite_def("dart-web")
-
-    assert dart_web["patterns"] == dart["patterns"]
-    assert dart_web["shell"] == dart["shell"]
-    assert dart_web["lint_command"] == dart["lint_command"]
-    assert dart_web["codegen_command"] == dart["codegen_command"]
-    assert dart_web["command"] == "uv run x.py test web"
+def test_full_matrix_covers_all_suites_unscoped():
+    entries = full_matrix()
+    assert {e["suite"] for e in entries} == set(ALL_SUITES)
+    for entry in entries:
+        assert "--packages" not in entry["lint_command"]
+        assert "--packages" not in entry["command"]
 
 
-def test_dart_web_included_for_dart_changes():
+def test_dart_and_dart_web_included_for_app_changes():
     names = _suite_names(["apps/eve-fit-assistant/lib/main.dart"])
     assert "dart" in names
     assert "dart-web" in names
@@ -33,27 +30,67 @@ def test_dart_web_included_for_dart_changes():
 
 def test_dart_web_not_included_for_python_only_changes():
     names = _suite_names(["bootstrap/cli/test.py"])
-    assert "dart-web" not in names
+    assert names == {"python"}
 
 
-def test_dart_web_included_on_infra_change():
+def test_all_suites_on_infra_change():
     names = _suite_names(["bootstrap/ci/suites.py"])
-    assert "dart-web" in names
+    assert names == set(ALL_SUITES)
 
 
-def test_package_changes_trigger_dart_suites():
+def test_infra_matrix_is_unscoped():
+    for entry in calculate_ci_matrix(["flake.nix"]):
+        assert "--packages" not in entry["lint_command"]
+        assert "--packages" not in entry["command"]
+
+
+def test_package_changes_trigger_dart_suites_and_l10n():
     names = _suite_names(["packages/efa_fit_snapshot/l10n/snapshot_zh.arb"])
     assert "dart" in names
     assert "dart-web" in names
     assert "l10n" in names
 
 
-def test_worker_changes_trigger_worker_suite():
+def test_worker_changes_trigger_worker_suite_only():
     names = _suite_names(["worker/efa-platform-api/src/index.ts"])
     assert names == {"worker"}
 
 
-def test_web_preview_patterns_cover_core_build_inputs():
+def test_ts_only_package_change_does_not_trigger_dart():
+    # The legacy glob matrix matched every `packages/**` change to the Dart
+    # suites; the graph restricts this to real dependents.
+    names = _suite_names(["packages/efa_fit_snapshot_ts/src/index.ts"])
+    assert "snapshot-ts" in names
+    assert "dart" not in names
+    assert "dart-web" not in names
+
+
+def test_dart_suite_commands_are_scoped_to_affected_packages():
+    entry = _suite_entry(["packages/efa_fit/lib/fit.dart"], "dart")
+    # efa_fit_snapshot and the app both (transitively) depend on efa_fit.
+    expected = "--packages efa_fit,efa_fit_snapshot,eve_fit_assistant"
+    assert expected in entry["lint_command"]
+    assert expected in entry["command"]
+    assert entry["codegen_command"] == "uv run x.py ci codegen --lang dart"
+
+
+def test_dart_web_mirrors_dart_scoping():
+    files = ["packages/efa_fit/lib/fit.dart"]
+    dart = _suite_entry(files, "dart")
+    dart_web = _suite_entry(files, "dart-web")
+    assert dart_web["shell"] == dart["shell"]
+    assert dart_web["lint_command"] == dart["lint_command"]
+    assert dart_web["codegen_command"] == dart["codegen_command"]
+    assert dart_web["command"] == "uv run x.py test web"
+
+
+def test_worker_suite_scopes_js_tests():
+    entry = _suite_entry(["packages/efa_proto_ts/src/index.ts"], "worker")
+    assert entry["command"].startswith("uv run x.py test js --packages ")
+    assert "efa-platform-api" in entry["command"]
+
+
+def test_web_preview_covers_core_build_inputs():
     for path in [
         "flake.nix",
         "flake.lock",
@@ -73,6 +110,7 @@ def test_web_preview_patterns_cover_core_build_inputs():
         "pyproject.toml",
         "uv.lock",
         ".github/workflows/web-preview.yml",
+        "ci/config/wrangler.nightly.toml",
     ]:
         assert web_preview_affected([path]), f"expected {path} to trigger web preview"
 
@@ -82,18 +120,23 @@ def test_web_preview_unaffected_by_unrelated_changes():
         [
             "site/home/src/routes/+page.svelte",
             "docs/manual/intro.md",
-            ".github/workflows/ci.yml",
             "AGENTS.md",
             "README.md",
         ]
     )
 
 
+def test_web_preview_follows_infra_escalation():
+    # Infrastructure changes run the full matrix; the web bundle is rebuilt
+    # as part of it, so the preview gate must agree.
+    assert web_preview_affected([".github/workflows/ci.yml"])
+    assert web_preview_affected(["bootstrap/ci/commands.py"])
+
+
 def test_web_preview_empty_change_list():
     assert not web_preview_affected([])
 
 
-def test_web_preview_patterns_are_anchored():
-    # Sibling paths sharing a prefix must not match directory patterns.
-    assert not web_preview_affected(["webfoo/x.txt", "library/main.dart"])
-    assert "apps/eve-fit-assistant/web/**" in WEB_PREVIEW_PATTERNS
+def test_web_preview_ignores_prefix_siblings():
+    # Sibling paths sharing a prefix must not match package directories.
+    assert not web_preview_affected(["apps/eve-fit-assistant-webfoo/x.txt"])

--- a/bootstrap/tests/test_ci_suites.py
+++ b/bootstrap/tests/test_ci_suites.py
@@ -38,6 +38,17 @@ def test_all_suites_on_infra_change():
     assert names == set(ALL_SUITES)
 
 
+def test_all_suites_on_selection_source_change():
+    # The registry/graph and the scope resolver decide what CI runs; a defect
+    # there must not merge with the dart, site, worker, or l10n suites unrun.
+    for path in [
+        "bootstrap/monorepo/packages.py",
+        "bootstrap/monorepo/graph.py",
+        "bootstrap/cli/runtime.py",
+    ]:
+        assert _suite_names([path]) == set(ALL_SUITES), path
+
+
 def test_infra_matrix_is_unscoped():
     for entry in calculate_ci_matrix(["flake.nix"]):
         assert "--packages" not in entry["lint_command"]

--- a/bootstrap/tests/test_cli_test_all.py
+++ b/bootstrap/tests/test_cli_test_all.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import click
+
+from click.testing import CliRunner
+
+from bootstrap.cli import runtime
+from bootstrap.cli.test import register_test_commands
+
+
+def _run_test_all(monkeypatch, scope, argv):
+    executed: list[list[str]] = []
+    monkeypatch.setattr(runtime, "execute", lambda cmd, *a, **k: executed.append(list(cmd)))
+    monkeypatch.setattr(runtime, "run_melos", lambda *a, **k: executed.append(["melos"]))
+    monkeypatch.setattr(runtime, "resolve_change_scope", lambda *a: scope)
+    monkeypatch.setattr("bootstrap.cli.test.get_command", lambda name: name)
+    monkeypatch.setattr("bootstrap.cli.test.get_melos_command", lambda: ["melos"])
+    cli = click.Group()
+    register_test_commands(cli)
+    result = CliRunner().invoke(cli, ["test", "all", *argv])
+    assert result.exit_code == 0, result.output
+    return executed
+
+
+def _ran_pytest(executed: list[list[str]]) -> bool:
+    return any("pytest" in cmd for cmd in executed)
+
+
+def test_all_unscoped_runs_python(monkeypatch):
+    executed = _run_test_all(monkeypatch, (None, None), [])
+    assert _ran_pytest(executed)
+
+
+def test_all_skips_python_for_dart_only_package_scope(monkeypatch):
+    executed = _run_test_all(monkeypatch, (("efa_fit",), None), ["--packages", "efa_fit"])
+    assert not _ran_pytest(executed)
+    assert any("exec" in cmd for cmd in executed)  # scoped dart run still happens
+
+
+def test_all_skips_python_for_dart_only_changes(monkeypatch):
+    scope = (("efa_fit",), ("packages/efa_fit/lib/fit.dart",))
+    executed = _run_test_all(monkeypatch, scope, ["--changed"])
+    assert not _ran_pytest(executed)
+
+
+def test_all_runs_python_for_python_relevant_changes(monkeypatch):
+    scope = (("efa_fit",), ("bootstrap/cli/build.py",))
+    executed = _run_test_all(monkeypatch, scope, ["--changed"])
+    assert _ran_pytest(executed)
+
+
+def test_all_runs_python_on_infra_escalation(monkeypatch):
+    # Infrastructure changes escalate to an unscoped run, which includes Python.
+    scope = (None, ("flake.nix",))
+    executed = _run_test_all(monkeypatch, scope, ["--changed"])
+    assert _ran_pytest(executed)

--- a/bootstrap/tests/test_monorepo.py
+++ b/bootstrap/tests/test_monorepo.py
@@ -1,0 +1,265 @@
+"""Consistency tests between the monorepo registry and the real manifests.
+
+The registry in ``bootstrap/monorepo/packages.py`` is the single source of
+truth for change-aware CI selection; these tests make sure it cannot drift
+from the actual ``pubspec.yaml``/``package.json``/``Cargo.toml`` manifests.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from bootstrap.constant import PROJECT_ROOT
+from bootstrap.monorepo.graph import ALL_SUITES
+from bootstrap.monorepo.graph import resolve_affected
+from bootstrap.monorepo.graph import web_relevant_packages
+from bootstrap.monorepo.packages import ALLOWED_EXTRA_EDGES
+from bootstrap.monorepo.packages import META_ENTRIES
+from bootstrap.monorepo.packages import PACKAGES
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+PACKAGES_BY_ID = {p.id: p for p in PACKAGES}
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open(encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _load_toml(path: Path) -> dict:
+    with path.open("rb") as f:
+        return tomllib.load(f)
+
+
+# ------------------------------------------------------------------ registry
+
+
+def test_package_ids_and_paths_are_unique():
+    ids = [p.id for p in PACKAGES]
+    paths = [p.path for p in PACKAGES]
+    assert len(ids) == len(set(ids)), f"duplicate package ids: {ids}"
+    assert len(paths) == len(set(paths)), f"duplicate package paths: {paths}"
+
+
+def test_declared_edges_reference_known_packages():
+    for package in PACKAGES:
+        for dep in package.depends_on:
+            assert dep in PACKAGES_BY_ID, f"{package.id} depends on unknown {dep}"
+
+
+def test_package_suites_are_known():
+    for package in PACKAGES:
+        for suite in package.suites:
+            assert suite in ALL_SUITES, f"{package.id} feeds unknown suite {suite}"
+
+
+def test_meta_entries_reference_known_targets():
+    ecosystems = {p.ecosystem for p in PACKAGES}
+    for entry in META_ENTRIES:
+        for package_id in entry.packages:
+            assert package_id in PACKAGES_BY_ID, f"{entry.id} references unknown {package_id}"
+        for ecosystem in entry.ecosystems:
+            assert ecosystem in ecosystems, f"{entry.id} references unknown {ecosystem}"
+        for suite in entry.suites:
+            assert suite in ALL_SUITES, f"{entry.id} references unknown suite {suite}"
+
+
+# ---------------------------------------------------------------------- Dart
+
+
+def _dart_workspace_members() -> list[str]:
+    return list(_load_yaml(PROJECT_ROOT / "pubspec.yaml").get("workspace", []))
+
+
+def test_dart_workspace_members_match_registry():
+    manifest = set(_dart_workspace_members())
+    registry = {p.path for p in PACKAGES if p.ecosystem == "dart"}
+    assert manifest == registry
+
+
+def test_dart_package_names_and_edges():
+    workspace_names: dict[str, str] = {}  # name -> path
+    for member in _dart_workspace_members():
+        pubspec = _load_yaml(PROJECT_ROOT / member / "pubspec.yaml")
+        workspace_names[pubspec["name"]] = member
+
+    for name, path in workspace_names.items():
+        package = PACKAGES_BY_ID[name]
+        assert package.path == path
+        pubspec = _load_yaml(PROJECT_ROOT / path / "pubspec.yaml")
+        manifest_edges: set[str] = set()
+        for section in ("dependencies", "dev_dependencies"):
+            deps = pubspec.get(section) or {}
+            manifest_edges.update(d for d in deps if d in workspace_names)
+        declared = set(package.depends_on) & workspace_names.keys()
+        extras = {d for a, d in ALLOWED_EXTRA_EDGES if a == name}
+        assert manifest_edges == declared - extras, (
+            f"{name}: manifest edges {sorted(manifest_edges)} != declared {sorted(declared - extras)}"
+        )
+        assert declared - manifest_edges <= extras
+
+
+# -------------------------------------------------------------- TypeScript
+
+
+def _pnpm_workspace_dirs() -> list[str]:
+    config = _load_yaml(PROJECT_ROOT / "pnpm-workspace.yaml")
+    dirs: list[str] = []
+    for pattern in config.get("packages", []):
+        if pattern.endswith("/*"):
+            parent = PROJECT_ROOT / pattern[:-2]
+            if not parent.is_dir():
+                continue
+            dirs.extend(
+                str(child.relative_to(PROJECT_ROOT))
+                for child in sorted(parent.iterdir())
+                if (child / "package.json").is_file()
+            )
+        else:
+            dirs.append(pattern)
+    return dirs
+
+
+def test_pnpm_workspace_members_match_registry():
+    manifest = set(_pnpm_workspace_dirs())
+    registry = {p.path for p in PACKAGES if p.ecosystem == "ts"}
+    assert manifest == registry
+
+
+def test_pnpm_package_names_and_edges():
+    names: dict[str, str] = {}  # name -> path
+    for directory in _pnpm_workspace_dirs():
+        manifest = json.loads((PROJECT_ROOT / directory / "package.json").read_text())
+        names[manifest["name"]] = directory
+
+    for name, path in names.items():
+        package = PACKAGES_BY_ID[name]
+        assert package.path == path
+        manifest = json.loads((PROJECT_ROOT / path / "package.json").read_text())
+        manifest_edges: set[str] = set()
+        for section in ("dependencies", "devDependencies"):
+            deps = manifest.get(section) or {}
+            manifest_edges.update(d for d in deps if d in names)
+        declared = set(package.depends_on) & names.keys()
+        assert manifest_edges == declared, (
+            f"{name}: manifest edges {sorted(manifest_edges)} != declared {sorted(declared)}"
+        )
+
+
+# ---------------------------------------------------------------------- Rust
+
+
+def _cargo_workspace_members() -> list[str]:
+    return list(_load_toml(PROJECT_ROOT / "Cargo.toml")["workspace"]["members"])
+
+
+def test_cargo_workspace_members_match_registry():
+    manifest = set(_cargo_workspace_members())
+    registry = {p.path for p in PACKAGES if p.ecosystem == "rust"}
+    assert manifest == registry
+
+
+def test_cargo_package_names_and_edges():
+    names: dict[str, str] = {}  # crate name -> member dir
+    for member in _cargo_workspace_members():
+        manifest_path = PROJECT_ROOT / member / "Cargo.toml"
+        if not manifest_path.is_file():  # submodule not checked out
+            continue
+        names[_load_toml(manifest_path)["package"]["name"]] = member
+
+    for name, path in names.items():
+        package = PACKAGES_BY_ID[name]
+        assert package.path == path
+        manifest = _load_toml(PROJECT_ROOT / path / "Cargo.toml")
+        manifest_edges: set[str] = set()
+        for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+            deps = manifest.get(section) or {}
+            for spec in deps.values():
+                if isinstance(spec, dict) and "path" in spec:
+                    target = (PROJECT_ROOT / path / spec["path"]).resolve()
+                    for other_name, other_path in names.items():
+                        if (PROJECT_ROOT / other_path).resolve() == target:
+                            manifest_edges.add(other_name)
+        declared = set(package.depends_on) & names.keys()
+        assert manifest_edges == declared, (
+            f"{name}: manifest edges {sorted(manifest_edges)} != declared {sorted(declared)}"
+        )
+
+
+# -------------------------------------------------------------------- graph
+
+
+def test_dependents_closure_marks_app_for_base_package_change():
+    affected = resolve_affected(["packages/efa_proto/lib/eve.pb.dart"])
+    assert "eve_fit_assistant" in affected.packages
+    assert "efa_fit" in affected.packages
+    assert affected.suites >= {"dart", "dart-web"}
+
+
+def test_leaf_ts_package_change_pulls_in_dependents():
+    affected = resolve_affected(["packages/efa_proto_ts/src/index.ts"])
+    assert "efa-fit-snapshot-ts" in affected.packages
+    assert "efa-platform" in affected.packages
+    assert "efa-platform-api" in affected.packages
+    assert affected.suites >= {"snapshot-ts", "site", "worker"}
+
+
+def test_nested_rust_crate_matches_most_specific_package():
+    affected = resolve_affected(["apps/eve-fit-assistant/rust/lib/efa-chat/src/lib.rs"])
+    assert "efa-chat" in affected.packages
+    assert "rust_lib_eve_fit_assistant" in affected.packages  # dependent
+    assert "eve_fit_assistant" in affected.packages  # dependent of dependent
+
+
+def test_submodule_gitlink_path_matches_package():
+    affected = resolve_affected(["packages/eve-fit-os"])
+    assert "eve-fit-os" in affected.packages
+    assert "efa-platform-fit-storage" in affected.packages
+
+
+def test_infra_change_escalates_to_full_run():
+    for path in ["bootstrap/ci/suites.py", "flake.nix", ".github/workflows/ci.yml"]:
+        affected = resolve_affected([path])
+        assert affected.full, path
+        assert affected.suites == set(ALL_SUITES)
+        assert affected.web
+
+
+def test_unrelated_files_affect_nothing():
+    affected = resolve_affected(["README.md", "docs/agents/README.md", "AGENTS.md"])
+    assert not affected.full
+    assert not affected.packages
+    assert not affected.suites
+    assert not affected.web
+
+
+def test_empty_change_list_affects_nothing():
+    affected = resolve_affected([])
+    assert not affected.full
+    assert not affected.packages
+    assert not affected.suites
+    assert not affected.web
+
+
+def test_web_gate_follows_app_dependency_closure():
+    assert resolve_affected(["packages/efa_fit/lib/fit.dart"]).web
+    assert resolve_affected(["packages/eve-fit-os/src/lib.rs"]).web
+    assert not resolve_affected(["site/home/src/routes/+page.svelte"]).web
+    assert not resolve_affected(["packages/efa_fit_snapshot/lib/snapshot.dart"]).web
+
+
+def test_web_relevant_packages_are_app_closure():
+    relevant = web_relevant_packages()
+    assert "eve_fit_assistant" in relevant
+    assert "rust_lib_eve_fit_assistant" in relevant
+    assert "eve-fit-os" in relevant
+    assert "efa_fit_snapshot" not in relevant  # not an app dependency

--- a/docs/agents/build-and-test.md
+++ b/docs/agents/build-and-test.md
@@ -11,6 +11,23 @@ Run commands from the repository root unless a command explicitly says otherwise
 ./x generate -f all      # generate all code, then format
 ```
 
+`lint`, `format`, and the `test` subcommands are change-aware; they restrict their work to
+the packages affected by your changes (mapped through the `bootstrap/monorepo/` dependency
+graph and closed over dependents):
+
+```sh
+./x lint --changed                       # lint only packages changed vs origin/dev
+./x lint --changed --base-ref main       # diff against a different ref
+./x lint --packages efa_fit,eve_fit_assistant   # explicit package scope
+./x format --changed
+./x test dart --changed
+./x test all --changed
+```
+
+Uncommitted (staged, unstaged, and untracked) changes are included in `--changed`.
+Infrastructure changes (`bootstrap/ci/**`, `flake.nix`, `.github/workflows/**`) escalate to
+the full pass. Use `uv run x.py ci affected --base-ref <ref>` to inspect the resolution.
+
 Focused generators:
 
 ```sh

--- a/docs/agents/ci-release.md
+++ b/docs/agents/ci-release.md
@@ -12,7 +12,8 @@ Selection is driven by the monorepo dependency graph in `bootstrap/monorepo/`: c
 map to packages, the affected set is closed over dependents, and each affected CI suite emits
 fully-resolved commands scoped via `--packages` (for example
 `uv run x.py test dart --packages efa_fit,eve_fit_assistant`). Changes to `bootstrap/ci/**`,
-`flake.nix`, or `.github/workflows/**` escalate to the full, unscoped matrix as a fail-safe.
+`bootstrap/monorepo/**`, `bootstrap/cli/runtime.py`, `flake.nix`, or `.github/workflows/**`
+escalate to the full, unscoped matrix as a fail-safe.
 
 The registry in `bootstrap/monorepo/packages.py` is the single source of truth for package
 paths, intra-repo dependency edges, and suite attribution; it is validated against the real

--- a/docs/agents/ci-release.md
+++ b/docs/agents/ci-release.md
@@ -4,6 +4,25 @@ App releases are driven by GitHub Actions workflows in `.github/workflows/`; see
 `RELEASING.md` for the manual release procedure. `flake.nix` and the workflow files are the
 sources of truth when this document disagrees with them.
 
+## Pull Request CI
+
+`ci.yml` runs a change-aware job matrix. The workflow diffs the PR base against its head and
+feeds the file list to `uv run x.py ci matrix --from-file` (pushes to `dev` use `--full`).
+Selection is driven by the monorepo dependency graph in `bootstrap/monorepo/`: changed files
+map to packages, the affected set is closed over dependents, and each affected CI suite emits
+fully-resolved commands scoped via `--packages` (for example
+`uv run x.py test dart --packages efa_fit,eve_fit_assistant`). Changes to `bootstrap/ci/**`,
+`flake.nix`, or `.github/workflows/**` escalate to the full, unscoped matrix as a fail-safe.
+
+The registry in `bootstrap/monorepo/packages.py` is the single source of truth for package
+paths, intra-repo dependency edges, and suite attribution; it is validated against the real
+`pubspec.yaml`/`package.json`/`Cargo.toml` manifests by `bootstrap/tests/test_monorepo.py`.
+Use `uv run x.py ci affected [--from-file F | --base-ref REF | --full]` to inspect the
+resolved packages/suites/web-gate for a change set as JSON.
+
+Release preflight (`ci release verify --check-all`) intentionally stays full-scope: a release
+must build and test everything regardless of what changed.
+
 ## Release Pull Requests
 
 Release PRs target the `dev` branch and use three labels:
@@ -108,8 +127,9 @@ config file, then runs `wrangler pages deploy` with `--commit-hash`.
 
 Entry points:
 
-- `web-preview.yml` — PRs to `dev` that touch web bundle inputs (`WEB_PREVIEW_PATTERNS` in
-  `bootstrap/ci/suites.py`, checked through `x.py ci web-affected`) get a branch preview on
+- `web-preview.yml` — PRs to `dev` that touch web bundle inputs (derived from the
+  `bootstrap/monorepo/` dependency graph: the app's forward dependency closure plus web
+  tooling meta entries, checked through `x.py ci web-affected`) get a branch preview on
   `efa-app-nightly` plus a pinned PR comment. This is gated on the `D-CI-Page Preview` label,
   which `D-Full CI` also enables. Release PRs labeled `V-Release` skip this build because
   `release-full.yml`'s `site`/`site-deploy` jobs build and deploy the web bundle instead.

--- a/docs/agents/workspace.md
+++ b/docs/agents/workspace.md
@@ -14,6 +14,7 @@ This document maps the repository's major areas. Scoped operating rules live in 
 | `pyproject.toml` / `uv.lock` | Python 3.13+ project and locked `uv` environment. |
 | `flake.nix` | Primary Linux development environment and toolchain source of truth. |
 | `./x`, `./x.ps1`, `x.py` | Workspace CLI and its Python implementation. Prefer `./x --help` over copied command prose. |
+| `bootstrap/monorepo/` | Package registry + dependency graph driving change-aware lint/test/CI selection; validated against manifests by `bootstrap/tests/test_monorepo.py`. |
 
 ## Flutter App
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added change-aware linting, formatting, testing, and CI selection.
  * Added options to target changed files, a base revision, or specific packages.
  * Added a command to inspect affected packages and test suites.
  * CI now scopes work to impacted packages and automatically runs full checks for infrastructure changes.

* **Documentation**
  * Documented change-aware commands, options, and CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->