### PR TITLE
feat(app): add open-in-app action to the platform post page

### DIFF
--- a/apps/eve-fit-assistant/l10n/app_en.arb
+++ b/apps/eve-fit-assistant/l10n/app_en.arb
@@ -225,6 +225,7 @@
   "platformWindow30d": "30 days",
   "platformWindowAll": "All time",
   "platformPostNotFound": "Post not found",
+  "platformPostOpenInApp": "Open in app",
   "platformCommentsTitle": "Comments ({count})",
   "platformCommentsEmpty": "No comments yet",
   "platformCommentDeletedAuthor": "Deleted account",

--- a/apps/eve-fit-assistant/l10n/app_zh.arb
+++ b/apps/eve-fit-assistant/l10n/app_zh.arb
@@ -363,6 +363,7 @@
   "platformWindow30d": "30 天",
   "platformWindowAll": "全部",
   "platformPostNotFound": "未找到该分享",
+  "platformPostOpenInApp": "在应用中打开",
   "platformCommentsTitle": "评论（{count}）",
   "@platformCommentsTitle": {
     "placeholders": { "count": { "type": "int" } }

--- a/apps/eve-fit-assistant/lib/features/fit_link/importer.dart
+++ b/apps/eve-fit-assistant/lib/features/fit_link/importer.dart
@@ -21,6 +21,13 @@ class FitLinkImporter {
 
   Future<FitMetadata> importBootUri(Uri uri) => _importParsed(uri, parseFitLinkBootUri(uri));
 
+  /// Imports a registered fit directly by its content-addressed hash — the
+  /// in-app counterpart of following an `efa://fit/registered` link, used by
+  /// the platform post page's open-in-app action. The hash is validated by
+  /// the same link grammar as external links.
+  Future<FitMetadata> importRegistered(String fitHash) =>
+      import(buildFitLinkRegisteredAppUri(fitHash));
+
   Future<FitMetadata> _importParsed(Uri uri, FitLinkParseResult? parsed) async => switch (parsed) {
     FitLinkRaw(:final payload) => _importRaw(payload),
     FitLinkRegistered(:final fitHash) => _importRegistered(uri, fitHash),

--- a/apps/eve-fit-assistant/lib/pages/platform/post_page.dart
+++ b/apps/eve-fit-assistant/lib/pages/platform/post_page.dart
@@ -1,10 +1,13 @@
 import "package:auto_route/auto_route.dart";
 import "package:efa_acl/efa_acl.dart";
+import "package:efa_fit/efa_fit.dart";
 import "package:efa_fit_snapshot/efa_fit_snapshot.dart";
 import "package:efa_platform_client/efa_platform_client.dart";
 import "package:eve_fit_assistant/components/icon/efa_icon_resolver.dart";
 import "package:eve_fit_assistant/components/layout.dart";
+import "package:eve_fit_assistant/config/logger.dart";
 import "package:eve_fit_assistant/features/account/providers.dart";
+import "package:eve_fit_assistant/features/fit_link/providers.dart";
 import "package:eve_fit_assistant/features/platform/providers.dart";
 import "package:eve_fit_assistant/pages/router.dart";
 import "package:eve_fit_assistant/utils/context.dart";
@@ -89,10 +92,65 @@ class _PlatformPostContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) => ListView(
     padding: const EdgeInsets.symmetric(vertical: 10),
     children: [
-      FitSnapshotView(snapshot: post.snapshot, iconResolver: ref.watch(appEfaIconResolverProvider)),
+      FitSnapshotView(
+        snapshot: post.snapshot,
+        iconResolver: ref.watch(appEfaIconResolverProvider),
+        headerAction: _OpenInAppButton(fitHash: post.record.fitHash),
+      ),
       const Divider(height: 32),
       _CommentSection(postId: postId, commentCount: post.record.commentCount),
     ],
+  );
+}
+
+/// The open-in-app action of a platform post: imports the registered fit
+/// addressed by [fitHash] into local storage and opens it, mirroring the
+/// site's post header (`FitShareLanding` forwards to the same registered
+/// link for browsers).
+class _OpenInAppButton extends ConsumerStatefulWidget {
+  const _OpenInAppButton({required this.fitHash});
+
+  final String fitHash;
+
+  @override
+  ConsumerState<_OpenInAppButton> createState() => _OpenInAppButtonState();
+}
+
+class _OpenInAppButtonState extends ConsumerState<_OpenInAppButton> {
+  bool _busy = false;
+
+  void _showError(String message) {
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _openInApp() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      final metadata = await ref.read(fitLinkImporterProvider).importRegistered(widget.fitHash);
+      if (!mounted) return;
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text(context.l10n.fitImportSuccess(fitName: metadata.name))),
+      );
+      await context.router.push(FitRoute(fitId: metadata.fitId));
+    } on FitLinkNotFoundException {
+      debug("Open-in-app: registered fit ${widget.fitHash} not found on the platform");
+      if (mounted) _showError(context.l10n.fitImportUnknownError);
+    } on Object catch (e, st) {
+      warning("Open-in-app import failed for ${widget.fitHash}: $e", stackTrace: st);
+      if (mounted) _showError(context.l10n.fitImportUnknownError);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => FilledButton.tonalIcon(
+    onPressed: _busy ? null : _openInApp,
+    icon: _busy
+        ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2))
+        : const Icon(Icons.rocket_launch_outlined),
+    label: Text(context.l10n.platformPostOpenInApp),
   );
 }
 

--- a/apps/eve-fit-assistant/test/features/fit_link/importer_test.dart
+++ b/apps/eve-fit-assistant/test/features/fit_link/importer_test.dart
@@ -301,5 +301,24 @@ void main() {
       );
       expect(fitManager.imported, isEmpty);
     });
+
+    test("importRegistered imports by hash without a link URI", () async {
+      overrideSession(_fakeSession(_makeFitState(), _makeSnapshot()));
+
+      final result = await importer.importRegistered(_fitHash);
+
+      expect(result.fitId, "imported-id");
+      expect(fitManager.imported.single.metadata.name, "Registered Fit");
+    });
+
+    test("importRegistered rejects a malformed hash before any request", () async {
+      overrideSession(_fakeSession(_makeFitState(), _makeSnapshot()));
+
+      await expectLater(
+        importer.importRegistered("abc"),
+        throwsA(isA<FitLinkNotFoundException>()),
+      );
+      expect(fitManager.imported, isEmpty);
+    });
   });
 }

--- a/apps/eve-fit-assistant/test/pages/platform/post_page_test.dart
+++ b/apps/eve-fit-assistant/test/pages/platform/post_page_test.dart
@@ -2,15 +2,21 @@
 library;
 
 import "dart:convert";
+import "dart:io";
 import "dart:typed_data";
 
 import "package:dio/dio.dart";
+import "package:efa_fit/efa_fit.dart";
 import "package:efa_platform_client/efa_platform_client.dart";
 import "package:efa_proto/fit_snapshot.pb.dart";
 import "package:eve_fit_assistant/components/icon/efa_icon_resolver.dart";
 import "package:eve_fit_assistant/config/locale.dart";
+import "package:eve_fit_assistant/config/logger.dart";
 import "package:eve_fit_assistant/features/account/providers.dart";
+import "package:eve_fit_assistant/features/fit_link/importer.dart";
+import "package:eve_fit_assistant/features/fit_link/providers.dart";
 import "package:eve_fit_assistant/pages/platform/post_page.dart";
+import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/storage/setting/setting.dart";
 import "package:fixnum/fixnum.dart";
 import "package:flutter/material.dart";
@@ -44,6 +50,16 @@ class _MemoryStore implements PlatformSessionStore {
 
   @override
   Future<void> clear() async {}
+}
+
+/// An importer whose registered-fit import always misses, so the open-in-app
+/// failure path can be exercised without storage or a router.
+class _MissingFitImporter extends FitLinkImporter {
+  const _MissingFitImporter(super.ref);
+
+  @override
+  Future<FitMetadata> importRegistered(String fitHash) =>
+      throw FitLinkNotFoundException(buildFitLinkRegisteredAppUri(fitHash));
 }
 
 ResponseBody _json(Object body, [int status = 200]) => ResponseBody.fromString(
@@ -102,6 +118,11 @@ PlatformSession _session() => PlatformSession(
 );
 
 void main() {
+  setUpAll(() {
+    final logDir = Directory.systemTemp.createTempSync("efa_post_page_log_");
+    GlobalLogger.init(logDir.path, enableDebugLog: false);
+  });
+
   testWidgets("renders the snapshot, the comments, and the sign-in prompt when signed out", (
     tester,
   ) async {
@@ -123,8 +144,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining("测试配置"), findsOneWidget);
+    expect(find.text("在应用中打开"), findsOneWidget);
     expect(find.text("评论（1）"), findsOneWidget);
     expect(find.text("不错的配置"), findsOneWidget);
     expect(find.text("登录后即可参与讨论"), findsOneWidget);
+  });
+
+  testWidgets("open-in-app shows an error snackbar when the registered fit is missing", (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 3200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          platformSessionProvider.overrideWith((ref) async => _session()),
+          localeProvider.overrideWithValue(Locale.zh),
+          appEfaIconResolverProvider.overrideWith((ref) => const AppEfaIconResolver(null, null)),
+          fitLinkImporterProvider.overrideWith(_MissingFitImporter.new),
+        ],
+        child: testApp(const PlatformPostPage(postId: "p-1")),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("在应用中打开"));
+    await tester.pumpAndSettle();
+
+    expect(find.text("无法导入该配置。"), findsOneWidget);
   });
 }

--- a/docs/agents/app-links.md
+++ b/docs/agents/app-links.md
@@ -18,6 +18,9 @@ The app-side feature lives in `apps/eve-fit-assistant/lib/features/fit_link/`:
 - `native_intake.dart` receives OS links through `app_links`.
 - `intake_gate.dart` is wired in `main.dart` with the other gates; it awaits repository
   readiness, imports the fit, then pushes `FitRoute`.
+- The platform post page (`pages/platform/post_page.dart`) has an open-in-app action that
+  imports the post's registered fit by hash through `FitLinkImporter.importRegistered` (the
+  in-app counterpart of the site's post-header "Open in app" button) and pushes `FitRoute`.
 
 Web keeps the hash URL strategy. `web/_redirects` serves the SPA at `/fit/*`, and the boot
 probe reads `Uri.base`.

--- a/packages/efa_fit/lib/src/link.dart
+++ b/packages/efa_fit/lib/src/link.dart
@@ -73,8 +73,12 @@ String buildFitLinkRegisteredShareUrl(String fitHash) {
 /// The `efa://` registered fit link for [fitHash]: the in-app counterpart of
 /// [buildFitLinkRegisteredShareUrl], used when the consumer is already the
 /// app (e.g. the platform post page's open-in-app action).
-Uri buildFitLinkRegisteredAppUri(String fitHash) =>
-    Uri.parse("$efaScheme://fit/registered?$fitLinkHashParam=$fitHash");
+Uri buildFitLinkRegisteredAppUri(String fitHash) => Uri(
+  scheme: efaScheme,
+  host: "fit",
+  path: "registered",
+  queryParameters: {fitLinkHashParam: fitHash},
+);
 
 /// The canonical fit path of [uri] (`/fit/raw` or `/fit/registered`),
 /// null when [uri] is not a recognized fit link.

--- a/packages/efa_fit/lib/src/link.dart
+++ b/packages/efa_fit/lib/src/link.dart
@@ -70,6 +70,12 @@ String buildFitLinkRegisteredShareUrl(String fitHash) {
   return "https://$fitLinkPlatformHost$fitLinkRegisteredPlatformPath?$fitLinkHashParam=$fitHash";
 }
 
+/// The `efa://` registered fit link for [fitHash]: the in-app counterpart of
+/// [buildFitLinkRegisteredShareUrl], used when the consumer is already the
+/// app (e.g. the platform post page's open-in-app action).
+Uri buildFitLinkRegisteredAppUri(String fitHash) =>
+    Uri.parse("$efaScheme://fit/registered?$fitLinkHashParam=$fitHash");
+
 /// The canonical fit path of [uri] (`/fit/raw` or `/fit/registered`),
 /// null when [uri] is not a recognized fit link.
 String? canonicalPathOf(Uri uri) {

--- a/packages/efa_fit/test/link_test.dart
+++ b/packages/efa_fit/test/link_test.dart
@@ -267,5 +267,13 @@ void main() {
         ),
       );
     });
+
+    test("built registered app URI round-trips through the parser", () {
+      final uri = buildFitLinkRegisteredAppUri(fitHash);
+      expect(uri.toString(), "efa://fit/registered?hash=$fitHash");
+      final result = parseFitLinkUri(uri);
+      expect(result, isA<FitLinkRegistered>());
+      expect((result! as FitLinkRegistered).fitHash, fitHash);
+    });
   });
 }

--- a/packages/efa_fit/test/link_test.dart
+++ b/packages/efa_fit/test/link_test.dart
@@ -275,5 +275,12 @@ void main() {
       expect(result, isA<FitLinkRegistered>());
       expect((result! as FitLinkRegistered).fitHash, fitHash);
     });
+
+    test("buildFitLinkRegisteredAppUri encodes the hash as a query parameter", () {
+      final malicious = "${'a' * 62}&hash=${'b' * 64}";
+      final uri = buildFitLinkRegisteredAppUri(malicious);
+      expect(uri.queryParameters.length, 1);
+      expect(uri.queryParameters[fitLinkHashParam], malicious);
+    });
   });
 }

--- a/packages/efa_fit_snapshot/lib/src/fit_snapshot_view.dart
+++ b/packages/efa_fit_snapshot/lib/src/fit_snapshot_view.dart
@@ -20,6 +20,7 @@ class FitSnapshotView extends StatelessWidget {
     this.locale,
     this.iconResolver,
     this.showHeader = true,
+    this.headerAction,
   });
 
   static const double _columnWidth = 420;
@@ -31,10 +32,89 @@ class FitSnapshotView extends StatelessWidget {
   /// Whether to show the fit name/description header above the columns.
   final bool showHeader;
 
+  /// An optional trailing widget for the header row (e.g. a caller-provided
+  /// action button); ignored when [showHeader] is false. The view stays
+  /// read-only — any behavior belongs to the widget the caller supplies.
+  final Widget? headerAction;
+
   @override
   Widget build(BuildContext context) {
     final effectiveLocale = locale ?? Localizations.maybeLocaleOf(context) ?? const Locale("en");
 
+    final child = SnapshotDisplay(
+      resolver: iconResolver,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          final columnCount = width >= _columnWidth * 3 + 48
+              ? 3
+              : width >= _columnWidth * 2 + 36
+              ? 2
+              : 1;
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (showHeader) _SnapshotHeader(snapshot: snapshot, action: headerAction),
+                switch (columnCount) {
+                  3 => Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    spacing: 12,
+                    children: [
+                      _column(SnapshotCharacterColumn(snapshot: snapshot)),
+                      _column(SnapshotEquipmentColumn(snapshot: snapshot)),
+                      _column(SnapshotStatisticsColumn(snapshot: snapshot)),
+                    ],
+                  ),
+                  2 => Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    spacing: 12,
+                    children: [
+                      _column(SnapshotEquipmentColumn(snapshot: snapshot)),
+                      _column(
+                        Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SnapshotCharacterColumn(snapshot: snapshot),
+                            const SizedBox(height: 12),
+                            SnapshotStatisticsColumn(snapshot: snapshot),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  _ => Column(
+                    mainAxisSize: MainAxisSize.min,
+                    spacing: 12,
+                    children: [
+                      SnapshotEquipmentColumn(snapshot: snapshot),
+                      SnapshotCharacterColumn(snapshot: snapshot),
+                      SnapshotStatisticsColumn(snapshot: snapshot),
+                    ],
+                  ),
+                },
+              ],
+            ),
+          );
+        },
+      ),
+    );
+
+    // With a surrounding localization scope, layer the snapshot delegate over
+    // it (the first delegate of a type wins) so caller-supplied widgets (e.g.
+    // [headerAction]) keep access to the app's delegates; standalone, install
+    // the minimal delegates the view needs on its own.
+    if (Localizations.maybeLocaleOf(context) != null) {
+      return Localizations.override(
+        context: context,
+        locale: effectiveLocale,
+        delegates: const [SnapshotLocalizations.delegate],
+        child: child,
+      );
+    }
     return Localizations(
       locale: effectiveLocale,
       delegates: const [
@@ -42,67 +122,7 @@ class FitSnapshotView extends StatelessWidget {
         DefaultMaterialLocalizations.delegate,
         DefaultWidgetsLocalizations.delegate,
       ],
-      child: SnapshotDisplay(
-        resolver: iconResolver,
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final width = constraints.maxWidth;
-            final columnCount = width >= _columnWidth * 3 + 48
-                ? 3
-                : width >= _columnWidth * 2 + 36
-                ? 2
-                : 1;
-
-            return SingleChildScrollView(
-              padding: const EdgeInsets.all(12),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  if (showHeader) _SnapshotHeader(snapshot: snapshot),
-                  switch (columnCount) {
-                    3 => Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      spacing: 12,
-                      children: [
-                        _column(SnapshotCharacterColumn(snapshot: snapshot)),
-                        _column(SnapshotEquipmentColumn(snapshot: snapshot)),
-                        _column(SnapshotStatisticsColumn(snapshot: snapshot)),
-                      ],
-                    ),
-                    2 => Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      spacing: 12,
-                      children: [
-                        _column(SnapshotEquipmentColumn(snapshot: snapshot)),
-                        _column(
-                          Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              SnapshotCharacterColumn(snapshot: snapshot),
-                              const SizedBox(height: 12),
-                              SnapshotStatisticsColumn(snapshot: snapshot),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                    _ => Column(
-                      mainAxisSize: MainAxisSize.min,
-                      spacing: 12,
-                      children: [
-                        SnapshotEquipmentColumn(snapshot: snapshot),
-                        SnapshotCharacterColumn(snapshot: snapshot),
-                        SnapshotStatisticsColumn(snapshot: snapshot),
-                      ],
-                    ),
-                  },
-                ],
-              ),
-            );
-          },
-        ),
-      ),
+      child: child,
     );
   }
 
@@ -127,9 +147,10 @@ class _SnapshotColumnFrame extends StatelessWidget {
 }
 
 class _SnapshotHeader extends StatelessWidget {
-  const _SnapshotHeader({required this.snapshot});
+  const _SnapshotHeader({required this.snapshot, this.action});
 
   final FitSnapshot snapshot;
+  final Widget? action;
 
   @override
   Widget build(BuildContext context) {
@@ -141,6 +162,7 @@ class _SnapshotHeader extends StatelessWidget {
       subtitle: header.hasDescription() && header.description.isNotEmpty
           ? Text(header.description)
           : null,
+      trailing: action,
     );
   }
 }

--- a/packages/efa_fit_snapshot/test/fit_snapshot_view_test.dart
+++ b/packages/efa_fit_snapshot/test/fit_snapshot_view_test.dart
@@ -23,11 +23,18 @@ Future<void> _pumpView(
   FitSnapshot snapshot, {
   Locale locale = const Locale("en"),
   Size size = const Size(1400, 2400),
+  bool showHeader = true,
+  Widget? headerAction,
 }) async {
   tester.view.physicalSize = size;
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.reset);
-  await tester.pumpWidget(_wrap(FitSnapshotView(snapshot: snapshot), locale: locale));
+  await tester.pumpWidget(
+    _wrap(
+      FitSnapshotView(snapshot: snapshot, showHeader: showHeader, headerAction: headerAction),
+      locale: locale,
+    ),
+  );
   await tester.pumpAndSettle();
 }
 
@@ -66,6 +73,30 @@ void main() {
 
     expect(find.text("High Slot"), findsOneWidget);
     expect(find.textContaining("Stable"), findsNothing);
+  });
+
+  testWidgets("renders the header action on the header row, beside the title", (tester) async {
+    await _pumpView(tester, buildFixtureSnapshot(), headerAction: const Text("ACTION"));
+
+    final title = tester.getRect(find.text("Test Rokh - Rokh"));
+    final action = tester.getRect(find.text("ACTION"));
+
+    expect(action.left, greaterThan(title.right));
+    // Same row: the action's vertical center overlaps the title's.
+    expect(action.center.dy, greaterThan(title.top));
+    expect(action.center.dy, lessThan(title.bottom + 24));
+  });
+
+  testWidgets("omits the header action when the header is hidden", (tester) async {
+    await _pumpView(
+      tester,
+      buildFixtureSnapshot(),
+      showHeader: false,
+      headerAction: const Text("ACTION"),
+    );
+
+    expect(find.text("Test Rokh - Rokh"), findsNothing);
+    expect(find.text("ACTION"), findsNothing);
   });
 
   testWidgets("stacks into a single column on narrow layouts", (tester) async {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Open in app” action to platform posts with registered fits.
  * Opening a fit now imports it and navigates directly to the fit view.
  * Added English and Chinese translations for the new action.
  * Added support for opening registered fits through in-app links.
* **Bug Fixes**
  * Improved error handling and feedback when a registered fit cannot be found.
* **Documentation**
  * Documented the new platform post action.
* **Tests**
  * Added coverage for registered-fit imports, link parsing, UI behavior, and missing-fit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->