### PR TITLE
refactor(platform): rebuild snapshot store with binary hashes and dense id rows

### DIFF
--- a/.github/actions/sync-platform-d1/action.yml
+++ b/.github/actions/sync-platform-d1/action.yml
@@ -3,7 +3,7 @@ name: Sync snapshot to platform D1
 description: >-
   Sync the built resource snapshots' engine data (types, type dogma, dogma
   attributes, dogma effects, buffs, plus name/icon metadata) into the
-  efa-platform-snapshots D1 database via the efa-platform-data-sync worker.
+  efa-snapshot-registry D1 database via the efa-platform-data-sync worker.
   Expects the v2-snapshots artifact contents (cache/remote/assets/ and
   snapshot-hashes.json) to already be present in the working directory,
   protobuf bindings generated, and efa.dev.toml initialized.

--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -5,11 +5,16 @@ dogma attributes, dogma effects, buff collections) into per-entry rows and
 builds per-entry name/icon metadata from the snapshot's collection and
 localization database, then uploads everything to the platform data-sync
 worker (``api.efa-tech.dev/platform/storage/data-sync``), which stores them in
-the ``efa-platform-snapshots`` D1 database.
+the ``efa-snapshot-registry`` D1 database.
 
-Layout per family ``<f>``:
-  - table ``<f>``:     (content_hash TEXT PRIMARY KEY, content BLOB)
-  - table ``<f>_reg``: (server_id, snapshot_hash, entry_id, content_hash)
+Storage layout (v2; see worker/efa-platform-data-sync/migrations):
+  - ``entries``:          (content_id, family, content_hash BLOB, content)
+                          content-addressed payloads; content_id is a dense
+                          database-local integer assigned by the worker
+  - ``snapshot_entries``: (snapshot_id, family, entry_id, content_id)
+                          registration rows referencing integer ids only
+  - ``snapshots``:        (snapshot_id, server_id, snapshot_hash BLOB,
+                          entry_count, completed_at) completeness registry
 
 Uploads run over a single WebSocket to the worker's ``SyncSession`` Durable
 Object: every frame is a small JSON message (``content``/``lookup``/
@@ -18,13 +23,17 @@ the same client-chosen ``id``. Each frame is a separate Durable Object event
 with its own CPU budget, which replaced the old multi-request HTTP API whose
 large per-request batches regularly failed with 503s.
 
+Registration rows reference content ids rather than content hashes, so the
+``content`` and ``lookup`` replies carry ``ids`` maps (content hash ->
+content id) that this driver accumulates before emitting ``register`` frames.
+
 All operations are idempotent, so the transport reconnects and resends an
 unacknowledged frame on connection failures, and a rerun of the whole sync
 converges: the ``snapshot`` frame skips already-completed snapshots and the
 ``lookup`` frame skips already-uploaded content rows. A snapshot is only
-complete once the uploader has posted every content and registration frame and
-then marked it in the ``snapshots`` registry table (``complete``); readers
-must check that registry before serving data.
+complete once the uploader has posted every content and registration frame
+and then frozen it in the ``snapshots`` registry (``complete``); readers must
+check that registry before serving data.
 """
 
 from __future__ import annotations
@@ -94,7 +103,7 @@ class Entry:
 
 @dataclass(frozen=True)
 class Registration:
-    """A single ``<family>_reg`` row."""
+    """A single ``snapshot_entries`` row candidate."""
 
     family: str
     entry_id: int
@@ -430,22 +439,39 @@ def run_sync(
                 info(f"Snapshot already complete, skipping: {server_id} ({snapshot_hash[:16]}...)")
                 del pending[(server_id, snapshot_hash)]
 
+        pending_hashes = {(reg.family, reg.hash) for regs in pending.values() for reg in regs}
+
+        # The worker's `ids` reply maps content hash -> content id, keyed by
+        # hash alone. That is only sound when no content hash appears under
+        # two families (identical bytes in two per-family protobuf schemas);
+        # enforce the invariant before relying on it.
+        families_by_hash: dict[str, set[str]] = {}
+        for family, entry_hash in pending_hashes:
+            families_by_hash.setdefault(entry_hash, set()).add(family)
+        ambiguous = [h for h, families in families_by_hash.items() if len(families) > 1]
+        if ambiguous:
+            raise ValueError(
+                f"content hashes shared across families are not supported: {ambiguous[:5]}"
+            )
+
         # Resume support: content rows already present on the server (from
         # earlier runs or shared with completed snapshots) are not resent.
-        pending_hashes = {(reg.family, reg.hash) for regs in pending.values() for reg in regs}
         rows_to_check = sorted(
             (family, entry_hash)
             for (family, entry_hash) in content
             if (family, entry_hash) in pending_hashes
         )
         missing: set[tuple[str, str]] = set()
+        content_ids: dict[tuple[str, str], int] = {}
         for family in ALL_FAMILIES:
             family_hashes = [h for f, h in rows_to_check if f == family]
             if not family_hashes:
                 continue
-            for chunk in _batched(family_hashes, 10_000):
+            for chunk in _batched(family_hashes, 5_000):
                 reply = transport.post("lookup", {"family": family, "content_hashes": chunk})
                 missing.update((family, h) for h in reply.get("missing", []))
+                for h, content_id in reply.get("ids", {}).items():
+                    content_ids[(family, h)] = content_id
         info(f"Content rows missing on the server: {len(missing)} of {len(rows_to_check)}")
 
         content_rows = [
@@ -459,14 +485,30 @@ def run_sync(
         for batch in _batched(content_rows, batch_size):
             reply = transport.post("content", {"entries": batch})
             info(f"Uploaded {len(batch)} content rows (inserted: {reply.get('inserted', '?')})")
+            # Content frames may mix families, but the cross-family hash
+            # invariant above keeps the flat ids map unambiguous.
+            family_by_hash = {row["content_hash"]: row["family"] for row in batch}
+            for h, content_id in reply.get("ids", {}).items():
+                content_ids[(family_by_hash[h], h)] = content_id
+
+        unresolved = pending_hashes - set(content_ids)
+        if unresolved:
+            raise RuntimeError(
+                f"server did not return content ids for {len(unresolved)} content rows "
+                f"(first: {min(unresolved)})"
+            )
 
         for (server_id, snapshot_hash), regs in sorted(pending.items()):
             reg_rows = [
-                {"family": reg.family, "entry_id": reg.entry_id, "content_hash": reg.hash}
+                {
+                    "family": reg.family,
+                    "entry_id": reg.entry_id,
+                    "content_id": content_ids[(reg.family, reg.hash)],
+                }
                 for reg in regs
             ]
             for batch in _batched(reg_rows, batch_size):
-                reply = transport.post(
+                transport.post(
                     "register",
                     {"server_id": server_id, "snapshot_hash": snapshot_hash, "entries": batch},
                 )

--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -26,6 +26,9 @@ large per-request batches regularly failed with 503s.
 Registration rows reference content ids rather than content hashes, so the
 ``content`` and ``lookup`` replies carry ``ids`` maps (content hash ->
 content id) that this driver accumulates before emitting ``register`` frames.
+The ``ids`` maps are keyed by hash alone, so ``content`` frames are sent one
+family at a time: identical bytes under two families are distinct
+``(family, content_hash)`` rows and must not share a frame.
 
 All operations are idempotent, so the transport reconnects and resends an
 unacknowledged frame on connection failures, and a rerun of the whole sync
@@ -441,19 +444,6 @@ def run_sync(
 
         pending_hashes = {(reg.family, reg.hash) for regs in pending.values() for reg in regs}
 
-        # The worker's `ids` reply maps content hash -> content id, keyed by
-        # hash alone. That is only sound when no content hash appears under
-        # two families (identical bytes in two per-family protobuf schemas);
-        # enforce the invariant before relying on it.
-        families_by_hash: dict[str, set[str]] = {}
-        for family, entry_hash in pending_hashes:
-            families_by_hash.setdefault(entry_hash, set()).add(family)
-        ambiguous = [h for h, families in families_by_hash.items() if len(families) > 1]
-        if ambiguous:
-            raise ValueError(
-                f"content hashes shared across families are not supported: {ambiguous[:5]}"
-            )
-
         # Resume support: content rows already present on the server (from
         # earlier runs or shared with completed snapshots) are not resent.
         rows_to_check = sorted(
@@ -474,22 +464,28 @@ def run_sync(
                     content_ids[(family, h)] = content_id
         info(f"Content rows missing on the server: {len(missing)} of {len(rows_to_check)}")
 
-        content_rows = [
-            {
-                "family": family,
-                "content_hash": entry_hash,
-                "content_b64": base64.b64encode(content[(family, entry_hash)]).decode("ascii"),
-            }
-            for family, entry_hash in sorted(missing)
-        ]
-        for batch in _batched(content_rows, batch_size):
-            reply = transport.post("content", {"entries": batch})
-            info(f"Uploaded {len(batch)} content rows (inserted: {reply.get('inserted', '?')})")
-            # Content frames may mix families, but the cross-family hash
-            # invariant above keeps the flat ids map unambiguous.
-            family_by_hash = {row["content_hash"]: row["family"] for row in batch}
-            for h, content_id in reply.get("ids", {}).items():
-                content_ids[(family_by_hash[h], h)] = content_id
+        # Content frames are kept per family so the worker's hash-keyed
+        # `ids` reply is unambiguous even when identical bytes (hence
+        # identical hashes) appear under two families; the entries table's
+        # (family, content_hash) uniqueness key makes those distinct rows.
+        for family in ALL_FAMILIES:
+            family_rows = [
+                {
+                    "family": family,
+                    "content_hash": entry_hash,
+                    "content_b64": base64.b64encode(content[(family, entry_hash)]).decode("ascii"),
+                }
+                for f, entry_hash in sorted(missing)
+                if f == family
+            ]
+            for batch in _batched(family_rows, batch_size):
+                reply = transport.post("content", {"entries": batch})
+                info(
+                    f"Uploaded {len(batch)} {family} content rows "
+                    f"(inserted: {reply.get('inserted', '?')})"
+                )
+                for h, content_id in reply.get("ids", {}).items():
+                    content_ids[(family, h)] = content_id
 
         unresolved = pending_hashes - set(content_ids)
         if unresolved:

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -229,17 +229,44 @@ class _FakeTransport:
         self._existing = existing or set()
         # (server_id, snapshot_hash) pairs already marked complete.
         self._completed = completed or set()
+        # Deterministic content ids, assigned as the worker would: dense,
+        # per (family, content_hash), stable for the session.
+        self._next_id = 0
+        self._ids: dict[tuple[str, str], int] = {}
+        for key in sorted(self._existing):
+            self._next_id += 1
+            self._ids[key] = self._next_id
+
+    def _ensure_id(self, family: str, content_hash: str) -> int:
+        key = (family, content_hash)
+        if key not in self._ids:
+            self._next_id += 1
+            self._ids[key] = self._next_id
+        return self._ids[key]
 
     def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         self.posts.append((path, payload))
         if path == "lookup":
+            present = [
+                h for h in payload["content_hashes"] if (payload["family"], h) in self._existing
+            ]
             missing = [
                 h for h in payload["content_hashes"] if (payload["family"], h) not in self._existing
             ]
-            return {"ok": True, "missing": missing}
+            return {
+                "ok": True,
+                "missing": missing,
+                "ids": {h: self._ids[(payload["family"], h)] for h in present},
+            }
         if path == "snapshot":
             complete = (payload["server_id"], payload["snapshot_hash"]) in self._completed
             return {"ok": True, "complete": complete}
+        if path == "content":
+            ids = {
+                entry["content_hash"]: self._ensure_id(entry["family"], entry["content_hash"])
+                for entry in payload["entries"]
+            }
+            return {"ok": True, "inserted": len(payload["entries"]), "ids": ids}
         return {"ok": True, "inserted": len(payload.get("entries", []))}
 
     def close(self) -> None:
@@ -454,6 +481,19 @@ class TestRunSync:
         assert servers == {"alpha", "beta"}
         for _path, payload in register_posts:
             assert len(payload["entries"]) == 10
+            # Registration rows reference worker-assigned content ids, not hashes.
+            for entry in payload["entries"]:
+                assert set(entry) == {"family", "entry_id", "content_id"}
+                assert isinstance(entry["content_id"], int)
+
+        # Identical snapshots share the same content ids across servers.
+        per_server = {
+            payload["server_id"]: {
+                (e["family"], e["entry_id"]): e["content_id"] for e in payload["entries"]
+            }
+            for _path, payload in register_posts
+        }
+        assert per_server["alpha"] == per_server["beta"]
 
         complete_posts = [p for p in transport.posts if p[0] == "complete"]
         assert len(complete_posts) == 2
@@ -519,6 +559,44 @@ class TestRunSync:
         with pytest.raises(RuntimeError, match="boom"):
             run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
         assert [p for p in transport.posts if p[0] == "complete"] == []
+
+    def test_fails_when_server_withholds_content_ids(self, schema_root: Path) -> None:
+        from bootstrap.data.d1.sync import run_sync
+
+        snapshot_hash = "dd" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+
+        class _IdlessTransport(_FakeTransport):
+            def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+                reply = super().post(path, payload)
+                reply.pop("ids", None)
+                return reply
+
+        transport = _IdlessTransport()
+        with pytest.raises(RuntimeError, match="did not return content ids"):
+            run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
+        assert [p for p in transport.posts if p[0] == "register"] == []
+
+    def test_rejects_content_hash_shared_across_families(
+        self, schema_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from bootstrap.data.d1 import sync
+
+        snapshot_hash = "dd" * 32
+        _build_snapshot(schema_root, snapshot_hash)
+
+        entries = sync.load_snapshot_entries(schema_root, snapshot_hash)
+        # Identical bytes under two families => identical content hash, which
+        # the hash-keyed `ids` reply map cannot disambiguate.
+        type_entry = next(e for e in entries if e.family == "types")
+        duplicate = sync.Entry("buffs", 999, type_entry.content)
+        assert duplicate.hash == type_entry.hash
+        monkeypatch.setattr(sync, "load_snapshot_entries", lambda *args: [*entries, duplicate])
+
+        transport = _FakeTransport()
+        with pytest.raises(ValueError, match="shared across families"):
+            sync.run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
+        assert [p for p in transport.posts if p[0] == "register"] == []
 
     def test_dry_run_uploads_nothing(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -577,7 +577,7 @@ class TestRunSync:
             run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
         assert [p for p in transport.posts if p[0] == "register"] == []
 
-    def test_rejects_content_hash_shared_across_families(
+    def test_registers_content_hash_shared_across_families(
         self, schema_root: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from bootstrap.data.d1 import sync
@@ -586,17 +586,40 @@ class TestRunSync:
         _build_snapshot(schema_root, snapshot_hash)
 
         entries = sync.load_snapshot_entries(schema_root, snapshot_hash)
-        # Identical bytes under two families => identical content hash, which
-        # the hash-keyed `ids` reply map cannot disambiguate.
+        # Identical bytes under two families => identical content hash. The
+        # entries table's (family, content_hash) uniqueness key makes these
+        # valid distinct rows, so the sync must succeed.
         type_entry = next(e for e in entries if e.family == "types")
         duplicate = sync.Entry("buffs", 999, type_entry.content)
         assert duplicate.hash == type_entry.hash
         monkeypatch.setattr(sync, "load_snapshot_entries", lambda *args: [*entries, duplicate])
 
         transport = _FakeTransport()
-        with pytest.raises(ValueError, match="shared across families"):
-            sync.run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
-        assert [p for p in transport.posts if p[0] == "register"] == []
+        sync.run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
+
+        # Content frames carry one family each, keeping the worker's
+        # hash-keyed ids reply unambiguous; both rows are uploaded.
+        content_posts = [p for p in transport.posts if p[0] == "content"]
+        for _path, payload in content_posts:
+            assert len({e["family"] for e in payload["entries"]}) == 1
+        uploaded = [e for _path, payload in content_posts for e in payload["entries"]]
+        assert ("types", type_entry.hash) in {(e["family"], e["content_hash"]) for e in uploaded}
+        assert ("buffs", duplicate.hash) in {(e["family"], e["content_hash"]) for e in uploaded}
+
+        # The shared hash resolves to a distinct content id per family, and
+        # both registrations complete.
+        register_posts = [p for p in transport.posts if p[0] == "register"]
+        reg_entries = [e for _path, payload in register_posts for e in payload["entries"]]
+        types_id = next(
+            e["content_id"]
+            for e in reg_entries
+            if e["family"] == "types" and e["entry_id"] == type_entry.entry_id
+        )
+        buffs_id = next(
+            e["content_id"] for e in reg_entries if e["family"] == "buffs" and e["entry_id"] == 999
+        )
+        assert types_id != buffs_id
+        assert [p for p in transport.posts if p[0] == "complete"] != []
 
     def test_dry_run_uploads_nothing(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -75,7 +75,8 @@ payload is verified against its SHA-256 hash. At most 2000 entries per frame.
 Replies `{ "id": 1, "ok": true, "inserted": n, "ids": { "<hash>": 123 } }`
 where `ids` resolves the frame's hashes to their content ids — freshly
 inserted and pre-existing alike. (`ids` is keyed by hash alone; a frame must
-not carry identical content bytes under two families.)
+not carry identical content bytes under two families — the reference uploader
+sends one family per frame.)
 
 ### Frame: `lookup`
 

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -1,7 +1,7 @@
 # efa-platform-data-sync — Cloudflare Worker
 
 Ingests per-entry engine data from resource snapshots into the
-`efa-platform-snapshots` D1 database, keyed by `(server_id, snapshot_hash)` so any
+`efa-snapshot-registry` D1 database, keyed by `(server_id, snapshot_hash)` so any
 historical snapshot stays addressable (checkout-ref semantics).
 
 Mounted at `api.efa-tech.dev/platform/storage/data-sync`.
@@ -10,23 +10,31 @@ Mounted at `api.efa-tech.dev/platform/storage/data-sync`.
 
 Eight families: the five native engine collections (`types`, `type_dogma`,
 `dogma_attributes`, `dogma_effects`, `buffs`) plus sync-built metadata
-(`type_meta`, `dogma_attribute_meta`, `dogma_effect_meta`). Each family `<f>`
-has two tables:
+(`type_meta`, `dogma_attribute_meta`, `dogma_effect_meta`), each with a fixed
+integer code (`types=0` … `dogma_effect_meta=7`, see `src/session.ts`).
+Storage v2 uses three tables:
 
-- `<f>` — `(content_hash TEXT PRIMARY KEY, content BLOB)`: content-addressed
+- `entries` — `(content_id INTEGER PRIMARY KEY, family, content_hash BLOB,
+  content BLOB, UNIQUE (family, content_hash))`: content-addressed
   single-entry protobuf payloads (efos `efos.*` entry messages for the engine
-  families, `efa.v2`-style `platform_data.*` messages for metadata).
-- `<f>_reg` — `(server_id, snapshot_hash, entry_id, content_hash)`:
-  registration rows mapping a snapshot's entries onto content rows.
+  families, `efa.v2`-style `platform_data.*` messages for metadata). Hashes
+  are raw 32-byte BLOBs; `content_id` is a dense database-local integer that
+  must never leak outside the sync protocol.
+- `snapshot_entries` — `(snapshot_id, family, entry_id, content_id)`:
+  registration rows mapping a snapshot's entries onto content rows,
+  referencing integer ids only (~25 B/row; the v1 schema repeated both full
+  hex hashes per row at ~344 B/row including indexes).
+- `snapshots` — `(snapshot_id INTEGER PRIMARY KEY, server_id, snapshot_hash
+  BLOB, entry_count, completed_at, UNIQUE (server_id, snapshot_hash))`: the
+  completeness registry. The first `register` frame creates the row with
+  `completed_at = NULL`; the uploader's `complete` frame freezes the snapshot
+  after the worker verifies the actual registration row count. **Readers must
+  check `completed_at IS NOT NULL` and treat any other
+  `(server_id, snapshot_hash)` as incomplete.**
 
 An upload spans many WebSocket frames (one D1 transaction each), so a failed
-sync leaves partial `<f>_reg` rows behind. The `snapshots` table —
-`(server_id, snapshot_hash, entry_count, completed_at)` — is the completeness
-registry: the uploader marks a row only after every content and registration
-frame for the snapshot succeeded, and the worker verifies the actual
-registration row count before accepting the marker. **Readers must check
-`snapshots` first and treat a `(server_id, snapshot_hash)` with no row as
-incomplete.**
+sync leaves partial `snapshot_entries` rows behind — always guarded by the
+pending `snapshots` row above.
 
 See `migrations/0001_init.sql` and `data/schema/platform_data.proto`.
 
@@ -62,9 +70,12 @@ HTTP GET probes below are public.
 }
 ```
 
-`INSERT OR IGNORE`s every row into the family content table (dedup by content
-hash); each payload is verified against its SHA-256 hash. At most 2000 entries
-per frame. Replies `{ "id": 1, "ok": true, "inserted": n }`.
+`INSERT OR IGNORE`s every row into `entries` (dedup by content hash); each
+payload is verified against its SHA-256 hash. At most 2000 entries per frame.
+Replies `{ "id": 1, "ok": true, "inserted": n, "ids": { "<hash>": 123 } }`
+where `ids` resolves the frame's hashes to their content ids — freshly
+inserted and pre-existing alike. (`ids` is keyed by hash alone; a frame must
+not carry identical content bytes under two families.)
 
 ### Frame: `lookup`
 
@@ -72,10 +83,11 @@ per frame. Replies `{ "id": 1, "ok": true, "inserted": n }`.
 { "type": "lookup", "id": 2, "family": "types", "content_hashes": ["sha256-hex"] }
 ```
 
-Returns the subset of the given hashes not yet present in the family content
-table (at most 10000 hashes per frame):
-`{ "id": 2, "ok": true, "missing": ["sha256-hex"] }`. Uploaders use this to
-skip already-synced content on reruns.
+Returns the subset of the given hashes not yet present in the family (at most
+5000 hashes per frame) plus the content ids of the present ones:
+`{ "id": 2, "ok": true, "missing": ["sha256-hex"], "ids": { "<hash>": 123 } }`.
+Uploaders use this to skip already-synced content on reruns and to resolve
+content ids for registration.
 
 ### Frame: `register`
 
@@ -85,15 +97,15 @@ skip already-synced content on reruns.
   "id": 3,
   "server_id": "tranquility",
   "snapshot_hash": "sha256-hex",
-  "entries": [{ "family": "types", "entry_id": 587, "content_hash": "sha256-hex" }]
+  "entries": [{ "family": "types", "entry_id": 587, "content_id": 123 }]
 }
 ```
 
-Verifies every referenced content hash exists (error reply with a `missing`
-list otherwise), then `INSERT OR IGNORE`s the registration rows (immutable per
-primary key, so re-runs are free of write quota). Inserts are conditional on
-the absence of the `snapshots` marker: once `complete` has frozen a snapshot,
-further registrations for it are skipped and the frame fails with
+Resolves-or-creates the pending `snapshots` row, verifies every referenced
+content id exists in the entry's family (error reply with a `missing` list
+otherwise), then `INSERT OR IGNORE`s the registration rows (immutable per
+primary key, so re-runs are free of write quota). Once `complete` has frozen
+a snapshot, further registrations for it fail with
 `Snapshot already complete`. At most 2000 entries per frame. Replies
 `{ "id": 3, "ok": true, "inserted": n }`.
 
@@ -104,9 +116,9 @@ further registrations for it are skipped and the frame fails with
 ```
 
 Marks a snapshot complete. Verifies server-side that the registration rows
-present for `(server_id, snapshot_hash)` across all `<f>_reg` tables equal
-`entry_count` (error reply otherwise), then upserts the `snapshots` registry
-row. Replies `{ "id": 4, "ok": true }`.
+present for the snapshot equal `entry_count` (error reply otherwise), then
+sets `entry_count` and `completed_at` on the `snapshots` registry row.
+Replies `{ "id": 4, "ok": true }`.
 
 ### Frame: `snapshot`
 
@@ -125,7 +137,7 @@ Returns `{ "ok": true }` after a `SELECT 1` probe.
 ### `GET /platform/storage/data-sync/snapshot?server_id=...&snapshot_hash=...`
 
 Completeness check for readers. Responds `{ "ok": true, "complete": false }`
-when the snapshot has no registry row, or
+when the snapshot is pending or unknown, or
 `{ "ok": true, "complete": true, "entry_count": n, "completed_at": "..." }`.
 
 ## Deployment
@@ -138,11 +150,16 @@ class automatically.
 
 One-time setup:
 
-1. `wrangler d1 create efa-platform-snapshots` and paste the printed `database_id`
-   into `wrangler.toml`.
-2. `wrangler d1 migrations apply efa-platform-snapshots --remote`.
+1. `wrangler d1 create efa-snapshot-registry` and paste the printed
+   `database_id` into `wrangler.toml` (and into `efa-platform-fit-storage`'s
+   `PLATFORM_DB` binding — readers and writer must move together).
+2. `wrangler d1 migrations apply efa-snapshot-registry --remote`.
 3. `wrangler secret put SYNC_TOKEN`; add the same value as the `D1_SYNC_TOKEN`
    secret of the `production-data` GitHub environment.
+4. Resync every snapshot from source
+   (`./x ci release-data d1-sync --hashes snapshot-hashes.json --schema-root cache/remote`);
+   the store is fully derived from resource snapshots, so no data migration
+   from the v1 database is needed.
 
 ## Sync driver
 

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -118,8 +118,12 @@ a snapshot, further registrations for it fail with
 
 Marks a snapshot complete. Verifies server-side that the registration rows
 present for the snapshot equal `entry_count` (error reply otherwise), then
-sets `entry_count` and `completed_at` on the `snapshots` registry row.
-Replies `{ "id": 4, "ok": true }`.
+sets `entry_count` and `completed_at` on the `snapshots` registry row. The
+count check and the freeze are a single conditional `UPDATE`, and every
+registration insert is guarded by `completed_at IS NULL`, so a concurrent
+`register` frame can never extend an already frozen registration set; a
+retry of the same `complete` frame after a lost reply succeeds. Replies
+`{ "id": 4, "ok": true }`.
 
 ### Frame: `snapshot`
 

--- a/worker/efa-platform-data-sync/migrations/0001_init.sql
+++ b/worker/efa-platform-data-sync/migrations/0001_init.sql
@@ -1,121 +1,48 @@
--- Platform data store: per-entry, content-addressed engine data rows.
--- Each family <f> has a content table and a registration table mapping
--- (server_id, snapshot_hash, entry_id) -> content_hash.
+-- Platform data store v2: per-entry, content-addressed engine data rows.
+--
+-- Two design changes over v1 (which stored every hash as 64-char hex TEXT and
+-- repeated the full snapshot hash in each of ~145k registration rows per
+-- snapshot, costing ~50 MiB/snapshot):
+--   1. All hashes are raw 32-byte BLOBs.
+--   2. Registration rows reference dense integer ids (snapshot_id, content_id)
+--      instead of hashes, ~25 B/row including the primary-key index.
+--
+-- The v1 tables were abandoned with the legacy database; this file is the
+-- initial migration of the v2 database (efa-snapshot-registry).
 
--- Snapshot completeness registry. Content and registration uploads span many
--- requests (one transaction each), so a failed run leaves partial <f>_reg rows
--- behind. The uploader inserts a row here only after every content and
--- registration batch for the snapshot succeeded; readers MUST treat any
--- (server_id, snapshot_hash) with no row here as incomplete and reject it.
+-- Snapshot registry, doubling as the pending/completion marker: a row is
+-- created by the first `register` frame for (server_id, snapshot_hash) and
+-- `completed_at` stays NULL until the uploader's `complete` frame verifies
+-- the registration row count and freezes the snapshot. Readers MUST treat a
+-- snapshot with completed_at IS NULL as incomplete and reject it.
 CREATE TABLE snapshots (
+    snapshot_id INTEGER PRIMARY KEY,
     server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
-    entry_count INTEGER NOT NULL,
-    completed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    PRIMARY KEY (server_id, snapshot_hash)
+    snapshot_hash BLOB NOT NULL,               -- raw 32-byte SHA-256
+    entry_count INTEGER,                       -- set at completion
+    completed_at TEXT,                         -- NULL = incomplete
+    UNIQUE (server_id, snapshot_hash)
 );
 
-CREATE TABLE types (
-    content_hash TEXT PRIMARY KEY,
-    content BLOB NOT NULL
+-- Content-addressed single-entry protobuf payloads for every family
+-- (efos.* entry messages for the engine families, platform_data.* messages
+-- for metadata). family codes: types=0, type_dogma=1, dogma_attributes=2,
+-- dogma_effects=3, buffs=4, type_meta=5, dogma_attribute_meta=6,
+-- dogma_effect_meta=7. content_id is database-local and must never leak
+-- outside the sync protocol.
+CREATE TABLE entries (
+    content_id INTEGER PRIMARY KEY,
+    family INTEGER NOT NULL,
+    content_hash BLOB NOT NULL,                -- raw 32-byte SHA-256
+    content BLOB NOT NULL,
+    UNIQUE (family, content_hash)
 );
-CREATE TABLE types_reg (
-    server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
-    entry_id INTEGER NOT NULL,
-    content_hash TEXT NOT NULL REFERENCES types (content_hash),
-    PRIMARY KEY (server_id, snapshot_hash, entry_id)
-);
--- Reverse lookup for reference counting / orphan cleanup / FK checks on DELETE.
-CREATE INDEX types_reg_content_hash ON types_reg (content_hash);
 
-CREATE TABLE type_dogma (
-    content_hash TEXT PRIMARY KEY,
-    content BLOB NOT NULL
-);
-CREATE TABLE type_dogma_reg (
-    server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
+-- Registration rows mapping a snapshot's entries onto content rows.
+CREATE TABLE snapshot_entries (
+    snapshot_id INTEGER NOT NULL REFERENCES snapshots (snapshot_id),
+    family INTEGER NOT NULL,
     entry_id INTEGER NOT NULL,
-    content_hash TEXT NOT NULL REFERENCES type_dogma (content_hash),
-    PRIMARY KEY (server_id, snapshot_hash, entry_id)
+    content_id INTEGER NOT NULL REFERENCES entries (content_id),
+    PRIMARY KEY (snapshot_id, family, entry_id)
 );
-CREATE INDEX type_dogma_reg_content_hash ON type_dogma_reg (content_hash);
-
-CREATE TABLE dogma_attributes (
-    content_hash TEXT PRIMARY KEY,
-    content BLOB NOT NULL
-);
-CREATE TABLE dogma_attributes_reg (
-    server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
-    entry_id INTEGER NOT NULL,
-    content_hash TEXT NOT NULL REFERENCES dogma_attributes (content_hash),
-    PRIMARY KEY (server_id, snapshot_hash, entry_id)
-);
-CREATE INDEX dogma_attributes_reg_content_hash ON dogma_attributes_reg (content_hash);
-
-CREATE TABLE dogma_effects (
-    content_hash TEXT PRIMARY KEY,
-    content BLOB NOT NULL
-);
-CREATE TABLE dogma_effects_reg (
-    server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
-    entry_id INTEGER NOT NULL,
-    content_hash TEXT NOT NULL REFERENCES dogma_effects (content_hash),
-    PRIMARY KEY (server_id, snapshot_hash, entry_id)
-);
-CREATE INDEX dogma_effects_reg_content_hash ON dogma_effects_reg (content_hash);
-
-CREATE TABLE buffs (
-    content_hash TEXT PRIMARY KEY,
-    content BLOB NOT NULL
-);
-CREATE TABLE buffs_reg (
-    server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
-    entry_id INTEGER NOT NULL,
-    content_hash TEXT NOT NULL REFERENCES buffs (content_hash),
-    PRIMARY KEY (server_id, snapshot_hash, entry_id)
-);
-CREATE INDEX buffs_reg_content_hash ON buffs_reg (content_hash);
-
-CREATE TABLE type_meta (
-    content_hash TEXT PRIMARY KEY,
-    content BLOB NOT NULL
-);
-CREATE TABLE type_meta_reg (
-    server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
-    entry_id INTEGER NOT NULL,
-    content_hash TEXT NOT NULL REFERENCES type_meta (content_hash),
-    PRIMARY KEY (server_id, snapshot_hash, entry_id)
-);
-CREATE INDEX type_meta_reg_content_hash ON type_meta_reg (content_hash);
-
-CREATE TABLE dogma_attribute_meta (
-    content_hash TEXT PRIMARY KEY,
-    content BLOB NOT NULL
-);
-CREATE TABLE dogma_attribute_meta_reg (
-    server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
-    entry_id INTEGER NOT NULL,
-    content_hash TEXT NOT NULL REFERENCES dogma_attribute_meta (content_hash),
-    PRIMARY KEY (server_id, snapshot_hash, entry_id)
-);
-CREATE INDEX dogma_attribute_meta_reg_content_hash ON dogma_attribute_meta_reg (content_hash);
-
-CREATE TABLE dogma_effect_meta (
-    content_hash TEXT PRIMARY KEY,
-    content BLOB NOT NULL
-);
-CREATE TABLE dogma_effect_meta_reg (
-    server_id TEXT NOT NULL,
-    snapshot_hash TEXT NOT NULL,
-    entry_id INTEGER NOT NULL,
-    content_hash TEXT NOT NULL REFERENCES dogma_effect_meta (content_hash),
-    PRIMARY KEY (server_id, snapshot_hash, entry_id)
-);
-CREATE INDEX dogma_effect_meta_reg_content_hash ON dogma_effect_meta_reg (content_hash);

--- a/worker/efa-platform-data-sync/src/index.ts
+++ b/worker/efa-platform-data-sync/src/index.ts
@@ -11,6 +11,14 @@ export interface Env {
 
 const HASH_RE = /^[0-9a-f]{64}$/;
 
+function hexToBlob(hex: string): ArrayBuffer {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return bytes.buffer as ArrayBuffer;
+}
+
 const app = new Hono<{ Bindings: Env }>();
 
 const MOUNT_PATH = "/platform/storage/data-sync";
@@ -70,10 +78,13 @@ app.get("/snapshot", async (c) => {
     if (!serverId || !snapshotHash || !HASH_RE.test(snapshotHash)) {
         return c.json({ ok: false, error: "Invalid server_id or snapshot_hash" }, 400);
     }
+    // A snapshot is complete only once the uploader's `complete` frame has
+    // frozen it; pending rows (completed_at IS NULL) are incomplete.
     const row = await c.env.PLATFORM_DB.prepare(
-        "SELECT entry_count, completed_at FROM snapshots WHERE server_id = ? AND snapshot_hash = ?",
+        "SELECT entry_count, completed_at FROM snapshots " +
+            "WHERE server_id = ? AND snapshot_hash = ? AND completed_at IS NOT NULL",
     )
-        .bind(serverId, snapshotHash)
+        .bind(serverId, hexToBlob(snapshotHash))
         .first<{ entry_count: number; completed_at: string }>();
     if (!row) {
         return c.json({ ok: true, complete: false });

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -9,24 +9,36 @@
 //
 // Protocol: every client frame is a JSON object with a `type` discriminator
 // and a client-chosen integer `id`; the server replies with one JSON object
-// carrying the same `id`. All operations are idempotent (INSERT OR IGNORE /
-// INSERT OR REPLACE), so a client that loses the connection may reconnect and
-// resend the unacknowledged frame — or rerun the whole sync, which converges
-// via the `lookup`/`snapshot` frames.
+// carrying the same `id`. All operations are idempotent (INSERT OR IGNORE),
+// so a client that loses the connection may reconnect and resend the
+// unacknowledged frame — or rerun the whole sync, which converges via the
+// `lookup`/`snapshot` frames.
+//
+// Storage v2 (see migrations/0001_init.sql): hashes cross the wire as
+// lowercase hex but are stored as raw 32-byte BLOBs, and registration rows
+// reference dense database-local integer ids (snapshot_id, content_id)
+// instead of repeating both hashes per row.
 //
 // Client frames:
 //   {type: "content",  id, entries: [{family, content_hash, content_b64}]}
-//       -> {id, ok: true, inserted} — INSERT OR IGNORE per-entry payloads,
-//          each verified against its SHA-256 content hash.
+//       -> {id, ok: true, inserted, ids: {content_hash: content_id}} —
+//          INSERT OR IGNORE per-entry payloads, each verified against its
+//          SHA-256 content hash, then the content ids of the frame's entries
+//          (present and freshly inserted alike) are resolved for the client.
+//          `ids` is keyed by hash alone: ids are only unique per
+//          (family, hash), so a frame must not carry identical content bytes
+//          under two families (the pipeline's per-family protobuf schemas
+//          make this impossible in practice).
 //   {type: "lookup",   id, family, content_hashes: [hex]}
-//       -> {id, ok: true, missing: [hex]} — subset of the given hashes not
-//          yet present in the family content table (resume support).
-//   {type: "register", id, server_id, snapshot_hash, entries: [{family, entry_id, content_hash}]}
+//       -> {id, ok: true, missing: [hex], ids: {content_hash: content_id}} —
+//          hashes not yet present in the family, plus the content ids of the
+//          present ones (resume support).
+//   {type: "register", id, server_id, snapshot_hash, entries: [{family, entry_id, content_id}]}
 //       -> {id, ok: true, inserted} — registration rows, conditional on the
 //          snapshot not being frozen by a `complete` marker yet.
 //   {type: "complete", id, server_id, snapshot_hash, entry_count}
-//       -> {id, ok: true} — writes the `snapshots` completeness marker after
-//          verifying the actual registration row count server-side.
+//       -> {id, ok: true} — freezes the snapshot after verifying the actual
+//          registration row count server-side.
 //   {type: "snapshot", id, server_id, snapshot_hash}
 //       -> {id, ok: true, complete: bool, entry_count?, completed_at?} —
 //          completeness probe so reruns can skip finished snapshots.
@@ -37,32 +49,32 @@ import { DurableObject } from "cloudflare:workers";
 import { z } from "zod";
 import type { Env } from "./index.ts";
 
-const FAMILIES = {
-    types: { content: "types", reg: "types_reg" },
-    type_dogma: { content: "type_dogma", reg: "type_dogma_reg" },
-    dogma_attributes: { content: "dogma_attributes", reg: "dogma_attributes_reg" },
-    dogma_effects: { content: "dogma_effects", reg: "dogma_effects_reg" },
-    buffs: { content: "buffs", reg: "buffs_reg" },
-    type_meta: { content: "type_meta", reg: "type_meta_reg" },
-    dogma_attribute_meta: {
-        content: "dogma_attribute_meta",
-        reg: "dogma_attribute_meta_reg",
-    },
-    dogma_effect_meta: { content: "dogma_effect_meta", reg: "dogma_effect_meta_reg" },
+// Family codes, mirrored in bootstrap/data/d1/sync.py and
+// worker/efa-platform-fit-storage/src/prefetch.rs.
+const FAMILY_CODES = {
+    types: 0,
+    type_dogma: 1,
+    dogma_attributes: 2,
+    dogma_effects: 3,
+    buffs: 4,
+    type_meta: 5,
+    dogma_attribute_meta: 6,
+    dogma_effect_meta: 7,
 } as const;
 
-type Family = keyof typeof FAMILIES;
+type Family = keyof typeof FAMILY_CODES;
 
 const HASH_RE = /^[0-9a-f]{64}$/;
-const FamilySchema = z.enum(Object.keys(FAMILIES) as [Family, ...Family[]]);
+const FamilySchema = z.enum(Object.keys(FAMILY_CODES) as [Family, ...Family[]]);
 const IdSchema = z.number().int().nonnegative();
 
 // Per-frame caps. Frames are deliberately small: each one is a separate Durable
 // Object event with its own CPU budget, so modest frames keep every event far
-// below the limit and give the uploader fast acks.
+// below the limit and give the uploader fast acks. The lookup cap also keeps
+// the reply (hash -> id map) well under the 1 MiB WebSocket message limit.
 const CONTENT_ENTRIES_PER_FRAME = 2000;
 const REGISTER_ENTRIES_PER_FRAME = 2000;
-const LOOKUP_HASHES_PER_FRAME = 10000;
+const LOOKUP_HASHES_PER_FRAME = 5000;
 
 const ContentEntrySchema = z.object({
     family: FamilySchema,
@@ -74,7 +86,7 @@ const RegisterEntrySchema = z.object({
     family: FamilySchema,
     // Engine-internal pseudo attributes/effects carry negative int32 IDs.
     entry_id: z.number().int().gte(-2147483648).lte(2147483647),
-    content_hash: z.string().regex(HASH_RE),
+    content_id: z.number().int().positive(),
 });
 
 const SnapshotSelectorSchema = z.object({
@@ -114,9 +126,9 @@ const ClientMessageSchema = z.discriminatedUnion("type", [
 ]);
 
 // D1 allows at most 100 bound parameters per statement.
-const CONTENT_ROWS_PER_STATEMENT = 50; // 2 params per row
-const REGISTER_ROWS_PER_STATEMENT = 24; // 4 params per row + 2 freeze-guard params
-const HASHES_PER_LOOKUP = 100;
+const CONTENT_ROWS_PER_STATEMENT = 32; // 3 params per row
+const REGISTER_ROWS_PER_STATEMENT = 25; // 4 params per row
+const HASHES_PER_LOOKUP = 49; // 2 params per hash (family + hash)
 const STATEMENTS_PER_BATCH = 50;
 
 function base64ToBytes(value: string): Uint8Array {
@@ -134,6 +146,18 @@ function bytesToHex(bytes: Uint8Array): string {
         hex += b.toString(16).padStart(2, "0");
     }
     return hex;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return bytes;
+}
+
+function hexToBlob(hex: string): ArrayBuffer {
+    return hexToBytes(hex).buffer as ArrayBuffer;
 }
 
 // Matches bootstrap/remote/hash.py content_hash(): plain SHA-256 of the raw
@@ -162,10 +186,83 @@ class SyncFailure extends Error {
 type ContentEntry = z.infer<typeof ContentEntrySchema>;
 type RegisterEntry = z.infer<typeof RegisterEntrySchema>;
 
+interface SnapshotRow {
+    snapshot_id: number;
+    completed_at: string | null;
+}
+
+// Resolve (server_id, snapshot_hash) to its registry row, if any.
+async function findSnapshot(
+    db: D1Database,
+    serverId: string,
+    snapshotHash: string,
+): Promise<SnapshotRow | null> {
+    return await db
+        .prepare(
+            "SELECT snapshot_id, completed_at FROM snapshots " +
+                "WHERE server_id = ? AND snapshot_hash = ?",
+        )
+        .bind(serverId, hexToBlob(snapshotHash))
+        .first<SnapshotRow>();
+}
+
+// Resolve-or-create the pending registry row for a snapshot. Registration
+// rows reference snapshot_id, so the row must exist before the first
+// register frame; `complete` later fills entry_count/completed_at.
+async function ensureSnapshot(
+    db: D1Database,
+    serverId: string,
+    snapshotHash: string,
+): Promise<SnapshotRow> {
+    await db
+        .prepare("INSERT OR IGNORE INTO snapshots (server_id, snapshot_hash) VALUES (?, ?)")
+        .bind(serverId, hexToBlob(snapshotHash))
+        .run();
+    const row = await findSnapshot(db, serverId, snapshotHash);
+    if (!row) {
+        throw new Error("snapshots row missing after insert");
+    }
+    return row;
+}
+
+// Resolve the content ids of the given hashes in one family. Returns the
+// hash -> id map for present rows and the list of missing hashes.
+async function resolveContentIds(
+    db: D1Database,
+    family: Family,
+    contentHashes: string[],
+): Promise<{ ids: Record<string, number>; missing: string[] }> {
+    const familyCode = FAMILY_CODES[family];
+    const ids: Record<string, number> = {};
+    const missing: string[] = [];
+    for (const chunk of chunked([...new Set(contentHashes)], HASHES_PER_LOOKUP)) {
+        const placeholders = chunk.map(() => "?").join(", ");
+        const found = await db
+            .prepare(
+                "SELECT content_id, content_hash FROM entries " +
+                    `WHERE family = ? AND content_hash IN (${placeholders})`,
+            )
+            .bind(familyCode, ...chunk.map(hexToBlob))
+            .all<{ content_id: number; content_hash: ArrayBuffer }>();
+        const foundSet = new Set<string>();
+        for (const row of found.results) {
+            const hex = bytesToHex(new Uint8Array(row.content_hash));
+            ids[hex] = row.content_id;
+            foundSet.add(hex);
+        }
+        for (const hash of chunk) {
+            if (!foundSet.has(hash)) {
+                missing.push(hash);
+            }
+        }
+    }
+    return { ids, missing };
+}
+
 async function handleContent(
     db: D1Database,
     entries: ContentEntry[],
-): Promise<{ inserted: number }> {
+): Promise<{ inserted: number; ids: Record<string, number> }> {
     const byFamily = new Map<Family, { hash: string; content: Uint8Array }[]>();
     const rejected: { family: Family; content_hash: string; reason: string }[] = [];
     for (const entry of entries) {
@@ -201,19 +298,21 @@ async function handleContent(
     }
 
     let inserted = 0;
+    const ids: Record<string, number> = {};
     for (const [family, rows] of byFamily) {
-        const table = FAMILIES[family].content;
         const statements: D1PreparedStatement[] = [];
         for (const chunk of chunked(rows, CONTENT_ROWS_PER_STATEMENT)) {
-            const placeholders = chunk.map(() => "(?, ?)").join(", ");
-            const binds: (string | ArrayBuffer)[] = chunk.flatMap((row) => [
-                row.hash,
+            const placeholders = chunk.map(() => "(?, ?, ?)").join(", ");
+            const binds: (number | ArrayBuffer)[] = chunk.flatMap((row) => [
+                FAMILY_CODES[family],
+                hexToBlob(row.hash),
                 row.content.buffer as ArrayBuffer,
             ]);
             statements.push(
                 db
                     .prepare(
-                        `INSERT OR IGNORE INTO ${table} (content_hash, content) VALUES ${placeholders}`,
+                        "INSERT OR IGNORE INTO entries (family, content_hash, content) " +
+                            `VALUES ${placeholders}`,
                     )
                     .bind(...binds),
             );
@@ -224,31 +323,24 @@ async function handleContent(
                 inserted += result.meta.changes ?? 0;
             }
         }
+        // Resolve the ids of every row in the frame, freshly inserted and
+        // pre-existing alike (INSERT OR IGNORE does not report which).
+        const resolved = await resolveContentIds(
+            db,
+            family,
+            rows.map((row) => row.hash),
+        );
+        Object.assign(ids, resolved.ids);
     }
-    return { inserted };
+    return { inserted, ids };
 }
 
 async function handleLookup(
     db: D1Database,
     family: Family,
     contentHashes: string[],
-): Promise<{ missing: string[] }> {
-    const table = FAMILIES[family].content;
-    const missing: string[] = [];
-    for (const chunk of chunked([...new Set(contentHashes)], HASHES_PER_LOOKUP)) {
-        const placeholders = chunk.map(() => "?").join(", ");
-        const found = await db
-            .prepare(`SELECT content_hash FROM ${table} WHERE content_hash IN (${placeholders})`)
-            .bind(...chunk)
-            .all<{ content_hash: string }>();
-        const foundSet = new Set(found.results.map((row) => row.content_hash));
-        for (const hash of chunk) {
-            if (!foundSet.has(hash)) {
-                missing.push(hash);
-            }
-        }
-    }
-    return { missing };
+): Promise<{ missing: string[]; ids: Record<string, number> }> {
+    return await resolveContentIds(db, family, contentHashes);
 }
 
 async function handleRegister(
@@ -257,64 +349,77 @@ async function handleRegister(
     snapshotHash: string,
     entries: RegisterEntry[],
 ): Promise<{ inserted: number }> {
-    const byFamily = new Map<Family, { id: number; hash: string }[]>();
-    for (const entry of entries) {
-        const rows = byFamily.get(entry.family) ?? [];
-        rows.push({ id: entry.entry_id, hash: entry.content_hash });
-        byFamily.set(entry.family, rows);
+    const snapshot = await ensureSnapshot(db, serverId, snapshotHash);
+    if (snapshot.completed_at !== null) {
+        throw new SyncFailure({ error: "Snapshot already complete" });
     }
 
-    // Referential integrity: every registered content hash must already exist.
-    const missing: { family: Family; content_hash: string }[] = [];
-    for (const [family, rows] of byFamily) {
-        const result = await handleLookup(
-            db,
-            family,
-            rows.map((row) => row.hash),
-        );
-        for (const hash of result.missing) {
-            missing.push({ family, content_hash: hash });
+    // Referential integrity: every referenced content id must exist and
+    // belong to the entry's stated family.
+    const missing: { family: Family; content_id: number }[] = [];
+    const byFamily = new Map<Family, number[]>();
+    for (const entry of entries) {
+        const ids = byFamily.get(entry.family) ?? [];
+        ids.push(entry.content_id);
+        byFamily.set(entry.family, ids);
+    }
+    for (const [family, contentIds] of byFamily) {
+        const familyCode = FAMILY_CODES[family];
+        for (const chunk of chunked([...new Set(contentIds)], HASHES_PER_LOOKUP)) {
+            const placeholders = chunk.map(() => "?").join(", ");
+            const found = await db
+                .prepare(
+                    "SELECT content_id FROM entries " +
+                        `WHERE family = ? AND content_id IN (${placeholders})`,
+                )
+                .bind(familyCode, ...chunk)
+                .all<{ content_id: number }>();
+            const foundSet = new Set(found.results.map((row) => row.content_id));
+            for (const contentId of chunk) {
+                if (!foundSet.has(contentId)) {
+                    missing.push({ family, content_id: contentId });
+                }
+            }
         }
     }
     if (missing.length > 0) {
-        throw new SyncFailure({ error: "Unknown content hashes", missing: missing.slice(0, 100) });
+        throw new SyncFailure({ error: "Unknown content ids", missing: missing.slice(0, 100) });
+    }
+
+    const byFamilyEntries = new Map<Family, { id: number; contentId: number }[]>();
+    for (const entry of entries) {
+        const rows = byFamilyEntries.get(entry.family) ?? [];
+        rows.push({ id: entry.entry_id, contentId: entry.content_id });
+        byFamilyEntries.set(entry.family, rows);
     }
 
     let inserted = 0;
-    for (const [family, rows] of byFamily) {
-        const table = FAMILIES[family].reg;
-        const statements: D1PreparedStatement[] = [];
+    const statements: D1PreparedStatement[] = [];
+    for (const [family, rows] of byFamilyEntries) {
+        const familyCode = FAMILY_CODES[family];
         for (const chunk of chunked(rows, REGISTER_ROWS_PER_STATEMENT)) {
             const placeholders = chunk.map(() => "(?, ?, ?, ?)").join(", ");
-            const binds = chunk.flatMap((row) => [serverId, snapshotHash, row.id, row.hash]);
-            binds.push(serverId, snapshotHash);
+            const binds = chunk.flatMap((row) => [
+                snapshot.snapshot_id,
+                familyCode,
+                row.id,
+                row.contentId,
+            ]);
             statements.push(
                 db
                     .prepare(
-                        `INSERT OR IGNORE INTO ${table} ` +
-                            "(server_id, snapshot_hash, entry_id, content_hash) " +
-                            `SELECT column1, column2, column3, column4 FROM (VALUES ${placeholders}) ` +
-                            "WHERE NOT EXISTS (" +
-                            "SELECT 1 FROM snapshots WHERE server_id = ? AND snapshot_hash = ?" +
-                            ")",
+                        "INSERT OR IGNORE INTO snapshot_entries " +
+                            `(snapshot_id, family, entry_id, content_id) VALUES ${placeholders}`,
                     )
                     .bind(...binds),
             );
         }
-        for (const batch of chunked(statements, STATEMENTS_PER_BATCH)) {
-            const results = await db.batch(batch);
-            for (const result of results) {
-                inserted += result.meta.changes ?? 0;
-            }
-        }
     }
-
-    const snapshot = await db
-        .prepare("SELECT entry_count FROM snapshots WHERE server_id = ? AND snapshot_hash = ?")
-        .bind(serverId, snapshotHash)
-        .first();
-    if (snapshot) {
-        throw new SyncFailure({ error: "Snapshot already complete" });
+    for (const batch of chunked(statements, STATEMENTS_PER_BATCH)) {
+        const results = await db.batch(batch);
+        for (const result of results) {
+            inserted += result.meta.changes ?? 0;
+        }
     }
     return { inserted };
 }
@@ -325,17 +430,22 @@ async function handleComplete(
     snapshotHash: string,
     entryCount: number,
 ): Promise<Record<string, never>> {
+    const snapshot = await findSnapshot(db, serverId, snapshotHash);
+    if (!snapshot) {
+        throw new SyncFailure({
+            error: "Snapshot incomplete",
+            expected: entryCount,
+            registered: 0,
+        });
+    }
+
     // Verify completeness server-side: the marker is only written when the
     // registration rows actually present match the uploader's entry count.
-    let registered = 0;
-    for (const family of Object.keys(FAMILIES) as Family[]) {
-        const table = FAMILIES[family].reg;
-        const row = await db
-            .prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE server_id = ? AND snapshot_hash = ?`)
-            .bind(serverId, snapshotHash)
-            .first<{ n: number }>();
-        registered += row?.n ?? 0;
-    }
+    const row = await db
+        .prepare("SELECT COUNT(*) AS n FROM snapshot_entries WHERE snapshot_id = ?")
+        .bind(snapshot.snapshot_id)
+        .first<{ n: number }>();
+    const registered = row?.n ?? 0;
     if (registered !== entryCount) {
         throw new SyncFailure({
             error: "Snapshot incomplete",
@@ -346,9 +456,11 @@ async function handleComplete(
 
     await db
         .prepare(
-            "INSERT OR REPLACE INTO snapshots (server_id, snapshot_hash, entry_count) VALUES (?, ?, ?)",
+            "UPDATE snapshots SET entry_count = ?, " +
+                "completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') " +
+                "WHERE snapshot_id = ?",
         )
-        .bind(serverId, snapshotHash, entryCount)
+        .bind(entryCount, snapshot.snapshot_id)
         .run();
     return {};
 }
@@ -360,14 +472,19 @@ async function handleSnapshot(
 ): Promise<{ complete: boolean; entry_count?: number; completed_at?: string }> {
     const row = await db
         .prepare(
-            "SELECT entry_count, completed_at FROM snapshots WHERE server_id = ? AND snapshot_hash = ?",
+            "SELECT entry_count, completed_at FROM snapshots " +
+                "WHERE server_id = ? AND snapshot_hash = ?",
         )
-        .bind(serverId, snapshotHash)
-        .first<{ entry_count: number; completed_at: string }>();
-    if (!row) {
+        .bind(serverId, hexToBlob(snapshotHash))
+        .first<{ entry_count: number | null; completed_at: string | null }>();
+    if (!row || row.completed_at === null) {
         return { complete: false };
     }
-    return { complete: true, entry_count: row.entry_count, completed_at: row.completed_at };
+    return {
+        complete: true,
+        entry_count: row.entry_count ?? undefined,
+        completed_at: row.completed_at,
+    };
 }
 
 export class SyncSession extends DurableObject<Env> {

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -27,8 +27,7 @@
 //          (present and freshly inserted alike) are resolved for the client.
 //          `ids` is keyed by hash alone: ids are only unique per
 //          (family, hash), so a frame must not carry identical content bytes
-//          under two families (the pipeline's per-family protobuf schemas
-//          make this impossible in practice).
+//          under two families (the uploader sends one family per frame).
 //   {type: "lookup",   id, family, content_hashes: [hex]}
 //       -> {id, ok: true, missing: [hex], ids: {content_hash: content_id}} —
 //          hashes not yet present in the family, plus the content ids of the

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -37,7 +37,9 @@
 //          snapshot not being frozen by a `complete` marker yet.
 //   {type: "complete", id, server_id, snapshot_hash, entry_count}
 //       -> {id, ok: true} — freezes the snapshot after verifying the actual
-//          registration row count server-side.
+//          registration row count server-side; the count check and the
+//          freeze are one atomic UPDATE, and a retry of the same frame after
+//          a lost reply succeeds.
 //   {type: "snapshot", id, server_id, snapshot_hash}
 //       -> {id, ok: true, complete: bool, entry_count?, completed_at?} —
 //          completeness probe so reruns can skip finished snapshots.
@@ -126,7 +128,7 @@ const ClientMessageSchema = z.discriminatedUnion("type", [
 
 // D1 allows at most 100 bound parameters per statement.
 const CONTENT_ROWS_PER_STATEMENT = 32; // 3 params per row
-const REGISTER_ROWS_PER_STATEMENT = 25; // 4 params per row
+const REGISTER_ROWS_PER_STATEMENT = 24; // 4 params per row + 1 freeze-guard param
 const HASHES_PER_LOOKUP = 49; // 2 params per hash (family + hash)
 const STATEMENTS_PER_BATCH = 50;
 
@@ -187,6 +189,7 @@ type RegisterEntry = z.infer<typeof RegisterEntrySchema>;
 
 interface SnapshotRow {
     snapshot_id: number;
+    entry_count: number | null;
     completed_at: string | null;
 }
 
@@ -198,7 +201,7 @@ async function findSnapshot(
 ): Promise<SnapshotRow | null> {
     return await db
         .prepare(
-            "SELECT snapshot_id, completed_at FROM snapshots " +
+            "SELECT snapshot_id, entry_count, completed_at FROM snapshots " +
                 "WHERE server_id = ? AND snapshot_hash = ?",
         )
         .bind(serverId, hexToBlob(snapshotHash))
@@ -349,6 +352,10 @@ async function handleRegister(
     entries: RegisterEntry[],
 ): Promise<{ inserted: number }> {
     const snapshot = await ensureSnapshot(db, serverId, snapshotHash);
+    // Fast path only. The authoritative freeze check is the guard on every
+    // insert plus the completed_at probe in the final batch below: the
+    // Durable Object input gate does not cover external D1 operations, so a
+    // concurrent complete event can commit between this read and the inserts.
     if (snapshot.completed_at !== null) {
         throw new SyncFailure({ error: "Snapshot already complete" });
     }
@@ -398,26 +405,60 @@ async function handleRegister(
         const familyCode = FAMILY_CODES[family];
         for (const chunk of chunked(rows, REGISTER_ROWS_PER_STATEMENT)) {
             const placeholders = chunk.map(() => "(?, ?, ?, ?)").join(", ");
-            const binds = chunk.flatMap((row) => [
+            const binds = [
+                ...chunk.flatMap((row) => [
+                    snapshot.snapshot_id,
+                    familyCode,
+                    row.id,
+                    row.contentId,
+                ]),
                 snapshot.snapshot_id,
-                familyCode,
-                row.id,
-                row.contentId,
-            ]);
+            ];
+            // Every insert is conditional on the snapshot not being frozen:
+            // INSERT OR IGNORE alone would silently add rows to an already
+            // completed snapshot if a complete event won the race after the
+            // fast-path check above. (SQLite names the columns of a VALUES
+            // subquery column1..column4.)
             statements.push(
                 db
                     .prepare(
                         "INSERT OR IGNORE INTO snapshot_entries " +
-                            `(snapshot_id, family, entry_id, content_id) VALUES ${placeholders}`,
+                            "(snapshot_id, family, entry_id, content_id) " +
+                            "SELECT column1, column2, column3, column4 " +
+                            `FROM (VALUES ${placeholders}) ` +
+                            "WHERE EXISTS (SELECT 1 FROM snapshots " +
+                            "WHERE snapshot_id = ? AND completed_at IS NULL)",
                     )
                     .bind(...binds),
             );
         }
     }
-    for (const batch of chunked(statements, STATEMENTS_PER_BATCH)) {
+    // The final batch also probes completed_at. A batch commits atomically,
+    // so a concurrent complete either committed before it (the guards above
+    // inserted nothing and the probe observes the freeze, rejecting this
+    // frame) or runs after it (and counts these rows in its own atomic
+    // count-and-freeze update). Registration and completion therefore cannot
+    // interleave into a frozen snapshot whose entry_count disagrees with its
+    // registration set.
+    const batches = chunked(statements, STATEMENTS_PER_BATCH);
+    for (const [index, batch] of batches.entries()) {
+        const isLast = index === batches.length - 1;
+        if (isLast) {
+            batch.push(
+                db
+                    .prepare("SELECT completed_at FROM snapshots WHERE snapshot_id = ?")
+                    .bind(snapshot.snapshot_id),
+            );
+        }
         const results = await db.batch(batch);
-        for (const result of results) {
+        for (const result of isLast ? results.slice(0, -1) : results) {
             inserted += result.meta.changes ?? 0;
+        }
+        if (isLast) {
+            const probe = results.at(-1)?.results[0] as { completed_at: string | null } | undefined;
+            if (probe?.completed_at != null) {
+                throw new SyncFailure({ error: "Snapshot already complete" });
+            }
         }
     }
     return { inserted };
@@ -438,30 +479,54 @@ async function handleComplete(
         });
     }
 
-    // Verify completeness server-side: the marker is only written when the
-    // registration rows actually present match the uploader's entry count.
-    const row = await db
-        .prepare("SELECT COUNT(*) AS n FROM snapshot_entries WHERE snapshot_id = ?")
-        .bind(snapshot.snapshot_id)
-        .first<{ n: number }>();
-    const registered = row?.n ?? 0;
-    if (registered !== entryCount) {
-        throw new SyncFailure({
-            error: "Snapshot incomplete",
-            expected: entryCount,
-            registered,
-        });
+    // Idempotent retry of a complete frame whose reply was lost.
+    if (snapshot.completed_at !== null) {
+        if (snapshot.entry_count === entryCount) {
+            return {};
+        }
+        throw new SyncFailure({ error: "Snapshot already complete" });
     }
 
-    await db
+    // Atomic completion: the count verification, the not-yet-frozen check,
+    // and the marker write are a single UPDATE statement. A concurrent
+    // register frame can therefore never slip rows in between the
+    // verification and the freeze (the Durable Object input gate does not
+    // cover external D1 operations).
+    const result = await db
         .prepare(
             "UPDATE snapshots SET entry_count = ?, " +
                 "completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') " +
-                "WHERE snapshot_id = ?",
+                "WHERE snapshot_id = ? AND completed_at IS NULL AND " +
+                "(SELECT COUNT(*) FROM snapshot_entries WHERE snapshot_id = ?) = ?",
         )
-        .bind(entryCount, snapshot.snapshot_id)
+        .bind(entryCount, snapshot.snapshot_id, snapshot.snapshot_id, entryCount)
         .run();
-    return {};
+    if ((result.meta.changes ?? 0) > 0) {
+        return {};
+    }
+
+    // The conditional update matched no row: a concurrent complete won the
+    // race, or the registration count moved under us. Re-read to report
+    // which one happened.
+    const state = await db
+        .prepare(
+            "SELECT entry_count, completed_at, " +
+                "(SELECT COUNT(*) FROM snapshot_entries WHERE snapshot_id = ?) AS registered " +
+                "FROM snapshots WHERE snapshot_id = ?",
+        )
+        .bind(snapshot.snapshot_id, snapshot.snapshot_id)
+        .first<{ entry_count: number | null; completed_at: string | null; registered: number }>();
+    if (state?.completed_at != null) {
+        if (state.entry_count === entryCount) {
+            return {};
+        }
+        throw new SyncFailure({ error: "Snapshot already complete" });
+    }
+    throw new SyncFailure({
+        error: "Snapshot incomplete",
+        expected: entryCount,
+        registered: state?.registered ?? 0,
+    });
 }
 
 async function handleSnapshot(

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -69,6 +69,14 @@ function toBase64(data: Uint8Array): string {
     return btoa(String.fromCharCode(...data));
 }
 
+function hexToBlob(hex: string): ArrayBuffer {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return bytes.buffer as ArrayBuffer;
+}
+
 describe("sync route access", () => {
     it("rejects unauthenticated upgrade requests", async () => {
         const res = await worker.fetch(
@@ -115,7 +123,7 @@ describe("frame validation", () => {
 });
 
 describe("lookup", () => {
-    it("reports only the hashes missing from the family content table", async () => {
+    it("reports missing hashes and resolves ids for present rows", async () => {
         const ws = await connect();
         const content = new TextEncoder().encode("type-entry-1");
         const contentHash = await sha256Hex(content);
@@ -126,15 +134,17 @@ describe("lookup", () => {
             family: "types",
             content_hashes: [contentHash],
         });
-        expect(before).toEqual({ id: 1, ok: true, missing: [contentHash] });
+        expect(before).toEqual({ id: 1, ok: true, missing: [contentHash], ids: {} });
 
-        await call(ws, {
+        const upload = await call(ws, {
             id: 2,
             type: "content",
             entries: [
                 { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
             ],
         });
+        const ids = upload.ids as Record<string, number>;
+        expect(ids[contentHash]).toBeGreaterThan(0);
 
         const after = await call(ws, {
             id: 3,
@@ -142,7 +152,12 @@ describe("lookup", () => {
             family: "types",
             content_hashes: [contentHash, "00".repeat(32)],
         });
-        expect(after).toEqual({ id: 3, ok: true, missing: ["00".repeat(32)] });
+        expect(after).toEqual({
+            id: 3,
+            ok: true,
+            missing: ["00".repeat(32)],
+            ids: { [contentHash]: ids[contentHash] },
+        });
 
         ws.close();
     });
@@ -164,14 +179,18 @@ describe("snapshot freeze", () => {
                 { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
             ],
         });
-        expect(reply).toEqual({ id: 1, ok: true, inserted: 1 });
+        expect(reply.id).toBe(1);
+        expect(reply.ok).toBe(true);
+        expect(reply.inserted).toBe(1);
+        const contentId = (reply.ids as Record<string, number>)[contentHash];
+        expect(contentId).toBeGreaterThan(0);
 
         reply = await call(ws, {
             id: 2,
             type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
-            entries: [{ family: "types", entry_id: 1, content_hash: contentHash }],
+            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
         });
         expect(reply).toEqual({ id: 2, ok: true, inserted: 1 });
 
@@ -189,16 +208,18 @@ describe("snapshot freeze", () => {
             type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
-            entries: [{ family: "types", entry_id: 2, content_hash: contentHash }],
+            entries: [{ family: "types", entry_id: 2, content_id: contentId }],
         });
         expect(reply.id).toBe(4);
         expect(reply.ok).toBe(false);
         expect(reply.error).toBe("Snapshot already complete");
 
         const regCount = await env.PLATFORM_DB.prepare(
-            "SELECT COUNT(*) AS n FROM types_reg WHERE server_id = ? AND snapshot_hash = ?",
+            "SELECT COUNT(*) AS n FROM snapshot_entries se " +
+                "JOIN snapshots s ON s.snapshot_id = se.snapshot_id " +
+                "WHERE s.server_id = ? AND s.snapshot_hash = ?",
         )
-            .bind(serverId, snapshotHash)
+            .bind(serverId, hexToBlob(snapshotHash))
             .first<{ n: number }>();
         expect(regCount?.n).toBe(1);
 
@@ -228,18 +249,57 @@ describe("snapshot freeze", () => {
         ws.close();
     });
 
-    it("rejects registration of unknown content hashes", async () => {
+    it("reports pending (registered but not completed) snapshots as incomplete", async () => {
+        const ws = await connect();
+        const serverId = "tranquility";
+        const snapshotHash = "12".repeat(32);
+
+        const content = new TextEncoder().encode("type-entry-1");
+        const contentHash = await sha256Hex(content);
+        const upload = await call(ws, {
+            id: 1,
+            type: "content",
+            entries: [
+                { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
+            ],
+        });
+        const contentId = (upload.ids as Record<string, number>)[contentHash];
+
+        await call(ws, {
+            id: 2,
+            type: "register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
+        });
+
+        const reply = await call(ws, {
+            id: 3,
+            type: "snapshot",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+        });
+        expect(reply).toEqual({ id: 3, ok: true, complete: false });
+
+        const res = await get(`/snapshot?server_id=${serverId}&snapshot_hash=${snapshotHash}`);
+        const snapshot = (await res.json()) as { complete: boolean };
+        expect(snapshot.complete).toBe(false);
+
+        ws.close();
+    });
+
+    it("rejects registration of unknown content ids", async () => {
         const ws = await connect();
         const reply = await call(ws, {
             id: 1,
             type: "register",
             server_id: "tranquility",
             snapshot_hash: "cd".repeat(32),
-            entries: [{ family: "types", entry_id: 1, content_hash: "ef".repeat(32) }],
+            entries: [{ family: "types", entry_id: 1, content_id: 424242 }],
         });
         expect(reply.id).toBe(1);
         expect(reply.ok).toBe(false);
-        expect(reply.error).toBe("Unknown content hashes");
+        expect(reply.error).toBe("Unknown content ids");
         ws.close();
     });
 });
@@ -264,14 +324,17 @@ describe("entry_id validation", () => {
                 },
             ],
         });
-        expect(reply).toEqual({ id: 1, ok: true, inserted: 1 });
+        expect(reply.id).toBe(1);
+        expect(reply.ok).toBe(true);
+        expect(reply.inserted).toBe(1);
+        const contentId = (reply.ids as Record<string, number>)[contentHash];
 
         reply = await call(ws, {
             id: 2,
             type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
-            entries: [{ family: "dogma_effects", entry_id: -64, content_hash: contentHash }],
+            entries: [{ family: "dogma_effects", entry_id: -64, content_id: contentId }],
         });
         expect(reply).toEqual({ id: 2, ok: true, inserted: 1 });
 
@@ -286,7 +349,7 @@ describe("entry_id validation", () => {
                 type: "register",
                 server_id: "tranquility",
                 snapshot_hash: "ef".repeat(32),
-                entries: [{ family: "types", entry_id: entryId, content_hash: "ab".repeat(32) }],
+                entries: [{ family: "types", entry_id: entryId, content_id: 1 }],
             });
             expect(reply.id).toBe(1);
             expect(reply.ok).toBe(false);

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -249,6 +249,102 @@ describe("snapshot freeze", () => {
         ws.close();
     });
 
+    it("never freezes a snapshot whose entry_count disagrees with its rows", async () => {
+        // Regression test for the register/complete race: Durable Object
+        // input gates do not cover external D1 operations, so a complete
+        // event can run between a register event's completed_at check and
+        // its inserts. The register frame below spans multiple D1 batches
+        // (2000 entries at 24 rows/statement over 50-statement batches) so
+        // the concurrent complete has real windows to interleave. Whichever
+        // side wins, the invariant must hold: a frozen snapshot's
+        // entry_count equals its actual registration row count.
+        const content = new TextEncoder().encode("type-entry-1");
+        const contentHash = await sha256Hex(content);
+
+        for (let round = 0; round < 5; round++) {
+            const ws1 = await connect();
+            const ws2 = await connect();
+            const serverId = "tranquility";
+            const snapshotHash = round.toString(16).padStart(2, "0").repeat(32);
+
+            const upload = await call(ws1, {
+                id: 1,
+                type: "content",
+                entries: [
+                    { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
+                ],
+            });
+            const contentId = (upload.ids as Record<string, number>)[contentHash];
+
+            const first = await call(ws1, {
+                id: 2,
+                type: "register",
+                server_id: serverId,
+                snapshot_hash: snapshotHash,
+                entries: [{ family: "types", entry_id: 1, content_id: contentId }],
+            });
+            expect(first).toEqual({ id: 2, ok: true, inserted: 1 });
+
+            // Fire both frames without awaiting so the two events interleave
+            // at their D1 awaits.
+            const [registerReply, completeReply] = await Promise.all([
+                call(ws1, {
+                    id: 3,
+                    type: "register",
+                    server_id: serverId,
+                    snapshot_hash: snapshotHash,
+                    entries: Array.from({ length: 2000 }, (_, i) => ({
+                        family: "types",
+                        entry_id: i + 2,
+                        content_id: contentId,
+                    })),
+                }),
+                call(ws2, {
+                    id: 4,
+                    type: "complete",
+                    server_id: serverId,
+                    snapshot_hash: snapshotHash,
+                    entry_count: 1,
+                }),
+            ]);
+
+            const regCount = await env.PLATFORM_DB.prepare(
+                "SELECT COUNT(*) AS n FROM snapshot_entries se " +
+                    "JOIN snapshots s ON s.snapshot_id = se.snapshot_id " +
+                    "WHERE s.server_id = ? AND s.snapshot_hash = ?",
+            )
+                .bind(serverId, hexToBlob(snapshotHash))
+                .first<{ n: number }>();
+
+            const probe = await call(ws1, {
+                id: 5,
+                type: "snapshot",
+                server_id: serverId,
+                snapshot_hash: snapshotHash,
+            });
+
+            if (completeReply.ok) {
+                // Completion won before any register batch committed: the
+                // freeze guards must have rejected every later insert.
+                expect(registerReply.ok).toBe(false);
+                expect(registerReply.error).toBe("Snapshot already complete");
+                expect(regCount?.n).toBe(1);
+                expect(probe.complete).toBe(true);
+                expect(probe.entry_count).toBe(1);
+            } else {
+                // The register committed rows the count check then saw, so
+                // completion must have failed instead of freezing a lie.
+                expect(completeReply.error).toBe("Snapshot incomplete");
+                expect(registerReply.ok).toBe(true);
+                expect(regCount?.n).toBe(2001);
+                expect(probe.complete).toBe(false);
+            }
+
+            ws1.close();
+            ws2.close();
+        }
+    });
+
     it("reports pending (registered but not completed) snapshots as incomplete", async () => {
         const ws = await connect();
         const serverId = "tranquility";

--- a/worker/efa-platform-data-sync/wrangler.toml
+++ b/worker/efa-platform-data-sync/wrangler.toml
@@ -4,8 +4,8 @@ main = "src/index.ts"
 
 [[d1_databases]]
 binding = "PLATFORM_DB"
-database_name = "efa-platform-snapshots"
-database_id = "ad8a55e2-3786-4258-ba79-e1f6ed30b498"
+database_name = "efa-snapshot-registry"
+database_id = "f75c61bb-7aca-4c6b-b67a-4332d172872c"
 migrations_dir = "migrations"
 
 # Sync session Durable Object: one named instance ("sync") terminates the

--- a/worker/efa-platform-fit-storage/README.md
+++ b/worker/efa-platform-fit-storage/README.md
@@ -36,15 +36,18 @@ Error responses are JSON `{ "error": <code>, "message": <string> }` (+ an
 | --- | --- | --- |
 | 400 | `bad_request` | Malformed protobuf, constraint violations |
 | 404 | `not_found` | Unknown fit hash |
-| 409 | `snapshot_incomplete` | `(server_id, snapshot_hash)` not in the `snapshots` registry |
+| 409 | `snapshot_incomplete` | `(server_id, snapshot_hash)` has no completed row in the `snapshots` registry |
 | 422 | `unknown_type` | A referenced type ID has no row in the snapshot |
 | 422 | `validation_failed` | Engine `validate_fit` returned Error-level issues |
 
 ## How it works
 
-- Engine data comes from the `efa-platform-snapshots` D1 database (populated
-  by `worker/efa-platform-data-sync`), addressed by the client-supplied
-  `(server_id, snapshot_hash)`. A 3-round transitive-closure prefetch
+- Engine data comes from the `efa-snapshot-registry` D1 database
+  (populated by `worker/efa-platform-data-sync`), addressed by the
+  client-supplied `(server_id, snapshot_hash)`. The selector is resolved to
+  the registry's `snapshot_id` (requiring `completed_at IS NOT NULL`, cached
+  per isolate), and rows are read from `snapshot_entries` ⋈ `entries` by
+  `(snapshot_id, family)`. A 3-round transitive-closure prefetch
   (`src/prefetch.rs`) loads exactly the reachable rows; a `thread_local!`
   isolate cache makes warm requests zero-query.
 - `eve-fit-os` is used with `default-features = false`; the worker decodes
@@ -92,7 +95,7 @@ pointing at it (never overwriting an existing one).
 
 `wrangler deploy --env preview` targets the `[env.preview]` preview chain:
 `FIT_DB` points at the disposable
-`efa-platform-test` database; `PLATFORM_DB` stays on `efa-platform-snapshots`
+`efa-platform-test` database; `PLATFORM_DB` stays on `efa-snapshot-registry`
 (engine data is read-only and shared).
 
 ## Deployment (one-time setup)

--- a/worker/efa-platform-fit-storage/src/d1.rs
+++ b/worker/efa-platform-fit-storage/src/d1.rs
@@ -22,9 +22,13 @@ fn js_blob(bytes: &[u8]) -> JsValue {
 }
 
 /// Lowercase hex -> raw bytes (snapshot hashes are stored as 32-byte BLOBs).
+/// Validate before slicing: `str::len` counts UTF-8 bytes, so slicing a
+/// non-ASCII hash (e.g. "aé…") would panic on a non-char boundary.
 fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, ApiError> {
-    if !hex.len().is_multiple_of(2) {
-        return Err(ApiError::internal("hex string has odd length"));
+    if hex.len() != 64 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(ApiError::bad_request(
+            "snapshot_hash must be a 64-character ASCII hexadecimal string",
+        ));
     }
     (0..hex.len() / 2)
         .map(|i| {

--- a/worker/efa-platform-fit-storage/src/d1.rs
+++ b/worker/efa-platform-fit-storage/src/d1.rs
@@ -5,14 +5,14 @@ use worker::{js_sys, wasm_bindgen::JsValue};
 use crate::error::ApiError;
 use crate::prefetch::FetchRequest;
 
-/// D1's bound-parameter limit is 100; reserve 2 for server_id/snapshot_hash.
+/// D1's bound-parameter limit is 100; reserve 2 for snapshot_id/family.
 const MAX_ENTRY_IDS_PER_CHUNK: usize = 98;
 
 fn js_text(value: &str) -> JsValue {
     JsValue::from_str(value)
 }
 
-fn js_int(value: i32) -> JsValue {
+fn js_int(value: i64) -> JsValue {
     JsValue::from_f64(value as f64)
 }
 
@@ -21,11 +21,32 @@ fn js_blob(bytes: &[u8]) -> JsValue {
     js_sys::Uint8Array::from(bytes).buffer().into()
 }
 
+/// Lowercase hex -> raw bytes (snapshot hashes are stored as 32-byte BLOBs).
+fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, ApiError> {
+    if !hex.len().is_multiple_of(2) {
+        return Err(ApiError::internal("hex string has odd length"));
+    }
+    (0..hex.len() / 2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16)
+                .map_err(|e| ApiError::internal(format!("invalid hex: {e}")))
+        })
+        .collect()
+}
+
 fn row_int(row: &JsValue, index: u32) -> Result<i32, ApiError> {
     js_sys::Reflect::get(row, &JsValue::from_f64(index as f64))
         .ok()
         .and_then(|v| v.as_f64())
         .map(|v| v as i32)
+        .ok_or_else(|| ApiError::internal("D1 row: expected integer column"))
+}
+
+fn row_int64(row: &JsValue, index: u32) -> Result<i64, ApiError> {
+    js_sys::Reflect::get(row, &JsValue::from_f64(index as f64))
+        .ok()
+        .and_then(|v| v.as_f64())
+        .map(|v| v as i64)
         .ok_or_else(|| ApiError::internal("D1 row: expected integer column"))
 }
 
@@ -87,22 +108,19 @@ async fn run_change_count(
 /// Chunked family lookup (spec §7.2). `ids == None` fetches the whole family.
 pub async fn fetch_family(
     db: &D1Database,
-    server_id: &str,
-    snapshot_hash: &str,
+    snapshot_id: i64,
     request: FetchRequest,
 ) -> anyhow::Result<Vec<(i32, Vec<u8>)>> {
     let family = request.family;
-    let table = family.table();
+    let family_code = family.code();
     let mut out = Vec::new();
 
     match request.ids {
         None => {
-            let sql = format!(
-                "SELECT r.entry_id, c.content FROM {table}_reg r \
-                 JOIN {table} c ON c.content_hash = r.content_hash \
-                 WHERE r.server_id = ? AND r.snapshot_hash = ?"
-            );
-            let rows = raw_query(db, &sql, &[js_text(server_id), js_text(snapshot_hash)]).await?;
+            let sql = "SELECT se.entry_id, e.content FROM snapshot_entries se \
+                 JOIN entries e ON e.content_id = se.content_id \
+                 WHERE se.snapshot_id = ? AND se.family = ?";
+            let rows = raw_query(db, sql, &[js_int(snapshot_id), js_int(family_code)]).await?;
             for row in &rows {
                 out.push((row_int(row, 0)?, row_blob(row, 1)?));
             }
@@ -111,13 +129,13 @@ pub async fn fetch_family(
             for chunk in ids.chunks(MAX_ENTRY_IDS_PER_CHUNK) {
                 let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
                 let sql = format!(
-                    "SELECT r.entry_id, c.content FROM {table}_reg r \
-                     JOIN {table} c ON c.content_hash = r.content_hash \
-                     WHERE r.server_id = ? AND r.snapshot_hash = ? \
-                     AND r.entry_id IN ({placeholders})"
+                    "SELECT se.entry_id, e.content FROM snapshot_entries se \
+                     JOIN entries e ON e.content_id = se.content_id \
+                     WHERE se.snapshot_id = ? AND se.family = ? \
+                     AND se.entry_id IN ({placeholders})"
                 );
-                let mut params = vec![js_text(server_id), js_text(snapshot_hash)];
-                params.extend(chunk.iter().map(|id| js_int(*id)));
+                let mut params = vec![js_int(snapshot_id), js_int(family_code)];
+                params.extend(chunk.iter().map(|id| js_int(*id as i64)));
                 let rows = raw_query(db, &sql, &params).await?;
                 for row in &rows {
                     out.push((row_int(row, 0)?, row_blob(row, 1)?));
@@ -128,19 +146,26 @@ pub async fn fetch_family(
     Ok(out)
 }
 
-/// Snapshot completeness probe (spec §6.2 step 3).
-pub async fn snapshot_exists(
+/// Resolve a snapshot selector to its registry id, requiring the snapshot to
+/// be complete (spec §6.2 step 3): pending rows (`completed_at IS NULL`) are
+/// incomplete and resolve to `None`.
+pub async fn resolve_snapshot(
     db: &D1Database,
     server_id: &str,
     snapshot_hash: &str,
-) -> Result<bool, ApiError> {
+) -> Result<Option<i64>, ApiError> {
+    let snapshot_hash_bytes = hex_to_bytes(snapshot_hash)?;
     let rows = raw_query(
         db,
-        "SELECT 1 FROM snapshots WHERE server_id = ? AND snapshot_hash = ?",
-        &[js_text(server_id), js_text(snapshot_hash)],
+        "SELECT snapshot_id FROM snapshots \
+         WHERE server_id = ? AND snapshot_hash = ? AND completed_at IS NOT NULL",
+        &[js_text(server_id), js_blob(&snapshot_hash_bytes)],
     )
     .await?;
-    Ok(!rows.is_empty())
+    match rows.first() {
+        Some(row) => Ok(Some(row_int64(row, 0)?)),
+        None => Ok(None),
+    }
 }
 
 /// The stored `FitSnapshot` protobuf bytes for a fit hash, if any.

--- a/worker/efa-platform-fit-storage/src/lib.rs
+++ b/worker/efa-platform-fit-storage/src/lib.rs
@@ -62,13 +62,21 @@ async fn handle_submit(mut req: Request, env: Env) -> Result<Response, ApiError>
     let platform_db = platform_db(&env)?;
     let fit_db = fit_db(&env)?;
 
-    // 2. Snapshot completeness.
-    if !d1::snapshot_exists(&platform_db, &request.server_id, &request.snapshot_hash).await? {
-        return Err(ApiError::snapshot_incomplete(
-            &request.server_id,
-            &request.snapshot_hash,
-        ));
-    }
+    // 2. Snapshot completeness: resolve the selector to its registry id.
+    //    Resolved ids are cached per isolate (completed snapshots are frozen).
+    let key: prefetch::SnapshotKey = (request.server_id.clone(), request.snapshot_hash.clone());
+    let snapshot_id = match prefetch::snapshot_id_get(&key) {
+        Some(id) => id,
+        None => {
+            let id = d1::resolve_snapshot(&platform_db, &request.server_id, &request.snapshot_hash)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::snapshot_incomplete(&request.server_id, &request.snapshot_hash)
+                })?;
+            prefetch::snapshot_id_put(key.clone(), id);
+            id
+        }
+    };
 
     // 3. Canonicalize → fit hash.
     let canonical = hash::canonical_state(state);
@@ -81,16 +89,11 @@ async fn handle_submit(mut req: Request, env: Env) -> Result<Response, ApiError>
 
     if !already_existed {
         // 5a. Prefetch the transitive closure (unknown seed type → 422).
-        let key: prefetch::SnapshotKey = (request.server_id.clone(), request.snapshot_hash.clone());
         let mut data = prefetch::cache_get(&key);
         {
-            let server_id = request.server_id.clone();
-            let snapshot_hash = request.snapshot_hash.clone();
             let platform_db = &platform_db;
-            let fetch = |request: prefetch::FetchRequest| {
-                let server_id = server_id.clone();
-                let snapshot_hash = snapshot_hash.clone();
-                async move { d1::fetch_family(platform_db, &server_id, &snapshot_hash, request).await }
+            let fetch = |request: prefetch::FetchRequest| async move {
+                d1::fetch_family(platform_db, snapshot_id, request).await
             };
             prefetch::prefetch(&mut data, &canonical, fetch).await?;
         }

--- a/worker/efa-platform-fit-storage/src/prefetch.rs
+++ b/worker/efa-platform-fit-storage/src/prefetch.rs
@@ -73,7 +73,10 @@ impl SnapshotData {
     }
 }
 
-/// Row families of `efa-platform-snapshots` (spec §7.2).
+/// Row families of `efa-snapshot-registry` (spec §7.2). The codes are
+/// mirrored in the sync worker and driver
+/// (`worker/efa-platform-data-sync/src/session.ts`,
+/// `bootstrap/data/d1/sync.py`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Family {
     Types,
@@ -85,6 +88,18 @@ pub enum Family {
 }
 
 impl Family {
+    pub fn code(self) -> i64 {
+        match self {
+            Family::Types => 0,
+            Family::TypeDogma => 1,
+            Family::DogmaAttributes => 2,
+            Family::DogmaEffects => 3,
+            Family::Buffs => 4,
+            Family::TypeMeta => 5,
+        }
+    }
+
+    /// Diagnostic name for error messages (the v1 table name).
     pub fn table(self) -> &'static str {
         match self {
             Family::Types => "types",
@@ -105,6 +120,10 @@ impl Family {
 thread_local! {
     static ISOLATE_CACHE: std::cell::RefCell<HashMap<SnapshotKey, SnapshotData>> =
         std::cell::RefCell::new(HashMap::new());
+    // Resolved registry ids of complete snapshots; one D1 query per snapshot
+    // per isolate instead of one per request.
+    static SNAPSHOT_IDS: std::cell::RefCell<HashMap<SnapshotKey, i64>> =
+        std::cell::RefCell::new(HashMap::new());
 }
 
 /// Clone out the accumulated data for a snapshot (empty on cold isolates).
@@ -124,6 +143,19 @@ pub fn cache_merge(key: SnapshotKey, data: SnapshotData) {
                 entry.insert(data);
             }
         }
+    });
+}
+
+/// The cached registry id of a complete snapshot, if resolved before.
+pub fn snapshot_id_get(key: &SnapshotKey) -> Option<i64> {
+    SNAPSHOT_IDS.with(|ids| ids.borrow().get(key).copied())
+}
+
+/// Cache the registry id of a complete snapshot. Snapshot rows are frozen at
+/// completion, so the mapping never changes.
+pub fn snapshot_id_put(key: SnapshotKey, snapshot_id: i64) {
+    SNAPSHOT_IDS.with(|ids| {
+        ids.borrow_mut().insert(key, snapshot_id);
     });
 }
 

--- a/worker/efa-platform-fit-storage/wrangler.toml
+++ b/worker/efa-platform-fit-storage/wrangler.toml
@@ -10,8 +10,8 @@ preview_urls = false
 
 [[d1_databases]]
 binding = "PLATFORM_DB"
-database_name = "efa-platform-snapshots"
-database_id = "ad8a55e2-3786-4258-ba79-e1f6ed30b498"
+database_name = "efa-snapshot-registry"
+database_id = "f75c61bb-7aca-4c6b-b67a-4332d172872c"
 
 [[d1_databases]]
 binding = "FIT_DB"
@@ -51,8 +51,8 @@ STORAGE_ORIGIN = "https://prod.storage.efa-tech.dev"
 
 [[env.preview.d1_databases]]
 binding = "PLATFORM_DB"
-database_name = "efa-platform-snapshots"
-database_id = "ad8a55e2-3786-4258-ba79-e1f6ed30b498"
+database_name = "efa-snapshot-registry"
+database_id = "f75c61bb-7aca-4c6b-b67a-4332d172872c"
 
 [[env.preview.d1_databases]]
 binding = "FIT_DB"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared storage schema for content and snapshots.
  * Sync operations now use content IDs and provide hash-to-ID mappings.
  * Snapshot completion is tracked explicitly; incomplete snapshots are excluded from lookups and submissions.
  * Added snapshot ID caching for repeated data access.

* **Bug Fixes**
  * Detects missing content IDs during synchronization.
  * Rejects registrations that reference unknown content IDs.
  * Supports identical content hashes across different content families.

* **Documentation**
  * Updated deployment and storage documentation for the new snapshot registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->