### PR TITLE
fix(app): render subsystem section only when subsystems are equipped

### DIFF
--- a/apps/eve-fit-assistant/lib/features/fit_io/snapshot_export.dart
+++ b/apps/eve-fit-assistant/lib/features/fit_io/snapshot_export.dart
@@ -159,7 +159,7 @@ class FitSnapshotExporter {
         mediumSlots: max(ship?.mediumSlots ?? 0, fit.body.slots.medium.length),
         lowSlots: max(ship?.lowSlots ?? 0, fit.body.slots.low.length),
         rigSlots: max(ship?.rigSlots ?? 0, fit.body.slots.rig.length),
-        subsystemSlots: max(ship?.subsystemSlots ?? 0, fit.body.slots.subsystem.length),
+        subsystemSlots: exportSubsystemSlotCount(ship?.subsystemSlots, fit.body.slots.subsystem),
         serviceSlots: max(ship?.serviceSlots ?? 0, fit.body.slots.service.length),
         turretHardpoints: turretHardpoints,
         launcherHardpoints: launcherHardpoints,

--- a/apps/eve-fit-assistant/lib/features/fit_io/upload_request.dart
+++ b/apps/eve-fit-assistant/lib/features/fit_io/upload_request.dart
@@ -314,7 +314,7 @@ FitUploadRequest buildFitUploadRequest({
         mediumSlots: max(ship?.mediumSlots ?? 0, fit.body.slots.medium.length),
         lowSlots: max(ship?.lowSlots ?? 0, fit.body.slots.low.length),
         rigSlots: max(ship?.rigSlots ?? 0, fit.body.slots.rig.length),
-        subsystemSlots: max(ship?.subsystemSlots ?? 0, fit.body.slots.subsystem.length),
+        subsystemSlots: exportSubsystemSlotCount(ship?.subsystemSlots, fit.body.slots.subsystem),
         serviceSlots: max(ship?.serviceSlots ?? 0, fit.body.slots.service.length),
         turretHardpoints: turretHardpoints,
         launcherHardpoints: launcherHardpoints,

--- a/apps/eve-fit-assistant/lib/storage/fit/schema.dart
+++ b/apps/eve-fit-assistant/lib/storage/fit/schema.dart
@@ -1,3 +1,5 @@
+import "dart:math";
+
 import "package:efa_constant/eve.dart";
 import "package:efa_proto/fit.pb.dart";
 import "package:eve_fit_assistant/config/logger.dart";
@@ -244,6 +246,21 @@ abstract class FitDynamicRegistry with _$FitDynamicRegistry {
 
   factory FitDynamicRegistry.fromJson(Map<String, dynamic> json) =>
       _$FitDynamicRegistryFromJson(json);
+}
+
+/// Layout subsystem slot count for exported representations of a fit.
+///
+/// [FitStorageSlots.subsystem] is always [EveConstGeneric.subsystemSize] long
+/// regardless of the ship, so unlike the other racks its raw length must not
+/// serve as a layout fallback: ships without subsystem slots would otherwise
+/// export a phantom subsystem section. When the ship definition is
+/// unavailable, fall back to covering every fitted subsystem.
+int exportSubsystemSlotCount(int? shipSubsystemSlots, IList<Option<FitModuleItem>> subsystem) {
+  var fitted = 0;
+  for (var index = 0; index < subsystem.length; index++) {
+    if (subsystem[index].isSome()) fitted = index + 1;
+  }
+  return max(shipSubsystemSlots ?? 0, fitted);
 }
 
 Set<int> collectReferencedDynamicItemIds(FitStorage fit) {

--- a/apps/eve-fit-assistant/test/features/fit_io/upload_request_test.dart
+++ b/apps/eve-fit-assistant/test/features/fit_io/upload_request_test.dart
@@ -144,6 +144,22 @@ void main() {
       expect(fit.layout.fighterTubes, 0);
     });
 
+    test("layout subsystem slots cover only fitted subsystems without a collection", () {
+      // The stored subsystem list is always `subsystemSize` long, so its raw
+      // length must not leak into the exported layout.
+      expect(_build(_makeFit()).fit.layout.subsystemSlots, 1);
+
+      final fit = _makeFit();
+      final emptySubsystem = fit.copyWith(
+        body: fit.body.copyWith(
+          slots: fit.body.slots.copyWith(
+            subsystem: IList(List<Option<FitModuleItem>>.filled(4, const None())),
+          ),
+        ),
+      );
+      expect(_build(emptySubsystem).fit.layout.subsystemSlots, 0);
+    });
+
     test("maps rack modules with charges and dynamic ids", () {
       final modules = _build(_makeFit()).fit.modules;
       expect(modules, hasLength(2));

--- a/packages/efa_fit_snapshot/lib/src/widgets/equipment_column.dart
+++ b/packages/efa_fit_snapshot/lib/src/widgets/equipment_column.dart
@@ -120,7 +120,9 @@ class SnapshotEquipmentColumn extends StatelessWidget {
           slots: snapshot.rigSlots,
           placeholder: EfaAssets.slotRig,
         ),
-        if (snapshot.subsystemSlots.isNotEmpty) ...[
+        // Subsystem slots are only meaningful as a full set (T3 cruisers); with
+        // zero equipped subsystems the section is nothing but empty placeholders.
+        if (snapshot.subsystemSlots.any((slot) => slot.hasItem())) ...[
           EfaSectionHeader(title: l10n.subsystemSlot),
           for (final slot in snapshot.subsystemSlots)
             slot.hasItem()

--- a/packages/efa_fit_snapshot/test/fit_snapshot_view_test.dart
+++ b/packages/efa_fit_snapshot/test/fit_snapshot_view_test.dart
@@ -75,6 +75,21 @@ void main() {
     expect(find.textContaining("Stable"), findsNothing);
   });
 
+  testWidgets("hides the subsystem section when no subsystem is equipped", (tester) async {
+    await _pumpView(tester, buildFixtureSnapshot(subsystemSlots: 4));
+
+    expect(find.text("Subsystem"), findsNothing);
+    expect(find.text("Subsystem (Empty)"), findsNothing);
+  });
+
+  testWidgets("renders the subsystem section when a subsystem is equipped", (tester) async {
+    await _pumpView(tester, buildFixtureSnapshot(subsystemSlots: 4, withSubsystem: true));
+
+    expect(find.text("Subsystem"), findsOneWidget);
+    expect(find.text("Tengu Defensive - Amplification Node"), findsOneWidget);
+    expect(find.text("Subsystem (Empty)"), findsNWidgets(3));
+  });
+
   testWidgets("renders the header action on the header row, beside the title", (tester) async {
     await _pumpView(tester, buildFixtureSnapshot(), headerAction: const Text("ACTION"));
 

--- a/packages/efa_fit_snapshot/test/fixture.dart
+++ b/packages/efa_fit_snapshot/test/fixture.dart
@@ -1,15 +1,20 @@
 import "package:efa_fit/efa_fit.dart";
 
-FitSnapshot buildFixtureSnapshot({bool withStatistics = true}) {
+FitSnapshot buildFixtureSnapshot({
+  bool withStatistics = true,
+  int subsystemSlots = 0,
+  bool withSubsystem = false,
+}) {
   final builder = FitSnapshotBuilder(
     fitName: "Test Rokh",
     description: "A snapshot fixture",
     ship: const SnapshotTypeData(typeId: 24688, names: {"en": "Rokh", "zh": "罗克级"}),
-    layout: const SnapshotShipLayoutData(
+    layout: SnapshotShipLayoutData(
       highSlots: 8,
       mediumSlots: 5,
       lowSlots: 6,
       rigSlots: 3,
+      subsystemSlots: subsystemSlots,
       turretHardpoints: 8,
       launcherHardpoints: 0,
     ),
@@ -41,6 +46,20 @@ FitSnapshot buildFixtureSnapshot({bool withStatistics = true}) {
       state: Slots_SlotState.ACTIVE,
     ),
   );
+
+  if (withSubsystem) {
+    builder.setSubsystem(
+      0,
+      Subsystem_SubsystemType.DEFENSIVE,
+      const SnapshotModuleData(
+        type: SnapshotTypeData(
+          typeId: 30078,
+          names: {"en": "Tengu Defensive - Amplification Node"},
+        ),
+        state: Slots_SlotState.ACTIVE,
+      ),
+    );
+  }
 
   builder.addDrone(
     const SnapshotDroneData(

--- a/packages/efa_fit_snapshot_ts/src/lib/columns/EquipmentColumn.svelte
+++ b/packages/efa_fit_snapshot_ts/src/lib/columns/EquipmentColumn.svelte
@@ -43,6 +43,12 @@ function subsystemPlaceholder(type: Subsystem_SubsystemType): EfaIconName {
 
 const layout = $derived(snapshot.ship?.layout);
 
+// Subsystem slots are only meaningful as a full set (T3 cruisers); with zero
+// equipped subsystems the section renders nothing but empty placeholders.
+const hasEquippedSubsystem = $derived(
+    snapshot.subsystemSlots.some((slot) => slot.item !== undefined),
+);
+
 const usedTurret = $derived(
     snapshot.highSlots.filter((slot) => slot.item?.isTurret === true).length,
 );
@@ -100,7 +106,7 @@ const fighterBay = $derived(
     <Rack title={ctx.t("lowSlot")} slots={snapshot.lowSlots} placeholder="slot-low" />
     <Rack title={ctx.t("rigSlot")} slots={snapshot.rigSlots} placeholder="slot-rig" />
 
-    {#if snapshot.subsystemSlots.length > 0}
+    {#if hasEquippedSubsystem}
         <SectionHeader title={ctx.t("subsystemSlot")} />
         {#each snapshot.subsystemSlots as slot (slot.index)}
             {#if slot.item}


### PR DESCRIPTION
Part of the fix for #430 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty subsystem slots no longer appear as a misleading subsystem section in fit views.
  - Exported fit layouts now report subsystem slots based on the ship configuration and equipped modules, avoiding phantom slots.
  - Fits with equipped subsystems continue to display the correct subsystem and remaining empty slots.

- **Tests**
  - Added coverage for exports and rendered views with both empty and equipped subsystem configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->