### PR TITLE
perf(platform): freeze snapshots via a registration counter, not `COUNT(*)`

### DIFF
--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -25,11 +25,14 @@ Storage v2 uses three tables:
   referencing integer ids only (~25 B/row; the v1 schema repeated both full
   hex hashes per row at ~344 B/row including indexes).
 - `snapshots` — `(snapshot_id INTEGER PRIMARY KEY, server_id, snapshot_hash
-  BLOB, entry_count, completed_at, UNIQUE (server_id, snapshot_hash))`: the
-  completeness registry. The first `register` frame creates the row with
-  `completed_at = NULL`; the uploader's `complete` frame freezes the snapshot
-  after the worker verifies the actual registration row count. **Readers must
-  check `completed_at IS NOT NULL` and treat any other
+  BLOB, entry_count, completed_at, registered_count, UNIQUE (server_id,
+  snapshot_hash))`: the completeness registry. The first `register` frame
+  creates the row with `completed_at = NULL`; each register frame adds its
+  actually-inserted row count to `registered_count`, and the uploader's
+  `complete` frame freezes the snapshot after verifying that counter against
+  the expected entry count (O(1); a real `COUNT(*)` scan only runs to repair
+  a counter diverged by a crash or a pre-migration pending snapshot).
+  **Readers must check `completed_at IS NOT NULL` and treat any other
   `(server_id, snapshot_hash)` as incomplete.**
 
 An upload spans many WebSocket frames (one D1 transaction each), so a failed
@@ -116,14 +119,14 @@ a snapshot, further registrations for it fail with
 { "type": "complete", "id": 4, "server_id": "tranquility", "snapshot_hash": "sha256-hex", "entry_count": 8 }
 ```
 
-Marks a snapshot complete. Verifies server-side that the registration rows
-present for the snapshot equal `entry_count` (error reply otherwise), then
-sets `entry_count` and `completed_at` on the `snapshots` registry row. The
-count check and the freeze are a single conditional `UPDATE`, and every
+Marks a snapshot complete. Verifies server-side that the register-maintained
+`registered_count` equals `entry_count` (error reply otherwise); the count
+check and the freeze are a single conditional `UPDATE`, and every
 registration insert is guarded by `completed_at IS NULL`, so a concurrent
-`register` frame can never extend an already frozen registration set; a
-retry of the same `complete` frame after a lost reply succeeds. Replies
-`{ "id": 4, "ok": true }`.
+`register` frame can never extend an already frozen registration set. A
+counter diverged by a crash (or a pre-migration pending snapshot) is repaired
+with one real `COUNT(*)` before the freeze; a retry of the same `complete`
+frame after a lost reply succeeds. Replies `{ "id": 4, "ok": true }`.
 
 ### Frame: `snapshot`
 

--- a/worker/efa-platform-data-sync/migrations/0002_registered_count.sql
+++ b/worker/efa-platform-data-sync/migrations/0002_registered_count.sql
@@ -1,0 +1,19 @@
+-- Registration counter for O(1) snapshot completion.
+--
+-- 0001's `complete` frame verified the registration set with
+-- `(SELECT COUNT(*) FROM snapshot_entries WHERE snapshot_id = ?)` inside the
+-- freezing UPDATE — an ~145k-row index-range scan per snapshot (run twice on
+-- a count-mismatch retry). registered_count is maintained incrementally: each
+-- register frame adds its actually-inserted row count (INSERT OR IGNORE
+-- conflicts contribute 0, so idempotent re-sends never inflate it), and
+-- `complete` compares the counter in its atomic conditional UPDATE instead.
+--
+-- The counter update is a separate transaction from the frame's inserts, so
+-- a worker crash between them can leave the counter short; a pre-migration
+-- pending snapshot (interrupted 0001-era sync) likewise starts at 0 with
+-- partial rows. Both are self-healing: when the fast-path counter check
+-- fails, `complete` falls back to one real COUNT(*), repairs the counter,
+-- and retries the freeze. Completed snapshots never need a value — frozen
+-- rows are never re-verified.
+
+ALTER TABLE snapshots ADD COLUMN registered_count INTEGER NOT NULL DEFAULT 0;

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -36,10 +36,16 @@
 //       -> {id, ok: true, inserted} — registration rows, conditional on the
 //          snapshot not being frozen by a `complete` marker yet.
 //   {type: "complete", id, server_id, snapshot_hash, entry_count}
-//       -> {id, ok: true} — freezes the snapshot after verifying the actual
-//          registration row count server-side; the count check and the
-//          freeze are one atomic UPDATE, and a retry of the same frame after
-//          a lost reply succeeds.
+//       -> {id, ok: true} — freezes the snapshot after verifying the
+//          registration count server-side. The check compares the
+//          register-maintained registered_count counter in one atomic
+//          conditional UPDATE (a real COUNT(*) scan only runs to repair a
+//          counter diverged by a crash), and a retry of the same frame
+//          after a lost reply succeeds. Register and complete frames for
+//          the same snapshot are serialized in instance memory
+//          (runSerialized), so the counter is settled whenever complete
+//          evaluates it; the per-statement freeze guards remain as the
+//          SQL-level backstop.
 //   {type: "snapshot", id, server_id, snapshot_hash}
 //       -> {id, ok: true, complete: bool, entry_count?, completed_at?} —
 //          completeness probe so reruns can skip finished snapshots.
@@ -191,6 +197,7 @@ interface SnapshotRow {
     snapshot_id: number;
     entry_count: number | null;
     completed_at: string | null;
+    registered_count: number;
 }
 
 // Resolve (server_id, snapshot_hash) to its registry row, if any.
@@ -201,7 +208,7 @@ async function findSnapshot(
 ): Promise<SnapshotRow | null> {
     return await db
         .prepare(
-            "SELECT snapshot_id, entry_count, completed_at FROM snapshots " +
+            "SELECT snapshot_id, entry_count, completed_at, registered_count FROM snapshots " +
                 "WHERE server_id = ? AND snapshot_hash = ?",
         )
         .bind(serverId, hexToBlob(snapshotHash))
@@ -353,9 +360,10 @@ async function handleRegister(
 ): Promise<{ inserted: number }> {
     const snapshot = await ensureSnapshot(db, serverId, snapshotHash);
     // Fast path only. The authoritative freeze check is the guard on every
-    // insert plus the completed_at probe in the final batch below: the
-    // Durable Object input gate does not cover external D1 operations, so a
-    // concurrent complete event can commit between this read and the inserts.
+    // insert plus the completed_at probe in the final batch below. Register
+    // and complete handlers for the same snapshot are serialized in the
+    // Durable Object (runSerialized), but that is instance memory — these
+    // SQL guards are the backstop for any writer that bypasses it.
     if (snapshot.completed_at !== null) {
         throw new SyncFailure({ error: "Snapshot already complete" });
     }
@@ -434,9 +442,10 @@ async function handleRegister(
         }
     }
     // The final batch also probes completed_at. A batch commits atomically,
-    // so a concurrent complete either committed before it (the guards above
-    // inserted nothing and the probe observes the freeze, rejecting this
-    // frame) or runs after it (and counts these rows in its own atomic
+    // so a concurrent complete that bypassed the instance-level
+    // serialization either committed before it (the guards above inserted
+    // nothing and the probe observes the freeze, rejecting this frame) or
+    // runs after it (and counts these rows in its own atomic
     // count-and-freeze update). Registration and completion therefore cannot
     // interleave into a frozen snapshot whose entry_count disagrees with its
     // registration set.
@@ -461,7 +470,54 @@ async function handleRegister(
             }
         }
     }
+    // Maintain the O(1) completion counter: add only the rows this frame
+    // actually inserted (INSERT OR IGNORE conflicts contribute 0, so re-sent
+    // frames never inflate it). The UPDATE commits separately from the
+    // insert batches above; a crash in between leaves the counter short,
+    // which the complete frame's fallback detects and repairs with one real
+    // COUNT(*). Incrementing an already-frozen snapshot is harmless: frozen
+    // rows are never re-verified.
+    if (inserted > 0) {
+        await db
+            .prepare(
+                "UPDATE snapshots SET registered_count = registered_count + ? " +
+                    "WHERE snapshot_id = ?",
+            )
+            .bind(inserted, snapshot.snapshot_id)
+            .run();
+    }
     return { inserted };
+}
+
+// The freezing UPDATE: the count verification, the not-yet-frozen check, and
+// the marker write are a single statement, so a concurrent register frame
+// that bypassed the instance-level serialization can never slip rows in
+// between the verification and the freeze. The count check compares
+// registered_count — maintained incrementally by register frames — instead
+// of scanning snapshot_entries: a COUNT(*) here costs a full index-range
+// scan of the snapshot's registration rows.
+async function freezeSnapshot(
+    db: D1Database,
+    snapshotId: number,
+    entryCount: number,
+): Promise<boolean> {
+    const result = await db
+        .prepare(
+            "UPDATE snapshots SET entry_count = ?, " +
+                "completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') " +
+                "WHERE snapshot_id = ? AND completed_at IS NULL AND registered_count = ?",
+        )
+        .bind(entryCount, snapshotId, entryCount)
+        .run();
+    return (result.meta.changes ?? 0) > 0;
+}
+
+async function countRegistrations(db: D1Database, snapshotId: number): Promise<number> {
+    const row = await db
+        .prepare("SELECT COUNT(*) AS n FROM snapshot_entries WHERE snapshot_id = ?")
+        .bind(snapshotId)
+        .first<{ n: number }>();
+    return row?.n ?? 0;
 }
 
 async function handleComplete(
@@ -487,37 +543,49 @@ async function handleComplete(
         throw new SyncFailure({ error: "Snapshot already complete" });
     }
 
-    // Atomic completion: the count verification, the not-yet-frozen check,
-    // and the marker write are a single UPDATE statement. A concurrent
-    // register frame can therefore never slip rows in between the
-    // verification and the freeze (the Durable Object input gate does not
-    // cover external D1 operations).
-    const result = await db
-        .prepare(
-            "UPDATE snapshots SET entry_count = ?, " +
-                "completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') " +
-                "WHERE snapshot_id = ? AND completed_at IS NULL AND " +
-                "(SELECT COUNT(*) FROM snapshot_entries WHERE snapshot_id = ?) = ?",
-        )
-        .bind(entryCount, snapshot.snapshot_id, snapshot.snapshot_id, entryCount)
-        .run();
-    if ((result.meta.changes ?? 0) > 0) {
+    if (await freezeSnapshot(db, snapshot.snapshot_id, entryCount)) {
         return {};
     }
 
     // The conditional update matched no row: a concurrent complete won the
-    // race, or the registration count moved under us. Re-read to report
-    // which one happened.
-    const state = await db
-        .prepare(
-            "SELECT entry_count, completed_at, " +
-                "(SELECT COUNT(*) FROM snapshot_entries WHERE snapshot_id = ?) AS registered " +
-                "FROM snapshots WHERE snapshot_id = ?",
-        )
-        .bind(snapshot.snapshot_id, snapshot.snapshot_id)
-        .first<{ entry_count: number | null; completed_at: string | null; registered: number }>();
+    // race, the registration count genuinely differs, or the counter
+    // diverged from the rows (a crash between a register frame's inserts and
+    // its counter update, or a pre-0002 pending snapshot). Re-read the
+    // registry row, then fall back to one real COUNT(*) to disambiguate.
+    const state = await findSnapshot(db, serverId, snapshotHash);
     if (state?.completed_at != null) {
         if (state.entry_count === entryCount) {
+            return {};
+        }
+        throw new SyncFailure({ error: "Snapshot already complete" });
+    }
+    const registered = await countRegistrations(db, snapshot.snapshot_id);
+    if (registered !== entryCount) {
+        throw new SyncFailure({
+            error: "Snapshot incomplete",
+            expected: entryCount,
+            registered,
+        });
+    }
+
+    // Complete row set behind a diverged counter: repair it (CAS on the
+    // value read above, so a concurrent register frame's increment is kept)
+    // and retry the freeze once.
+    await db
+        .prepare(
+            "UPDATE snapshots SET registered_count = ? " +
+                "WHERE snapshot_id = ? AND registered_count = ?",
+        )
+        .bind(registered, snapshot.snapshot_id, state?.registered_count ?? 0)
+        .run();
+    if (await freezeSnapshot(db, snapshot.snapshot_id, entryCount)) {
+        return {};
+    }
+    // The retry matched no row: a concurrent complete or register won the
+    // race in between. Report from a fresh read.
+    const final = await findSnapshot(db, serverId, snapshotHash);
+    if (final?.completed_at != null) {
+        if (final.entry_count === entryCount) {
             return {};
         }
         throw new SyncFailure({ error: "Snapshot already complete" });
@@ -525,7 +593,7 @@ async function handleComplete(
     throw new SyncFailure({
         error: "Snapshot incomplete",
         expected: entryCount,
-        registered: state?.registered ?? 0,
+        registered: final?.registered_count ?? registered,
     });
 }
 
@@ -552,6 +620,38 @@ async function handleSnapshot(
 }
 
 export class SyncSession extends DurableObject<Env> {
+    // Per-snapshot mutual exclusion between register and complete handlers.
+    // The freeze fast path trusts registered_count, which a register frame
+    // updates only after its insert batches commit; serializing the two
+    // handlers per snapshot guarantees no register frame is mid-flight when
+    // complete evaluates the counter. This is instance memory, so a
+    // restarted instance starts empty — safe, because an instance is never
+    // evicted while it is still processing a frame, and a crashed register
+    // frame's divergence is repaired by the complete fallback's COUNT(*).
+    // The per-statement freeze guards remain the SQL-level backstop.
+    private readonly snapshotLocks = new Map<string, Promise<unknown>>();
+
+    // Run `task` after every previously queued register/complete handler for
+    // the same snapshot settles; settled chains remove themselves so the map
+    // does not grow without bound.
+    private async runSerialized<T>(key: string, task: () => Promise<T>): Promise<T> {
+        const previous = this.snapshotLocks.get(key) ?? Promise.resolve();
+        const current = (async () => {
+            // A failed predecessor must not block the chain.
+            await previous.catch(() => {});
+            return await task();
+        })();
+        const tail = current
+            .catch(() => {})
+            .finally(() => {
+                if (this.snapshotLocks.get(key) === tail) {
+                    this.snapshotLocks.delete(key);
+                }
+            });
+        this.snapshotLocks.set(key, tail);
+        return await current;
+    }
+
     fetch(_request: Request): Response {
         // Auth runs in the worker middleware before the request is forwarded
         // here; the worker route already rejected non-upgrade requests.
@@ -601,20 +701,24 @@ export class SyncSession extends DurableObject<Env> {
                 case "register":
                     Object.assign(
                         reply,
-                        await handleRegister(
-                            this.env.PLATFORM_DB,
-                            msg.server_id,
-                            msg.snapshot_hash,
-                            msg.entries,
+                        await this.runSerialized(`${msg.server_id}:${msg.snapshot_hash}`, () =>
+                            handleRegister(
+                                this.env.PLATFORM_DB,
+                                msg.server_id,
+                                msg.snapshot_hash,
+                                msg.entries,
+                            ),
                         ),
                     );
                     break;
                 case "complete":
-                    await handleComplete(
-                        this.env.PLATFORM_DB,
-                        msg.server_id,
-                        msg.snapshot_hash,
-                        msg.entry_count,
+                    await this.runSerialized(`${msg.server_id}:${msg.snapshot_hash}`, () =>
+                        handleComplete(
+                            this.env.PLATFORM_DB,
+                            msg.server_id,
+                            msg.snapshot_hash,
+                            msg.entry_count,
+                        ),
                     );
                     break;
                 case "snapshot":

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -250,14 +250,16 @@ describe("snapshot freeze", () => {
     });
 
     it("never freezes a snapshot whose entry_count disagrees with its rows", async () => {
-        // Regression test for the register/complete race: Durable Object
-        // input gates do not cover external D1 operations, so a complete
-        // event can run between a register event's completed_at check and
-        // its inserts. The register frame below spans multiple D1 batches
-        // (2000 entries at 24 rows/statement over 50-statement batches) so
-        // the concurrent complete has real windows to interleave. Whichever
-        // side wins, the invariant must hold: a frozen snapshot's
-        // entry_count equals its actual registration row count.
+        // Regression test for the register/complete race: register and
+        // complete frames for the same snapshot are serialized in the
+        // Durable Object (runSerialized), and the per-statement freeze
+        // guards plus the counter check are the SQL-level backstop. The
+        // register frame below spans multiple D1 batches (2000 entries at
+        // 24 rows/statement over 50-statement batches), so without the
+        // serialization a complete event would have real windows to
+        // interleave. Whichever side runs first, the invariant must hold:
+        // a frozen snapshot's entry_count equals its actual registration
+        // row count.
         const content = new TextEncoder().encode("type-entry-1");
         const contentHash = await sha256Hex(content);
 
@@ -396,6 +398,187 @@ describe("snapshot freeze", () => {
         expect(reply.id).toBe(1);
         expect(reply.ok).toBe(false);
         expect(reply.error).toBe("Unknown content ids");
+        ws.close();
+    });
+});
+
+describe("registration counter", () => {
+    async function snapshotRow(
+        serverId: string,
+        snapshotHash: string,
+    ): Promise<{
+        snapshot_id: number;
+        entry_count: number | null;
+        completed_at: string | null;
+        registered_count: number;
+    } | null> {
+        return await env.PLATFORM_DB.prepare(
+            "SELECT snapshot_id, entry_count, completed_at, registered_count FROM snapshots " +
+                "WHERE server_id = ? AND snapshot_hash = ?",
+        )
+            .bind(serverId, hexToBlob(snapshotHash))
+            .first<{
+                snapshot_id: number;
+                entry_count: number | null;
+                completed_at: string | null;
+                registered_count: number;
+            }>();
+    }
+
+    async function uploadType(ws: WebSocket, id: number, label: string): Promise<number> {
+        const content = new TextEncoder().encode(label);
+        const contentHash = await sha256Hex(content);
+        const reply = await call(ws, {
+            id,
+            type: "content",
+            entries: [
+                { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
+            ],
+        });
+        expect(reply.ok).toBe(true);
+        return (reply.ids as Record<string, number>)[contentHash];
+    }
+
+    it("tracks registrations across frames and freezes via the counter", async () => {
+        const ws = await connect();
+        const serverId = "tranquility";
+        const snapshotHash = "aa".repeat(32);
+        const contentId = await uploadType(ws, 1, "type-entry-1");
+
+        for (let frame = 0; frame < 3; frame++) {
+            const reply = await call(ws, {
+                id: 10 + frame,
+                type: "register",
+                server_id: serverId,
+                snapshot_hash: snapshotHash,
+                entries: [{ family: "types", entry_id: frame + 1, content_id: contentId }],
+            });
+            expect(reply).toEqual({ id: 10 + frame, ok: true, inserted: 1 });
+        }
+        expect((await snapshotRow(serverId, snapshotHash))?.registered_count).toBe(3);
+
+        const complete = await call(ws, {
+            id: 20,
+            type: "complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 3,
+        });
+        expect(complete).toEqual({ id: 20, ok: true });
+
+        const row = await snapshotRow(serverId, snapshotHash);
+        expect(row?.completed_at).not.toBeNull();
+        expect(row?.entry_count).toBe(3);
+        ws.close();
+    });
+
+    it("does not inflate the counter on re-sent register frames", async () => {
+        const ws = await connect();
+        const serverId = "tranquility";
+        const snapshotHash = "bb".repeat(32);
+        const contentId = await uploadType(ws, 1, "type-entry-1");
+
+        const frame = {
+            type: "register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
+        };
+        expect(await call(ws, { id: 2, ...frame })).toEqual({ id: 2, ok: true, inserted: 1 });
+        // Idempotent re-send (lost reply): all rows conflict, so the counter
+        // must stay at 1.
+        expect(await call(ws, { id: 3, ...frame })).toEqual({ id: 3, ok: true, inserted: 0 });
+        expect((await snapshotRow(serverId, snapshotHash))?.registered_count).toBe(1);
+
+        const complete = await call(ws, {
+            id: 4,
+            type: "complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 1,
+        });
+        expect(complete).toEqual({ id: 4, ok: true });
+        ws.close();
+    });
+
+    it("repairs a diverged counter before freezing", async () => {
+        const ws = await connect();
+        const serverId = "tranquility";
+        const snapshotHash = "cc".repeat(32);
+        const contentId = await uploadType(ws, 1, "type-entry-1");
+
+        const register = await call(ws, {
+            id: 2,
+            type: "register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
+        });
+        expect(register).toEqual({ id: 2, ok: true, inserted: 1 });
+
+        // Simulate a crash between a register frame's inserts and its
+        // counter update: the row exists but registered_count does not
+        // reflect it (also the state of a pre-0002 pending snapshot).
+        const row = await snapshotRow(serverId, snapshotHash);
+        await env.PLATFORM_DB.prepare(
+            "INSERT INTO snapshot_entries (snapshot_id, family, entry_id, content_id) " +
+                "VALUES (?, 0, 2, ?)",
+        )
+            .bind(row?.snapshot_id, contentId)
+            .run();
+        expect((await snapshotRow(serverId, snapshotHash))?.registered_count).toBe(1);
+
+        const complete = await call(ws, {
+            id: 3,
+            type: "complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 2,
+        });
+        expect(complete).toEqual({ id: 3, ok: true });
+
+        const repaired = await snapshotRow(serverId, snapshotHash);
+        expect(repaired?.completed_at).not.toBeNull();
+        expect(repaired?.entry_count).toBe(2);
+        expect(repaired?.registered_count).toBe(2);
+        ws.close();
+    });
+
+    it("reports a genuinely incomplete snapshot with the real row count", async () => {
+        const ws = await connect();
+        const serverId = "tranquility";
+        const snapshotHash = "dd".repeat(32);
+        const contentId = await uploadType(ws, 1, "type-entry-1");
+
+        await call(ws, {
+            id: 2,
+            type: "register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
+        });
+        const row = await snapshotRow(serverId, snapshotHash);
+        await env.PLATFORM_DB.prepare(
+            "INSERT INTO snapshot_entries (snapshot_id, family, entry_id, content_id) " +
+                "VALUES (?, 0, 2, ?)",
+        )
+            .bind(row?.snapshot_id, contentId)
+            .run();
+
+        // Counter says 1, the uploader claims 3, the truth is 2: the error
+        // must report the real row count, and the snapshot stays pending.
+        const reply = await call(ws, {
+            id: 3,
+            type: "complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 3,
+        });
+        expect(reply.id).toBe(3);
+        expect(reply.ok).toBe(false);
+        expect(reply.error).toBe("Snapshot incomplete");
+        expect(reply.registered).toBe(2);
+        expect((await snapshotRow(serverId, snapshotHash))?.completed_at).toBeNull();
         ws.close();
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Snapshot completion now verifies registration totals more efficiently, avoiding full data scans in normal cases.

* **Reliability**
  * Registration totals are automatically repaired when interrupted processing or older pending snapshots cause discrepancies.
  * Duplicate registration submissions remain safely handled without inflating totals.
  * Snapshot completion continues to enforce accurate row-count validation and prevent incomplete snapshots from being finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->