### PR TITLE
feat(app): add share-to-platform action to the fit detail page

### DIFF
--- a/apps/eve-fit-assistant/l10n/app_en.arb
+++ b/apps/eve-fit-assistant/l10n/app_en.arb
@@ -407,6 +407,7 @@
   "fitUtilsNameRequired": "Fit name is required",
   "fitUtilsExportButton": "Export fit",
   "fitUtilsExportImageButton": "Export image",
+  "fitUtilsShareButton": "Share to platform",
   "fitUtilsNameLabel": "Fit name",
   "fitUtilsDescriptionLabel": "Description",
   "fitExportDialogTitle": "Export fit",

--- a/apps/eve-fit-assistant/l10n/app_zh.arb
+++ b/apps/eve-fit-assistant/l10n/app_zh.arb
@@ -985,6 +985,7 @@
   "fitUtilsNameRequired": "请输入配置名。",
   "fitUtilsExportButton": "导出配置",
   "fitUtilsExportImageButton": "导出图片",
+  "fitUtilsShareButton": "分享到平台",
   "fitUtilsNameLabel": "配置名称",
   "fitUtilsDescriptionLabel": "配置备注",
   "fitExportDialogTitle": "导出配置",

--- a/apps/eve-fit-assistant/lib/pages/fit/page.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/page.dart
@@ -26,6 +26,8 @@ import "package:eve_fit_assistant/constant/colors.dart";
 import "package:eve_fit_assistant/data/l10n/app_localizations.dart";
 import "package:eve_fit_assistant/features/chat/fit_context.dart";
 import "package:eve_fit_assistant/features/fit_io/export_dialog.dart";
+import "package:eve_fit_assistant/features/fit_io/share_dialog.dart";
+import "package:eve_fit_assistant/features/fit_io/share_operation.dart";
 import "package:eve_fit_assistant/features/market_price/ui/fit_price_tile.dart";
 import "package:eve_fit_assistant/native/api/output.dart" as native;
 import "package:eve_fit_assistant/native/api/storage.dart" as native_storage;

--- a/apps/eve-fit-assistant/lib/pages/fit/tabs/utils.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/tabs/utils.dart
@@ -46,37 +46,52 @@ class _UtilsTabState extends ConsumerState<_UtilsTab> with AutomaticKeepAliveCli
   Widget build(BuildContext context) {
     super.build(context);
 
+    // Mirror the fit-list swipe action: only accounts holding the platform
+    // post:create permission may publish fits (fail-closed while resolving).
+    final canShare = ref.watch(fitShareEligibilityProvider);
+
     return SingleChildScrollView(
       padding: const EdgeInsets.all(20),
       child: Form(
         key: _formKey,
         child: Column(
           children: [
-            Align(
-              child: Wrap(
-                spacing: 12,
-                runSpacing: 12,
-                children: [
+            // Stretch each action across the tab width: a wrapping row sends
+            // later buttons to a second line with mismatched alignment, while
+            // full-width buttons line up with the form fields below.
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              spacing: 12,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: () => showFitExportDialog(
+                    context,
+                    fitId: widget.fitContext.fitId,
+                    initialFit: widget.fitContext.fit,
+                  ),
+                  icon: const Icon(Icons.ios_share_outlined),
+                  label: Text(context.l10n.fitUtilsExportButton),
+                ),
+                OutlinedButton.icon(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (context) => FitScreenshotPage(fitId: widget.fitContext.fitId),
+                    ),
+                  ),
+                  icon: const Icon(Icons.image_outlined),
+                  label: Text(context.l10n.fitUtilsExportImageButton),
+                ),
+                if (canShare)
                   OutlinedButton.icon(
-                    onPressed: () => showFitExportDialog(
+                    onPressed: () => showFitShareDialog(
                       context,
                       fitId: widget.fitContext.fitId,
                       initialFit: widget.fitContext.fit,
                     ),
-                    icon: const Icon(Icons.ios_share_outlined),
-                    label: Text(context.l10n.fitUtilsExportButton),
+                    icon: const Icon(Icons.share_outlined),
+                    label: Text(context.l10n.fitUtilsShareButton),
                   ),
-                  OutlinedButton.icon(
-                    onPressed: () => Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (context) => FitScreenshotPage(fitId: widget.fitContext.fitId),
-                      ),
-                    ),
-                    icon: const Icon(Icons.image_outlined),
-                    label: Text(context.l10n.fitUtilsExportImageButton),
-                  ),
-                ],
-              ),
+              ],
             ),
             const SizedBox(height: 16),
             TextFormField(

--- a/apps/eve-fit-assistant/lib/pages/fit/tabs/utils.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/tabs/utils.dart
@@ -83,11 +83,17 @@ class _UtilsTabState extends ConsumerState<_UtilsTab> with AutomaticKeepAliveCli
                 ),
                 if (canShare)
                   OutlinedButton.icon(
-                    onPressed: () => showFitShareDialog(
-                      context,
-                      fitId: widget.fitContext.fitId,
-                      initialFit: widget.fitContext.fit,
-                    ),
+                    // The share dialog uploads the persisted fit
+                    // (widget.fitContext.fit), not the controller values, so
+                    // sharing must wait until pending metadata edits are saved
+                    // or discarded.
+                    onPressed: _editable
+                        ? null
+                        : () => showFitShareDialog(
+                            context,
+                            fitId: widget.fitContext.fitId,
+                            initialFit: widget.fitContext.fit,
+                          ),
                     icon: const Icon(Icons.share_outlined),
                     label: Text(context.l10n.fitUtilsShareButton),
                   ),

--- a/apps/eve-fit-assistant/test/pages/fit/utils_tab_test.dart
+++ b/apps/eve-fit-assistant/test/pages/fit/utils_tab_test.dart
@@ -1,0 +1,243 @@
+@TestOn("vm")
+library;
+
+import "dart:convert";
+import "dart:io";
+import "dart:ui" as ui;
+
+import "package:efa_proto/collections.pb.dart";
+import "package:efa_proto/fit.pb.dart" as proto_fit;
+import "package:eve_fit_assistant/config/locale.dart";
+import "package:eve_fit_assistant/config/logger.dart";
+import "package:eve_fit_assistant/config/type_list.dart";
+import "package:eve_fit_assistant/data/l10n/app_localizations.dart";
+import "package:eve_fit_assistant/features/fit_io/share_dialog.dart";
+import "package:eve_fit_assistant/features/fit_io/share_operation.dart";
+import "package:eve_fit_assistant/pages/fit/page.dart";
+import "package:eve_fit_assistant/storage/fit/manager.dart";
+import "package:eve_fit_assistant/storage/fit/persistence.dart";
+import "package:eve_fit_assistant/storage/fit/schema.dart";
+import "package:eve_fit_assistant/storage/fit/service.dart";
+import "package:eve_fit_assistant/storage/fs/doc_store.dart";
+import "package:eve_fit_assistant/storage/repo/collection.dart";
+import "package:eve_fit_assistant/storage/repo/models/checkout_ref.dart";
+import "package:eve_fit_assistant/storage/repo/providers.dart";
+import "package:eve_fit_assistant/storage/setting/setting.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:fpdart/fpdart.dart";
+
+import "../../test_helpers.dart";
+
+const String _fitId = "utils-tab-test-fit";
+const int _shipTypeId = 587;
+
+proto_fit.Ship _ship() => proto_fit.Ship()..typeId = _shipTypeId;
+
+FitStorage _fitStorage() => FitStorage.empty(
+  const FitMetadata(
+    fitId: _fitId,
+    shipTypeId: _shipTypeId,
+    name: "Test Fit",
+    lastModified: 0,
+    description: "Original description",
+    // An empty checkout ref keeps the fit editable regardless of the (absent)
+    // active checkout in tests.
+    checkoutRef: CheckoutRef(checkoutId: "", serverId: ""),
+  ),
+  _ship(),
+);
+
+class _InMemoryDocStore implements DocStore {
+  final Map<String, String> docs = {};
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Future<String?> read(String key) async => docs[key];
+
+  @override
+  Future<bool> exists(String key) async => docs.containsKey(key);
+
+  @override
+  Future<void> write(String key, String value) async {
+    docs[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    docs.remove(key);
+  }
+
+  @override
+  Future<List<String>> keys() async => docs.keys.toList();
+}
+
+/// Registry manager without disk access: keeps the registry in memory only.
+class _FakeFitRegistryManager extends FitRegistryManager {
+  _FakeFitRegistryManager(this._initial);
+
+  final FitRegistry _initial;
+
+  @override
+  FitRegistry build() => _initial;
+
+  @override
+  void updateFit(FitMetadata metadata) {
+    state = state.copyWith(fits: state.fits.add(metadata.fitId, metadata));
+  }
+}
+
+/// Mounts [FitDisplayColumns] (the public entry point containing the utils
+/// tab) the same way `_FitPage` wires it up.
+class _Subject extends ConsumerWidget {
+  const _Subject({required this.fit});
+
+  final FitStorage fit;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final fitState = ref.watch(fitProvider(fit.metadata.fitId));
+    final fitWrapper = FitWrapper(
+      wrapped: ref.read(fitProvider(fit.metadata.fitId).notifier),
+      fitId: fit.metadata.fitId,
+      ref: ref,
+    );
+    // A narrow surface forces the single-column layout, so only one tab bar
+    // (and therefore at most one of each button label) exists in the tree.
+    return MediaQuery(
+      data: const MediaQueryData(size: Size(500, 800)),
+      child: Scaffold(
+        body: FitDisplayColumns(
+          fitContext: FitContext(
+            fitId: fit.metadata.fitId,
+            fit: fitState.fit,
+            fitWrapper: fitWrapper,
+            emulated: null,
+            ship: _ship(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  setUpAll(() {
+    GlobalLogger.init(
+      Directory.systemTemp.createTempSync("efa-utils-tab-test").path,
+      enableDebugLog: false,
+    );
+  });
+
+  final l10n = lookupAppLocalizations(const ui.Locale("zh"));
+
+  late _InMemoryDocStore fitStore;
+
+  setUp(() {
+    fitStore = _InMemoryDocStore();
+  });
+
+  Widget buildSubject(FitStorage fit) => ProviderScope(
+    overrides: [
+      appSettingServiceProvider.overrideWithValue(
+        const AppSetting(
+          locale: Locale.zh,
+          enableDebugLog: false,
+          shipSelectListDisplayVariant: TypeListDisplayVariant.marketGroup,
+          showCheckoutImpactWarnings: true,
+          typeListReturnBehavior: TypeListReturnBehavior.previousPage,
+          developerMode: false,
+        ),
+      ),
+      activeCheckoutProvider.overrideWithValue(const None()),
+      activeCheckoutIdProvider.overrideWithValue(const None()),
+      repoCollectionProvider.overrideWithValue(
+        RepoCollectionService.forTest(collection: Collection()..ships[_shipTypeId] = _ship()),
+      ),
+      fitsDocStoreProvider.overrideWithValue(fitStore),
+      fitRegistryManagerProvider.overrideWith(
+        () => _FakeFitRegistryManager(FitRegistry(fits: IMap({_fitId: fit.metadata}))),
+      ),
+      fitProvider(_fitId).overrideWithBuild(
+        (ref, notifier) => FitServiceState.loaded(
+          status: FitServiceStatus.loaded(lastSync: DateTime.fromMillisecondsSinceEpoch(0)),
+          fit: fit,
+        ),
+      ),
+      fitEmulatorServiceProvider(
+        _fitId,
+      ).overrideWithBuild((ref, notifier) => const FitEmulatorState.notInitialized()),
+      fitShareEligibilityProvider.overrideWith((ref) => true),
+    ],
+    child: testApp(_Subject(fit: fit)),
+  );
+
+  Finder shareButton() => find.widgetWithText(OutlinedButton, l10n.fitUtilsShareButton);
+
+  bool shareEnabled(WidgetTester tester) =>
+      tester.widget<OutlinedButton>(shareButton()).onPressed != null;
+
+  Future<void> openUtilsTab(WidgetTester tester, FitStorage fit) async {
+    await tester.pumpWidget(buildSubject(fit));
+    await tester.pump();
+    // The single-column layout starts on the equipment tab; switch to utils.
+    await tester.tap(find.text(l10n.fitTabsUtils));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(shareButton(), findsOneWidget);
+  }
+
+  testWidgets("share is disabled while metadata edits are pending", (tester) async {
+    await openUtilsTab(tester, _fitStorage());
+    expect(shareEnabled(tester), isTrue);
+
+    await tester.tap(find.widgetWithText(OutlinedButton, l10n.edit));
+    await tester.pump();
+
+    // Unsaved name/description edits live only in the controllers; the share
+    // dialog would upload the stale persisted fit, so the button is disabled.
+    expect(shareEnabled(tester), isFalse);
+    await tester.tap(shareButton());
+    await tester.pump();
+    expect(find.byType(FitShareDialog), findsNothing);
+
+    // Discarding the edits re-enables sharing.
+    await tester.tap(find.widgetWithText(OutlinedButton, l10n.cancel));
+    await tester.pump();
+    expect(shareEnabled(tester), isTrue);
+  });
+
+  testWidgets("share is re-enabled once the metadata save completes", (tester) async {
+    await openUtilsTab(tester, _fitStorage());
+
+    await tester.tap(find.widgetWithText(OutlinedButton, l10n.edit));
+    await tester.pump();
+    expect(shareEnabled(tester), isFalse);
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, l10n.fitUtilsNameLabel),
+      "Renamed Fit",
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, l10n.fitUtilsDescriptionLabel),
+      "Updated description",
+    );
+    await tester.tap(find.widgetWithText(FilledButton, l10n.confirm));
+    await tester.pump();
+    await tester.pump();
+
+    expect(shareEnabled(tester), isTrue);
+
+    // The persisted fit now carries the edited metadata, so the share dialog
+    // uploads exactly what the user sees in the form.
+    final saved = fitStore.docs["$_fitId.json"];
+    expect(saved, isNotNull);
+    final savedMetadata = decodeFitStorage(jsonDecode(saved!) as Map<String, dynamic>).fit.metadata;
+    expect(savedMetadata.name, "Renamed Fit");
+    expect(savedMetadata.description, "Updated description");
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Share to platform” action to the fit utilities.
  * Sharing is available when the current fit meets eligibility requirements.
  * Updated English and Chinese translations.
  * Improved utility action layout for clearer spacing and full-width controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->