### PR TITLE
perf(platform): fold snapshot engine data into content-addressed segments

### DIFF
--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -1,41 +1,52 @@
 """Sync resource snapshot engine data into the platform D1 database.
 
-Splits the snapshot's native engine protobuf collections (types, type dogma,
-dogma attributes, dogma effects, buff collections) into per-entry rows and
-builds per-entry name/icon metadata from the snapshot's collection and
-localization database, then uploads everything to the platform data-sync
-worker (``api.efa-tech.dev/platform/storage/data-sync``), which stores them in
-the ``efa-snapshot-registry`` D1 database.
+Folds the snapshot's native engine protobuf collections (types, type dogma,
+dogma attributes, dogma effects, buff collections) plus sync-built metadata
+into per-family binary streams, segments each stream into self-contained
+content-addressed blobs of at most 512 KiB, and uploads everything to the
+platform data-sync worker (``api.efa-tech.dev/platform/storage/data-sync``),
+which stores them in the ``efa-snapshot-registry`` D1 database.
 
-Storage layout (v2; see worker/efa-platform-data-sync/migrations):
-  - ``entries``:          (content_id, family, content_hash BLOB, content)
-                          content-addressed payloads; content_id is a dense
-                          database-local integer assigned by the worker
-  - ``snapshot_entries``: (snapshot_id, family, entry_id, content_id)
-                          registration rows referencing integer ids only
-  - ``snapshots``:        (snapshot_id, server_id, snapshot_hash BLOB,
-                          entry_count, completed_at) completeness registry
+Storage layout (v3; see worker/efa-platform-data-sync/migrations):
+  - ``folded_blobs``:            (blob_id, family, content_hash BLOB,
+                                 entry_count, first_entry_id, last_entry_id,
+                                 content) — the only content store; blob_id is
+                                 a dense database-local integer assigned by
+                                 the worker
+  - ``snapshot_family_segments``: (snapshot_id, family, seq, blob_id)
+                                 per-snapshot segment links, no content
+  - ``snapshots``:               (snapshot_id, server_id, snapshot_hash BLOB,
+                                 entry_count, completed_at) completeness
+                                 registry
+
+Segment format (self-contained, entries sorted by entry id)::
+
+    u32 count
+    count x { i32 entry_id, u32 offset, u32 length }   # offset from segment start
+    payload bytes (concatenated per-entry protobufs)
+
+Segments are capped at 512 KiB because D1 caps a BLOB row at 2 MB and the
+base64'd frame stays well under the 1 MiB WebSocket message limit. Folding
+is a deterministic greedy pack at entry boundaries (not CDC): cross-snapshot
+segment-level dedup is marginal (~1.3%) because inter-snapshot churn is
+dense. Content addressing still deduplicates segments shared verbatim
+across servers (e.g. identical snapshots on two servers).
 
 Uploads run over a single WebSocket to the worker's ``SyncSession`` Durable
-Object: every frame is a small JSON message (``content``/``lookup``/
-``register``/``complete``/``snapshot``) answered by one JSON reply carrying
-the same client-chosen ``id``. Each frame is a separate Durable Object event
-with its own CPU budget, which replaced the old multi-request HTTP API whose
-large per-request batches regularly failed with 503s.
-
-Registration rows reference content ids rather than content hashes, so the
-``content`` and ``lookup`` replies carry ``ids`` maps (content hash ->
-content id) that this driver accumulates before emitting ``register`` frames.
-The ``ids`` maps are keyed by hash alone, so ``content`` frames are sent one
-family at a time: identical bytes under two families are distinct
-``(family, content_hash)`` rows and must not share a frame.
+Object: every frame is a small JSON message (``segment``/
+``segment_lookup``/``segment_register``/``segment_complete``/``snapshot``)
+answered by one JSON reply carrying the same client-chosen ``id``. Each
+frame is a separate Durable Object event with its own CPU budget, which
+replaced the old multi-request HTTP API whose large per-request batches
+regularly failed with 503s.
 
 All operations are idempotent, so the transport reconnects and resends an
 unacknowledged frame on connection failures, and a rerun of the whole sync
 converges: the ``snapshot`` frame skips already-completed snapshots and the
-``lookup`` frame skips already-uploaded content rows. A snapshot is only
-complete once the uploader has posted every content and registration frame
-and then frozen it in the ``snapshots`` registry (``complete``); readers must
+``segment_lookup`` frame skips already-uploaded segments. A snapshot is only
+complete once the uploader has posted every segment and link frame and then
+frozen it in the ``snapshots`` registry (``segment_complete``, verified
+server-side via ``SUM(entry_count)`` over the segment links); readers must
 check that registry before serving data.
 """
 
@@ -46,6 +57,7 @@ import contextlib
 import json
 import random
 import sqlite3
+import struct
 import sys
 import tempfile
 import time
@@ -93,10 +105,30 @@ ALL_FAMILIES = tuple(ENGINE_FAMILIES) + META_FAMILIES
 
 @dataclass(frozen=True)
 class Entry:
-    """A single D1 content row candidate."""
+    """A single engine-data entry (one protobuf payload per entry id)."""
 
     family: str
     entry_id: int
+    content: bytes
+
+
+#: Segment size cap in raw bytes: D1 caps a BLOB row at 2 MB, and the
+#: base64'd frame (~683 KiB) stays well under the 1 MiB WebSocket limit.
+SEGMENT_MAX_BYTES = 512 * 1024
+
+#: Segment framing: u32 count + count x (i32 id, u32 offset, u32 length).
+_SEGMENT_HEADER_BYTES = 4
+_SEGMENT_INDEX_ENTRY_BYTES = 12
+
+
+@dataclass(frozen=True)
+class Segment:
+    """One self-contained, content-addressed folded segment of a family."""
+
+    family: str
+    entry_count: int
+    first_entry_id: int
+    last_entry_id: int
     content: bytes
     hash: str = field(init=False)
 
@@ -104,21 +136,12 @@ class Entry:
         object.__setattr__(self, "hash", content_hash(self.content))
 
 
-@dataclass(frozen=True)
-class Registration:
-    """A single ``snapshot_entries`` row candidate."""
-
-    family: str
-    entry_id: int
-    hash: str
-
-
 class SyncTransport(Protocol):
     """Send one frame payload to the worker and return the decoded reply.
 
-    ``path`` is the frame type (``content``, ``lookup``, ``register``,
-    ``complete``, ``snapshot``); the payload carries the frame's remaining
-    fields. Raises on ``ok: false`` replies.
+    ``path`` is the frame type (``segment``, ``segment_lookup``,
+    ``segment_register``, ``segment_complete``, ``snapshot``); the payload
+    carries the frame's remaining fields. Raises on ``ok: false`` replies.
     """
 
     def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]: ...
@@ -386,6 +409,47 @@ def _batched(items: list, batch_size: int) -> Iterable[list]:
         yield items[offset : offset + batch_size]
 
 
+def fold_family(family: str, entries: list[Entry]) -> list[Segment]:
+    """Fold one family's entries into self-contained <=512 KiB segments.
+
+    Entries are sorted by entry id and greedy-packed at entry boundaries
+    (deterministic, not CDC — see the module docstring). One SHA-256 per
+    segment replaces the v2 per-entry hashes (~300k -> ~160 hashes).
+    """
+    groups: list[list[Entry]] = []
+    current: list[Entry] = []
+    size = _SEGMENT_HEADER_BYTES
+    for entry in sorted(entries, key=lambda e: e.entry_id):
+        entry_size = _SEGMENT_INDEX_ENTRY_BYTES + len(entry.content)
+        if current and size + entry_size > SEGMENT_MAX_BYTES:
+            groups.append(current)
+            current = []
+            size = _SEGMENT_HEADER_BYTES
+        current.append(entry)
+        size += entry_size
+    if current:
+        groups.append(current)
+    return [_build_segment(family, group) for group in groups]
+
+
+def _build_segment(family: str, group: list[Entry]) -> Segment:
+    index = bytearray()
+    payload = bytearray()
+    data_offset = _SEGMENT_HEADER_BYTES + _SEGMENT_INDEX_ENTRY_BYTES * len(group)
+    for entry in group:
+        index += struct.pack("<iII", entry.entry_id, data_offset, len(entry.content))
+        payload += entry.content
+        data_offset += len(entry.content)
+    content = struct.pack("<I", len(group)) + bytes(index) + bytes(payload)
+    return Segment(
+        family=family,
+        entry_count=len(group),
+        first_entry_id=group[0].entry_id,
+        last_entry_id=group[-1].entry_id,
+        content=content,
+    )
+
+
 def run_sync(
     hashes: dict[str, str],
     schema_root: Path,
@@ -395,35 +459,48 @@ def run_sync(
 ) -> None:
     """Sync every server snapshot in ``hashes`` to the platform D1 database.
 
-    Content rows are deduplicated across servers before uploading (identical
-    entries share a content hash); registration rows are uploaded per server.
-    Reruns converge: snapshots already marked complete are skipped, and
-    already-uploaded content rows are filtered out via ``lookup`` frames.
+    Each snapshot's families are folded into segments; segments are
+    deduplicated across servers by content hash before uploading, and segment
+    links are registered per (snapshot, family). Reruns converge: snapshots
+    already marked complete are skipped, and already-uploaded segments are
+    filtered out via ``segment_lookup`` frames. ``batch_size`` chunks the
+    lookup frames.
     """
     if not 1 <= batch_size <= 2_000:
         raise ValueError(f"batch_size must be between 1 and 2000, got {batch_size}")
 
-    content: dict[tuple[str, str], bytes] = {}
-    registrations: dict[tuple[str, str], list[Registration]] = {}
+    segments: dict[tuple[str, str], Segment] = {}
+    per_snapshot: dict[tuple[str, str], dict[str, list[Segment]]] = {}
+    entry_counts: dict[tuple[str, str], int] = {}
 
     for server_id, snapshot_hash in sorted(hashes.items()):
         info(f"Loading snapshot entries for {server_id} ({snapshot_hash[:16]}...)...")
         entries = load_snapshot_entries(schema_root, snapshot_hash)
-        regs: list[Registration] = []
+        by_family: dict[str, list[Entry]] = {family: [] for family in ALL_FAMILIES}
         for entry in entries:
-            content.setdefault((entry.family, entry.hash), entry.content)
-            regs.append(Registration(entry.family, entry.entry_id, entry.hash))
-        registrations[(server_id, snapshot_hash)] = regs
+            by_family[entry.family].append(entry)
+        families: dict[str, list[Segment]] = {}
+        for family in ALL_FAMILIES:
+            family_segments = fold_family(family, by_family[family])
+            families[family] = family_segments
+            for segment in family_segments:
+                segments.setdefault((family, segment.hash), segment)
+        key = (server_id, snapshot_hash)
+        per_snapshot[key] = families
+        entry_counts[key] = len(entries)
 
-    info(f"Total unique content rows: {len(content)}")
-    info(f"Total registration rows: {sum(len(r) for r in registrations.values())}")
+    info(f"Total unique segments: {len(segments)}")
+    info(
+        "Total segment links: "
+        f"{sum(len(segs) for families in per_snapshot.values() for segs in families.values())}"
+    )
 
     if dry_run:
         per_family: dict[str, int] = {}
-        for family, _hash in content:
+        for family, _hash in segments:
             per_family[family] = per_family.get(family, 0) + 1
         for family in ALL_FAMILIES:
-            info(f"  {family}: {per_family.get(family, 0)} content rows")
+            info(f"  {family}: {per_family.get(family, 0)} segments")
         info("Dry run: skipped upload.")
         return
 
@@ -431,10 +508,10 @@ def run_sync(
         raise ValueError("transport is required unless dry_run is set")
 
     try:
-        # Skip snapshots a previous run already finished: their registration
-        # set is frozen and the worker would reject further register frames.
-        pending = dict(registrations)
-        for server_id, snapshot_hash in sorted(registrations):
+        # Skip snapshots a previous run already finished: their segment links
+        # are frozen and the worker would reject further register frames.
+        pending = dict(per_snapshot)
+        for server_id, snapshot_hash in sorted(per_snapshot):
             reply = transport.post(
                 "snapshot", {"server_id": server_id, "snapshot_hash": snapshot_hash}
             )
@@ -442,83 +519,92 @@ def run_sync(
                 info(f"Snapshot already complete, skipping: {server_id} ({snapshot_hash[:16]}...)")
                 del pending[(server_id, snapshot_hash)]
 
-        pending_hashes = {(reg.family, reg.hash) for regs in pending.values() for reg in regs}
+        pending_segments = {
+            (family, segment.hash)
+            for key in pending
+            for family, family_segments in per_snapshot[key].items()
+            for segment in family_segments
+        }
 
-        # Resume support: content rows already present on the server (from
+        # Resume support: segments already present on the server (from
         # earlier runs or shared with completed snapshots) are not resent.
-        rows_to_check = sorted(
-            (family, entry_hash)
-            for (family, entry_hash) in content
-            if (family, entry_hash) in pending_hashes
-        )
+        blob_ids: dict[tuple[str, str], int] = {}
         missing: set[tuple[str, str]] = set()
-        content_ids: dict[tuple[str, str], int] = {}
         for family in ALL_FAMILIES:
-            family_hashes = [h for f, h in rows_to_check if f == family]
-            if not family_hashes:
-                continue
-            for chunk in _batched(family_hashes, 5_000):
-                reply = transport.post("lookup", {"family": family, "content_hashes": chunk})
+            family_hashes = sorted(h for f, h in pending_segments if f == family)
+            for chunk in _batched(family_hashes, batch_size):
+                reply = transport.post(
+                    "segment_lookup", {"family": family, "content_hashes": chunk}
+                )
                 missing.update((family, h) for h in reply.get("missing", []))
-                for h, content_id in reply.get("ids", {}).items():
-                    content_ids[(family, h)] = content_id
-        info(f"Content rows missing on the server: {len(missing)} of {len(rows_to_check)}")
+                for h, blob_id in reply.get("ids", {}).items():
+                    blob_ids[(family, h)] = blob_id
+        info(f"Segments missing on the server: {len(missing)} of {len(pending_segments)}")
 
-        # Content frames are kept per family so the worker's hash-keyed
-        # `ids` reply is unambiguous even when identical bytes (hence
-        # identical hashes) appear under two families; the entries table's
-        # (family, content_hash) uniqueness key makes those distinct rows.
-        for family in ALL_FAMILIES:
-            family_rows = [
+        # One content frame per missing segment; the reply resolves the
+        # database-local blob id used by the register frames below.
+        for family, segment_hash in sorted(missing):
+            segment = segments[(family, segment_hash)]
+            reply = transport.post(
+                "segment",
                 {
                     "family": family,
-                    "content_hash": entry_hash,
-                    "content_b64": base64.b64encode(content[(family, entry_hash)]).decode("ascii"),
-                }
-                for f, entry_hash in sorted(missing)
-                if f == family
-            ]
-            for batch in _batched(family_rows, batch_size):
-                reply = transport.post("content", {"entries": batch})
-                info(
-                    f"Uploaded {len(batch)} {family} content rows "
-                    f"(inserted: {reply.get('inserted', '?')})"
-                )
-                for h, content_id in reply.get("ids", {}).items():
-                    content_ids[(family, h)] = content_id
+                    "content_hash": segment.hash,
+                    "entry_count": segment.entry_count,
+                    "first_entry_id": segment.first_entry_id,
+                    "last_entry_id": segment.last_entry_id,
+                    "content_b64": base64.b64encode(segment.content).decode("ascii"),
+                },
+            )
+            # A reply without a blob id leaves the segment unresolved, which
+            # the check below reports.
+            blob_id = reply.get("blob_id")
+            if blob_id is not None:
+                blob_ids[(family, segment_hash)] = blob_id
+        if missing:
+            info(f"Uploaded {len(missing)} segments")
 
-        unresolved = pending_hashes - set(content_ids)
+        unresolved = pending_segments - set(blob_ids)
         if unresolved:
             raise RuntimeError(
-                f"server did not return content ids for {len(unresolved)} content rows "
+                f"server did not return blob ids for {len(unresolved)} segments "
                 f"(first: {min(unresolved)})"
             )
 
-        for (server_id, snapshot_hash), regs in sorted(pending.items()):
-            reg_rows = [
-                {
-                    "family": reg.family,
-                    "entry_id": reg.entry_id,
-                    "content_id": content_ids[(reg.family, reg.hash)],
-                }
-                for reg in regs
-            ]
-            for batch in _batched(reg_rows, batch_size):
+        for (server_id, snapshot_hash), families in sorted(pending.items()):
+            links = 0
+            for family in ALL_FAMILIES:
+                family_segments = families[family]
+                if not family_segments:
+                    continue
                 transport.post(
-                    "register",
-                    {"server_id": server_id, "snapshot_hash": snapshot_hash, "entries": batch},
+                    "segment_register",
+                    {
+                        "server_id": server_id,
+                        "snapshot_hash": snapshot_hash,
+                        "segments": [
+                            {
+                                "family": family,
+                                "seq": seq,
+                                "blob_id": blob_ids[(family, segment.hash)],
+                            }
+                            for seq, segment in enumerate(family_segments)
+                        ],
+                    },
                 )
-            info(f"Registered {len(reg_rows)} rows for {server_id} ({snapshot_hash[:16]}...)")
+                links += len(family_segments)
+            info(f"Registered {links} segment links for {server_id} ({snapshot_hash[:16]}...)")
 
-            # Completeness marker: only reached when every content frame and
-            # every registration frame for this snapshot succeeded. Readers
-            # treat a snapshot without this marker as incomplete.
+            # Completeness marker: only reached when every segment frame and
+            # every link frame for this snapshot succeeded; the worker
+            # verifies SUM(entry_count) over the links before freezing.
+            # Readers treat a snapshot without this marker as incomplete.
             transport.post(
-                "complete",
+                "segment_complete",
                 {
                     "server_id": server_id,
                     "snapshot_hash": snapshot_hash,
-                    "entry_count": len(reg_rows),
+                    "entry_count": entry_counts[(server_id, snapshot_hash)],
                 },
             )
             info(f"Marked snapshot complete for {server_id} ({snapshot_hash[:16]}...)")

--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -421,6 +421,11 @@ def fold_family(family: str, entries: list[Entry]) -> list[Segment]:
     size = _SEGMENT_HEADER_BYTES
     for entry in sorted(entries, key=lambda e: e.entry_id):
         entry_size = _SEGMENT_INDEX_ENTRY_BYTES + len(entry.content)
+        if _SEGMENT_HEADER_BYTES + entry_size > SEGMENT_MAX_BYTES:
+            raise ValueError(
+                f"Entry {entry.entry_id} in family '{family}' is {entry_size} bytes, "
+                f"exceeding the {SEGMENT_MAX_BYTES}-byte segment cap"
+            )
         if current and size + entry_size > SEGMENT_MAX_BYTES:
             groups.append(current)
             current = []

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -258,6 +258,20 @@ class TestFoldFamily:
             assert len(segment.content) + next_entry_size > SEGMENT_MAX_BYTES
             offset += segment.entry_count
 
+    def test_rejects_entry_exceeding_segment_cap(self) -> None:
+        from bootstrap.data.d1.sync import SEGMENT_MAX_BYTES
+        from bootstrap.data.d1.sync import Entry
+        from bootstrap.data.d1.sync import fold_family
+
+        oversized = Entry("types", 42, bytes(SEGMENT_MAX_BYTES))
+        with pytest.raises(ValueError, match="42"):
+            fold_family("types", [Entry("types", 1, b"ok"), oversized])
+
+        # Just under the cap still folds into a single-entry segment.
+        just_fits = Entry("types", 7, bytes(SEGMENT_MAX_BYTES - 4 - 12))
+        [segment] = fold_family("types", [just_fits])
+        assert segment.entry_count == 1
+
     def test_hash_is_content_hash_of_segment_bytes(self) -> None:
         from bootstrap.data.d1.sync import Entry
         from bootstrap.data.d1.sync import fold_family

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -217,6 +217,87 @@ class TestLoadSnapshotEntries:
         assert negative_effect_meta.name == "shipModularity"
 
 
+class TestFoldFamily:
+    def test_deterministic_regardless_of_input_order(self) -> None:
+        from bootstrap.data.d1.sync import Entry
+        from bootstrap.data.d1.sync import fold_family
+
+        entries = [Entry("types", i, bytes([i]) * (10 + i)) for i in range(50)]
+        shuffled = list(reversed(entries))
+
+        folded_a = fold_family("types", entries)
+        folded_b = fold_family("types", shuffled)
+
+        assert [s.hash for s in folded_a] == [s.hash for s in folded_b]
+        assert [s.content for s in folded_a] == [s.content for s in folded_b]
+
+    def test_size_cap_and_boundary_packing(self) -> None:
+        from bootstrap.data.d1.sync import SEGMENT_MAX_BYTES
+        from bootstrap.data.d1.sync import Entry
+        from bootstrap.data.d1.sync import fold_family
+
+        # 300 KiB entries: one per segment (two would exceed the cap).
+        entries = [Entry("types", i, bytes(300 * 1024)) for i in range(4)]
+        segments = fold_family("types", entries)
+
+        assert len(segments) == 4
+        for segment in segments:
+            assert len(segment.content) <= SEGMENT_MAX_BYTES
+            assert segment.entry_count == 1
+
+        # Small entries pack greedily up to the cap.
+        small = [Entry("types", i, bytes(1000)) for i in range(600)]
+        packed = fold_family("types", small)
+        assert 1 < len(packed) < 600
+        for segment in packed:
+            assert len(segment.content) <= SEGMENT_MAX_BYTES
+        # Greedy: every segment except the last is full to the cap.
+        offset = 0
+        for segment in packed[:-1]:
+            next_entry_size = 12 + len(small[offset + segment.entry_count].content)
+            assert len(segment.content) + next_entry_size > SEGMENT_MAX_BYTES
+            offset += segment.entry_count
+
+    def test_hash_is_content_hash_of_segment_bytes(self) -> None:
+        from bootstrap.data.d1.sync import Entry
+        from bootstrap.data.d1.sync import fold_family
+        from bootstrap.remote.hash import content_hash
+
+        segments = fold_family("types", [Entry("types", 1, b"payload")])
+        assert len(segments) == 1
+        assert segments[0].hash == content_hash(segments[0].content)
+
+    def test_segment_format_round_trip(self) -> None:
+        import struct
+
+        from bootstrap.data.d1.sync import Entry
+        from bootstrap.data.d1.sync import fold_family
+
+        entries = [
+            Entry("dogma_effects", -64, b"negative-id"),
+            Entry("dogma_effects", 10, b"effect-10"),
+            Entry("dogma_effects", 11, b"effect-11"),
+        ]
+        [segment] = fold_family("dogma_effects", entries)
+
+        assert segment.entry_count == 3
+        assert segment.first_entry_id == -64  # sorted by id, negatives first
+        assert segment.last_entry_id == 11
+
+        (count,) = struct.unpack_from("<I", segment.content, 0)
+        assert count == 3
+        decoded = []
+        for i in range(count):
+            entry_id, offset, length = struct.unpack_from("<iII", segment.content, 4 + i * 12)
+            decoded.append((entry_id, segment.content[offset : offset + length]))
+        assert decoded == [(-64, b"negative-id"), (10, b"effect-10"), (11, b"effect-11")]
+
+    def test_empty_family_folds_to_no_segments(self) -> None:
+        from bootstrap.data.d1.sync import fold_family
+
+        assert fold_family("types", []) == []
+
+
 class _FakeTransport:
     def __init__(
         self,
@@ -225,11 +306,11 @@ class _FakeTransport:
     ) -> None:
         self.posts: list[tuple[str, dict[str, Any]]] = []
         self.closed = False
-        # (family, content_hash) rows the server already holds.
+        # (family, content_hash) segments the server already holds.
         self._existing = existing or set()
         # (server_id, snapshot_hash) pairs already marked complete.
         self._completed = completed or set()
-        # Deterministic content ids, assigned as the worker would: dense,
+        # Deterministic blob ids, assigned as the worker would: dense,
         # per (family, content_hash), stable for the session.
         self._next_id = 0
         self._ids: dict[tuple[str, str], int] = {}
@@ -246,7 +327,7 @@ class _FakeTransport:
 
     def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         self.posts.append((path, payload))
-        if path == "lookup":
+        if path == "segment_lookup":
             present = [
                 h for h in payload["content_hashes"] if (payload["family"], h) in self._existing
             ]
@@ -261,13 +342,12 @@ class _FakeTransport:
         if path == "snapshot":
             complete = (payload["server_id"], payload["snapshot_hash"]) in self._completed
             return {"ok": True, "complete": complete}
-        if path == "content":
-            ids = {
-                entry["content_hash"]: self._ensure_id(entry["family"], entry["content_hash"])
-                for entry in payload["entries"]
-            }
-            return {"ok": True, "inserted": len(payload["entries"]), "ids": ids}
-        return {"ok": True, "inserted": len(payload.get("entries", []))}
+        if path == "segment":
+            blob_id = self._ensure_id(payload["family"], payload["content_hash"])
+            return {"ok": True, "inserted": 1, "blob_id": blob_id}
+        if path == "segment_register":
+            return {"ok": True, "inserted": len(payload["segments"])}
+        return {"ok": True}
 
     def close(self) -> None:
         self.closed = True
@@ -466,41 +546,39 @@ class TestRunSync:
         transport = _FakeTransport()
         run_sync({"alpha": hash_a, "beta": hash_b}, schema_root, transport, batch_size=2000)
 
-        content_posts = [p for p in transport.posts if p[0] == "content"]
-        register_posts = [p for p in transport.posts if p[0] == "register"]
+        segment_posts = [p for p in transport.posts if p[0] == "segment"]
+        register_posts = [p for p in transport.posts if p[0] == "segment_register"]
 
-        # Identical snapshots: content uploaded once, deduplicated by hash.
-        content_hashes = [
-            e["content_hash"] for _path, payload in content_posts for e in payload["entries"]
-        ]
-        assert len(content_hashes) == len(set(content_hashes))
-        assert len(content_hashes) == 10  # one entry per family
+        # Identical snapshots: segments uploaded once, deduplicated by hash.
+        segment_hashes = [payload["content_hash"] for _path, payload in segment_posts]
+        assert len(segment_hashes) == len(set(segment_hashes))
+        assert len(segment_hashes) == 8  # one folded segment per family
 
-        assert len(register_posts) == 2
+        # One register frame per (snapshot, family).
+        assert len(register_posts) == 16
         servers = {payload["server_id"] for _path, payload in register_posts}
         assert servers == {"alpha", "beta"}
         for _path, payload in register_posts:
-            assert len(payload["entries"]) == 10
-            # Registration rows reference worker-assigned content ids, not hashes.
-            for entry in payload["entries"]:
-                assert set(entry) == {"family", "entry_id", "content_id"}
-                assert isinstance(entry["content_id"], int)
+            assert len(payload["segments"]) == 1
+            # Segment links reference worker-assigned blob ids, not hashes.
+            for link in payload["segments"]:
+                assert set(link) == {"family", "seq", "blob_id"}
+                assert link["seq"] == 0
+                assert isinstance(link["blob_id"], int)
 
-        # Identical snapshots share the same content ids across servers.
+        # Identical snapshots share the same blob ids across servers.
         per_server = {
-            payload["server_id"]: {
-                (e["family"], e["entry_id"]): e["content_id"] for e in payload["entries"]
-            }
+            payload["server_id"]: {link["family"]: link["blob_id"] for link in payload["segments"]}
             for _path, payload in register_posts
         }
         assert per_server["alpha"] == per_server["beta"]
 
-        complete_posts = [p for p in transport.posts if p[0] == "complete"]
+        complete_posts = [p for p in transport.posts if p[0] == "segment_complete"]
         assert len(complete_posts) == 2
         complete_servers = {payload["server_id"] for _path, payload in complete_posts}
         assert complete_servers == {"alpha", "beta"}
         for _path, payload in complete_posts:
-            assert payload["entry_count"] == 10
+            assert payload["entry_count"] == 10  # total entries, all families
 
         assert transport.closed
 
@@ -516,32 +594,34 @@ class TestRunSync:
         run_sync({"alpha": hash_a, "beta": hash_b}, schema_root, transport, batch_size=2000)
 
         # Nothing is re-registered or re-completed for the finished snapshot.
-        register_posts = [p for p in transport.posts if p[0] == "register"]
-        complete_posts = [p for p in transport.posts if p[0] == "complete"]
+        register_posts = [p for p in transport.posts if p[0] == "segment_register"]
+        complete_posts = [p for p in transport.posts if p[0] == "segment_complete"]
         assert {payload["server_id"] for _path, payload in register_posts} == {"beta"}
         assert {payload["server_id"] for _path, payload in complete_posts} == {"beta"}
 
-    def test_lookup_skips_existing_content(self, schema_root: Path) -> None:
+    def test_lookup_skips_existing_segments(self, schema_root: Path) -> None:
+        from bootstrap.data.d1.sync import fold_family
         from bootstrap.data.d1.sync import load_snapshot_entries
         from bootstrap.data.d1.sync import run_sync
 
         snapshot_hash = "cc" * 32
         _build_snapshot(schema_root, snapshot_hash)
 
+        entries = load_snapshot_entries(schema_root, snapshot_hash)
         existing = {
-            (entry.family, entry.hash)
-            for entry in load_snapshot_entries(schema_root, snapshot_hash)
-            if entry.family == "types"
+            (segment.family, segment.hash)
+            for segment in fold_family(
+                "types", [entry for entry in entries if entry.family == "types"]
+            )
         }
         assert existing  # fixture sanity check
 
         transport = _FakeTransport(existing=existing)
         run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
 
-        content_posts = [p for p in transport.posts if p[0] == "content"]
-        uploaded = [e for _path, payload in content_posts for e in payload["entries"]]
-        assert "types" not in {e["family"] for e in uploaded}
-        assert len(uploaded) == 9  # 10 rows minus the existing types row
+        segment_posts = [p for p in transport.posts if p[0] == "segment"]
+        assert "types" not in {payload["family"] for _path, payload in segment_posts}
+        assert len(segment_posts) == 7  # 8 families minus the existing types segment
 
     def test_complete_not_posted_when_register_fails(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync
@@ -551,16 +631,16 @@ class TestRunSync:
 
         class _FailingTransport(_FakeTransport):
             def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
-                if path == "register":
+                if path == "segment_register":
                     raise RuntimeError("boom")
                 return super().post(path, payload)
 
         transport = _FailingTransport()
         with pytest.raises(RuntimeError, match="boom"):
             run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
-        assert [p for p in transport.posts if p[0] == "complete"] == []
+        assert [p for p in transport.posts if p[0] == "segment_complete"] == []
 
-    def test_fails_when_server_withholds_content_ids(self, schema_root: Path) -> None:
+    def test_fails_when_server_withholds_blob_ids(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync
 
         snapshot_hash = "dd" * 32
@@ -569,57 +649,49 @@ class TestRunSync:
         class _IdlessTransport(_FakeTransport):
             def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
                 reply = super().post(path, payload)
-                reply.pop("ids", None)
+                if path == "segment":
+                    reply.pop("blob_id", None)
                 return reply
 
         transport = _IdlessTransport()
-        with pytest.raises(RuntimeError, match="did not return content ids"):
+        with pytest.raises(RuntimeError, match="did not return blob ids"):
             run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
-        assert [p for p in transport.posts if p[0] == "register"] == []
+        assert [p for p in transport.posts if p[0] == "segment_register"] == []
 
-    def test_registers_content_hash_shared_across_families(
+    def test_identical_segment_bytes_across_families_stay_distinct(
         self, schema_root: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from bootstrap.data.d1 import sync
 
-        snapshot_hash = "dd" * 32
-        _build_snapshot(schema_root, snapshot_hash)
-
-        entries = sync.load_snapshot_entries(schema_root, snapshot_hash)
-        # Identical bytes under two families => identical content hash. The
-        # entries table's (family, content_hash) uniqueness key makes these
-        # valid distinct rows, so the sync must succeed.
-        type_entry = next(e for e in entries if e.family == "types")
-        duplicate = sync.Entry("buffs", 999, type_entry.content)
-        assert duplicate.hash == type_entry.hash
-        monkeypatch.setattr(sync, "load_snapshot_entries", lambda *args: [*entries, duplicate])
+        # Identical segment bytes under two families => identical content
+        # hash. The folded_blobs table's (family, content_hash) uniqueness
+        # key makes these valid distinct rows, so both must be uploaded.
+        entries = [sync.Entry("types", 1, b"shared"), sync.Entry("buffs", 1, b"shared")]
+        monkeypatch.setattr(sync, "load_snapshot_entries", lambda *args: entries)
 
         transport = _FakeTransport()
-        sync.run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
+        sync.run_sync({"alpha": "dd" * 32}, schema_root, transport, batch_size=2000)
 
-        # Content frames carry one family each, keeping the worker's
-        # hash-keyed ids reply unambiguous; both rows are uploaded.
-        content_posts = [p for p in transport.posts if p[0] == "content"]
-        for _path, payload in content_posts:
-            assert len({e["family"] for e in payload["entries"]}) == 1
-        uploaded = [e for _path, payload in content_posts for e in payload["entries"]]
-        assert ("types", type_entry.hash) in {(e["family"], e["content_hash"]) for e in uploaded}
-        assert ("buffs", duplicate.hash) in {(e["family"], e["content_hash"]) for e in uploaded}
+        segment_posts = [payload for path, payload in transport.posts if path == "segment"]
+        assert len(segment_posts) == 2
+        assert {payload["family"] for payload in segment_posts} == {"types", "buffs"}
+        assert segment_posts[0]["content_hash"] == segment_posts[1]["content_hash"]
 
-        # The shared hash resolves to a distinct content id per family, and
+        # The shared hash resolves to a distinct blob id per family, and
         # both registrations complete.
-        register_posts = [p for p in transport.posts if p[0] == "register"]
-        reg_entries = [e for _path, payload in register_posts for e in payload["entries"]]
-        types_id = next(
-            e["content_id"]
-            for e in reg_entries
-            if e["family"] == "types" and e["entry_id"] == type_entry.entry_id
-        )
-        buffs_id = next(
-            e["content_id"] for e in reg_entries if e["family"] == "buffs" and e["entry_id"] == 999
-        )
-        assert types_id != buffs_id
-        assert [p for p in transport.posts if p[0] == "complete"] != []
+        register_posts = [
+            payload for path, payload in transport.posts if path == "segment_register"
+        ]
+        blob_ids = {
+            payload["segments"][0]["family"]: payload["segments"][0]["blob_id"]
+            for payload in register_posts
+        }
+        assert blob_ids["types"] != blob_ids["buffs"]
+        complete_posts = [
+            payload for path, payload in transport.posts if path == "segment_complete"
+        ]
+        assert len(complete_posts) == 1
+        assert complete_posts[0]["entry_count"] == 2
 
     def test_dry_run_uploads_nothing(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync
@@ -656,9 +728,9 @@ class TestRunSync:
         run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=batch_size)
 
         for path, payload in transport.posts:
-            if path in ("content", "register"):
-                assert len(payload["entries"]) <= batch_size
-        assert [p for p in transport.posts if p[0] == "complete"] != []
+            if path == "segment_lookup":
+                assert len(payload["content_hashes"]) <= batch_size
+        assert [p for p in transport.posts if p[0] == "segment_complete"] != []
 
 
 class TestCli:

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -207,7 +207,11 @@ ids of the present ones.
 
 Links a snapshot's segments (one frame per family). Every referenced blob id
 must exist in the link's family (error reply with a `missing` list
-otherwise). Links are freeze-guarded exactly like v2 `register`: once
+otherwise), and a frame may link each blob id at most once per family — a
+duplicate fails with `Duplicate segment links` and inserts nothing (the
+freeze `SUM(entry_count)` counts once per link row, so a duplicated blob id
+would be double-counted). Links are freeze-guarded exactly like v2
+`register`: once
 `segment_complete` has frozen a snapshot, further registrations fail with
 `Snapshot already complete`. Replies `{ "id": 8, "ok": true, "inserted": n }`.
 

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -12,7 +12,31 @@ Eight families: the five native engine collections (`types`, `type_dogma`,
 `dogma_attributes`, `dogma_effects`, `buffs`) plus sync-built metadata
 (`type_meta`, `dogma_attribute_meta`, `dogma_effect_meta`), each with a fixed
 integer code (`types=0` … `dogma_effect_meta=7`, see `src/session.ts`).
-Storage v2 uses three tables:
+
+Storage v3 (folded per-family segments, `migrations/0003_folded.sql`,
+additive) is the current layout:
+
+- `folded_blobs` — `(blob_id INTEGER PRIMARY KEY, family, content_hash BLOB,
+  entry_count, first_entry_id, last_entry_id, content BLOB, UNIQUE (family,
+  content_hash))`: the only content store. Each row is one self-contained,
+  content-addressed ≤512 KiB segment of a family's folded stream (`u32
+  count` + `count × (i32 entry_id, u32 offset, u32 length)` + concatenated
+  per-entry protobuf payloads, byte-identical to v2 `entries.content`).
+  `first_entry_id`/`last_entry_id` bound the segment's id range for subset
+  routing; `blob_id` is a dense database-local integer that must never leak
+  outside the sync protocol.
+- `snapshot_family_segments` — `(snapshot_id, family, seq, blob_id)`:
+  per-snapshot segment links, no content.
+- `snapshots` — unchanged registry + freeze semantics. v3 keeps no
+  `registered_count`: `segment_complete` verifies `SUM(entry_count)` over
+  the segment-link join inside the freezing `UPDATE`.
+
+The v2 tables (`entries`, `snapshot_entries`) stay in place for the rollback
+window — 0003 deliberately drops nothing — and the v2 frames below stay
+operational until cutover; migration 0004 drops the v2 tables and the v2
+frames are removed in the same step.
+
+Storage v2 (`migrations/0001_init.sql`, legacy after cutover):
 
 - `entries` — `(content_id INTEGER PRIMARY KEY, family, content_hash BLOB,
   content BLOB, UNIQUE (family, content_hash))`: content-addressed
@@ -137,6 +161,68 @@ frame after a lost reply succeeds. Replies `{ "id": 4, "ok": true }`.
 Completeness probe, same semantics as the HTTP GET below:
 `{ "id": 5, "ok": true, "complete": false }` or
 `{ "id": 5, "ok": true, "complete": true, "entry_count": n, "completed_at": "..." }`.
+
+### Frame: `segment` (v3)
+
+```json
+{
+  "type": "segment",
+  "id": 6,
+  "family": "types",
+  "content_hash": "sha256-hex",
+  "entry_count": 137,
+  "first_entry_id": 587,
+  "last_entry_id": 42000,
+  "content_b64": "..."
+}
+```
+
+Uploads one folded segment: base64-decoded, verified against its SHA-256
+content hash, `INSERT OR IGNORE`d into `folded_blobs`. One segment per frame,
+≤512 KiB raw (base64 capped at ~700 KiB, keeping the frame under the 1 MiB
+WebSocket message limit). Replies `{ "id": 6, "ok": true, "inserted": n,
+"blob_id": 123 }` — the blob id of the freshly inserted or pre-existing row.
+
+### Frame: `segment_lookup` (v3)
+
+```json
+{ "type": "segment_lookup", "id": 7, "family": "types", "content_hashes": ["sha256-hex"] }
+```
+
+Same shape as v2 `lookup`, resolved against `folded_blobs`: the segment
+hashes not yet present in the family (at most 5000 per frame) plus the blob
+ids of the present ones.
+
+### Frame: `segment_register` (v3)
+
+```json
+{
+  "type": "segment_register",
+  "id": 8,
+  "server_id": "tranquility",
+  "snapshot_hash": "sha256-hex",
+  "segments": [{ "family": "types", "seq": 0, "blob_id": 123 }]
+}
+```
+
+Links a snapshot's segments (one frame per family). Every referenced blob id
+must exist in the link's family (error reply with a `missing` list
+otherwise). Links are freeze-guarded exactly like v2 `register`: once
+`segment_complete` has frozen a snapshot, further registrations fail with
+`Snapshot already complete`. Replies `{ "id": 8, "ok": true, "inserted": n }`.
+
+### Frame: `segment_complete` (v3)
+
+```json
+{ "type": "segment_complete", "id": 9, "server_id": "tranquility", "snapshot_hash": "sha256-hex", "entry_count": 8 }
+```
+
+Marks a snapshot complete. Verifies server-side that
+`SUM(folded_blobs.entry_count)` over the snapshot's segment links equals
+`entry_count` (error reply carrying the real sum otherwise); the SUM check
+and the freeze are a single conditional `UPDATE`. v3 keeps no counter, so
+there is no divergence/repair path. A retry of the same frame after a lost
+reply succeeds. Replies `{ "id": 9, "ok": true }`.
 
 ### `GET /platform/storage/data-sync/health`
 

--- a/worker/efa-platform-data-sync/migrations/0003_folded.sql
+++ b/worker/efa-platform-data-sync/migrations/0003_folded.sql
@@ -1,0 +1,58 @@
+-- Storage v3: folded per-family segments (additive).
+--
+-- Replaces the v2 per-entry content store (`entries` + `snapshot_entries`)
+-- with folded per-family binary streams segmented into self-contained,
+-- content-addressed <=512 KiB blobs. Motivation (benchmark-measured on the
+-- real 2-snapshot dataset, ~300k entries / 31.3 MiB payload): the v2 layout
+-- costs ~800k billable row-writes (index writes count) and ~830 WebSocket
+-- frames per 2-snapshot sync; the folded layout needs ~300 writes and ~104
+-- frames. Whole-family reads drop from a ~54k-row join to ~40 segment rows.
+--
+-- Segment size is bounded at 512 KiB because D1 caps a BLOB/row at 2 MB
+-- (a mono-blob per family is impossible: type_dogma is ~10.4 MiB) and the
+-- base64'd frame stays well under the 1 MiB WebSocket message limit.
+-- Segments are deduplicated content-addressed per (family, content_hash);
+-- cross-snapshot segment-level dedup is marginal (~1.3%) because
+-- inter-snapshot churn is dense, so segmentation is a deterministic greedy
+-- pack at entry boundaries, not CDC.
+--
+-- THIS MIGRATION IS ADDITIVE ONLY. It deliberately does NOT drop the v2
+-- tables: `entries` and `snapshot_entries` stay in place for the rollback
+-- window while the sync worker serves both the v2 and v3 frame protocols and
+-- readers dual-read (v3 catalog probe first, v2 join fallback). The drops
+-- happen in migration 0004, after cutover is complete and burned in.
+
+-- The ONLY content store of v3. Each row is one self-contained segment of a
+-- family's folded stream (entries sorted by entry id):
+--   u32 count
+--   count x { i32 entry_id, u32 offset, u32 length }  -- offset from segment start
+--   payload bytes (concatenated per-entry protobufs, byte-identical to the
+--   v2 entries.content payloads)
+-- family codes are unchanged: types=0, type_dogma=1, dogma_attributes=2,
+-- dogma_effects=3, buffs=4, type_meta=5, dogma_attribute_meta=6,
+-- dogma_effect_meta=7. first_entry_id/last_entry_id bound the segment's id
+-- range for subset routing; blob_id is database-local and must never leak
+-- outside the sync protocol.
+CREATE TABLE folded_blobs (
+    blob_id INTEGER PRIMARY KEY,
+    family INTEGER NOT NULL,
+    content_hash BLOB NOT NULL,                -- raw 32-byte SHA-256 of the segment bytes
+    entry_count INTEGER NOT NULL,
+    first_entry_id INTEGER NOT NULL,           -- subset routing
+    last_entry_id INTEGER NOT NULL,
+    content BLOB NOT NULL,
+    UNIQUE (family, content_hash)
+);
+
+-- Per-snapshot links onto segments; no content. (snapshot_id, family, seq)
+-- orders a snapshot's segments within one family. Completion is verified by
+-- SUM(folded_blobs.entry_count) over this join, replacing v2's
+-- registered_count counter and its crash-repair path (v3 register frames do
+-- not maintain registered_count).
+CREATE TABLE snapshot_family_segments (
+    snapshot_id INTEGER NOT NULL REFERENCES snapshots (snapshot_id),
+    family INTEGER NOT NULL,
+    seq INTEGER NOT NULL,
+    blob_id INTEGER NOT NULL REFERENCES folded_blobs (blob_id),
+    PRIMARY KEY (snapshot_id, family, seq)
+);

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -706,8 +706,11 @@ const SEGMENT_HEADER_BYTES = 4;
 const SEGMENT_INDEX_ENTRY_BYTES = 12;
 
 // Parse a verified segment's own index. Returns null when the buffer is too
-// small to hold the index its header declares (or declares zero entries, in
-// which case first/last entry ids are undefined).
+// small to hold the index its header declares, declares zero entries, or the
+// entry ids are not strictly increasing. The ordering guarantee matters:
+// readers binary-search this index (prefetch's segment_extract), and the
+// stored blob is immutable (INSERT OR IGNORE keeps the first row), so an
+// unsorted or duplicate index accepted here would be unrepairable.
 function parseSegmentIndex(
     content: Uint8Array,
 ): { count: number; firstId: number; lastId: number } | null {
@@ -719,11 +722,16 @@ function parseSegmentIndex(
     if (count < 1 || SEGMENT_HEADER_BYTES + count * SEGMENT_INDEX_ENTRY_BYTES > content.length) {
         return null;
     }
-    return {
-        count,
-        firstId: view.getInt32(SEGMENT_HEADER_BYTES, true),
-        lastId: view.getInt32(SEGMENT_HEADER_BYTES + (count - 1) * SEGMENT_INDEX_ENTRY_BYTES, true),
-    };
+    const firstId = view.getInt32(SEGMENT_HEADER_BYTES, true);
+    let lastId = firstId;
+    for (let i = 1; i < count; i++) {
+        const id = view.getInt32(SEGMENT_HEADER_BYTES + i * SEGMENT_INDEX_ENTRY_BYTES, true);
+        if (id <= lastId) {
+            return null;
+        }
+        lastId = id;
+    }
+    return { count, firstId, lastId };
 }
 
 interface SegmentFrame {

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -65,7 +65,9 @@
 //   {type: "segment_register", id, server_id, snapshot_hash,
 //    segments: [{family, seq, blob_id}]}
 //       -> {id, ok: true, inserted} — per-snapshot segment links, guarded
-//          against frozen snapshots exactly like v2 register.
+//          against frozen snapshots exactly like v2 register. A frame
+//          linking the same blob id more than once per family is rejected
+//          (the freeze SUM counts entry_count once per link row).
 //   {type: "segment_complete", id, server_id, snapshot_hash, entry_count}
 //       -> {id, ok: true} — freezes the snapshot after verifying
 //          SUM(folded_blobs.entry_count) over the segment-link join inside
@@ -885,13 +887,33 @@ async function handleSegmentRegister(
     }
 
     // Referential integrity: every referenced blob id must exist and belong
-    // to the link's stated family.
+    // to the link's stated family. Within one frame, each blob id may be
+    // linked at most once per family: freezeSnapshotSegments sums
+    // entry_count once per link row, so a duplicated blob id would be
+    // double-counted (and enumerated twice by readers' catalogs). Reject
+    // before any insert so a bad frame writes nothing. Cross-frame replays
+    // are unaffected — they carry identical (family, seq, blob_id) rows,
+    // which the INSERT OR IGNORE below dedupes by primary key.
+    const duplicates: { family: Family; blob_id: number }[] = [];
+    const frameLinks = new Set<string>();
     const missing: { family: Family; blob_id: number }[] = [];
     const byFamily = new Map<Family, number[]>();
     for (const link of segments) {
+        const key = `${FAMILY_CODES[link.family]}:${link.blob_id}`;
+        if (frameLinks.has(key)) {
+            duplicates.push({ family: link.family, blob_id: link.blob_id });
+            continue;
+        }
+        frameLinks.add(key);
         const ids = byFamily.get(link.family) ?? [];
         ids.push(link.blob_id);
         byFamily.set(link.family, ids);
+    }
+    if (duplicates.length > 0) {
+        throw new SyncFailure({
+            error: "Duplicate segment links",
+            duplicates: duplicates.slice(0, 100),
+        });
     }
     for (const [family, blobIds] of byFamily) {
         const familyCode = FAMILY_CODES[family];

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -50,6 +50,29 @@
 //       -> {id, ok: true, complete: bool, entry_count?, completed_at?} —
 //          completeness probe so reruns can skip finished snapshots.
 //
+// Storage v3 (folded per-family segments, see migrations/0003_folded.sql)
+// adds a parallel frame set; the v2 frames above stay operational until
+// cutover (additive deploy, rollback window — the v2 tables are dropped by
+// migration 0004, not 0003):
+//   {type: "segment", id, family, content_hash, entry_count,
+//    first_entry_id, last_entry_id, content_b64}
+//       -> {id, ok: true, inserted, blob_id} — one folded segment (<=512 KiB
+//          raw, ~700 KiB base64 cap), SHA-256-verified, INSERT OR IGNORE
+//          into folded_blobs; the reply resolves the database-local blob id.
+//   {type: "segment_lookup", id, family, content_hashes: [hex]}
+//       -> {id, ok: true, missing: [hex], ids: {content_hash: blob_id}} —
+//          same shape as v2 lookup, resolved against folded_blobs.
+//   {type: "segment_register", id, server_id, snapshot_hash,
+//    segments: [{family, seq, blob_id}]}
+//       -> {id, ok: true, inserted} — per-snapshot segment links, guarded
+//          against frozen snapshots exactly like v2 register.
+//   {type: "segment_complete", id, server_id, snapshot_hash, entry_count}
+//       -> {id, ok: true} — freezes the snapshot after verifying
+//          SUM(folded_blobs.entry_count) over the segment-link join inside
+//          the single conditional UPDATE; v3 keeps no registered_count
+//          counter, so there is no crash-repair path — the SUM is the check.
+//          A retry of the same frame after a lost reply succeeds.
+//
 // Error replies carry {id, ok: false, error, ...details}.
 
 import { DurableObject } from "cloudflare:workers";
@@ -83,6 +106,18 @@ const CONTENT_ENTRIES_PER_FRAME = 2000;
 const REGISTER_ENTRIES_PER_FRAME = 2000;
 const LOOKUP_HASHES_PER_FRAME = 5000;
 
+// v3 (folded segments): one segment per content frame, <=512 KiB raw. The
+// base64 cap (~700 KiB) keeps the JSON frame well under the 1 MiB WebSocket
+// message limit. Register frames carry one family's segment links (the
+// largest family folds to ~25 segments at 512 KiB); 1000 is generous
+// headroom, not an expected size.
+const SEGMENT_CONTENT_B64_MAX = 700 * 1024;
+const SEGMENT_LINKS_PER_FRAME = 1000;
+const SEGMENT_LOOKUP_HASHES_PER_FRAME = 5000;
+
+// Engine-internal pseudo attributes/effects carry negative int32 IDs.
+const EntryIdSchema = z.number().int().gte(-2147483648).lte(2147483647);
+
 const ContentEntrySchema = z.object({
     family: FamilySchema,
     content_hash: z.string().regex(HASH_RE),
@@ -91,9 +126,14 @@ const ContentEntrySchema = z.object({
 
 const RegisterEntrySchema = z.object({
     family: FamilySchema,
-    // Engine-internal pseudo attributes/effects carry negative int32 IDs.
-    entry_id: z.number().int().gte(-2147483648).lte(2147483647),
+    entry_id: EntryIdSchema,
     content_id: z.number().int().positive(),
+});
+
+const SegmentLinkSchema = z.object({
+    family: FamilySchema,
+    seq: z.number().int().nonnegative(),
+    blob_id: z.number().int().positive(),
 });
 
 const SnapshotSelectorSchema = z.object({
@@ -129,6 +169,38 @@ const ClientMessageSchema = z.discriminatedUnion("type", [
         type: z.literal("snapshot"),
         id: IdSchema,
         ...SnapshotSelectorSchema.shape,
+    }),
+    // Storage v3 (folded segments); see the header comment.
+    z.object({
+        type: z.literal("segment"),
+        id: IdSchema,
+        family: FamilySchema,
+        content_hash: z.string().regex(HASH_RE),
+        entry_count: z.number().int().positive(),
+        first_entry_id: EntryIdSchema,
+        last_entry_id: EntryIdSchema,
+        content_b64: z.base64().min(1).max(SEGMENT_CONTENT_B64_MAX),
+    }),
+    z.object({
+        type: z.literal("segment_lookup"),
+        id: IdSchema,
+        family: FamilySchema,
+        content_hashes: z
+            .array(z.string().regex(HASH_RE))
+            .min(1)
+            .max(SEGMENT_LOOKUP_HASHES_PER_FRAME),
+    }),
+    z.object({
+        type: z.literal("segment_register"),
+        id: IdSchema,
+        ...SnapshotSelectorSchema.shape,
+        segments: z.array(SegmentLinkSchema).min(1).max(SEGMENT_LINKS_PER_FRAME),
+    }),
+    z.object({
+        type: z.literal("segment_complete"),
+        id: IdSchema,
+        ...SnapshotSelectorSchema.shape,
+        entry_count: z.number().int().nonnegative(),
     }),
 ]);
 
@@ -619,16 +691,316 @@ async function handleSnapshot(
     };
 }
 
+// ---------------------------------------------------------------------------
+// Storage v3: folded per-family segments (migrations/0003_folded.sql).
+// ---------------------------------------------------------------------------
+
+type SegmentLink = z.infer<typeof SegmentLinkSchema>;
+
+interface SegmentFrame {
+    family: Family;
+    content_hash: string;
+    entry_count: number;
+    first_entry_id: number;
+    last_entry_id: number;
+    content_b64: string;
+}
+
+// One folded segment: base64-decode, verify against its SHA-256 content
+// hash, INSERT OR IGNORE, then resolve the database-local blob id (the row
+// may have pre-existed, so the id is read back rather than derived from the
+// insert result).
+async function handleSegment(
+    db: D1Database,
+    frame: SegmentFrame,
+): Promise<{ inserted: number; blob_id: number }> {
+    let content: Uint8Array;
+    try {
+        content = base64ToBytes(frame.content_b64);
+    } catch {
+        throw new SyncFailure({
+            error: "Content verification failed",
+            rejected: [
+                {
+                    family: frame.family,
+                    content_hash: frame.content_hash,
+                    reason: "invalid base64",
+                },
+            ],
+        });
+    }
+    const actual = await sha256Hex(content);
+    if (actual !== frame.content_hash) {
+        throw new SyncFailure({
+            error: "Content verification failed",
+            rejected: [
+                {
+                    family: frame.family,
+                    content_hash: frame.content_hash,
+                    reason: `hash mismatch: content hashes to ${actual}`,
+                },
+            ],
+        });
+    }
+    const familyCode = FAMILY_CODES[frame.family];
+    const inserted = await db
+        .prepare(
+            "INSERT OR IGNORE INTO folded_blobs " +
+                "(family, content_hash, entry_count, first_entry_id, last_entry_id, content) " +
+                "VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(
+            familyCode,
+            hexToBlob(frame.content_hash),
+            frame.entry_count,
+            frame.first_entry_id,
+            frame.last_entry_id,
+            content.buffer as ArrayBuffer,
+        )
+        .run();
+    const row = await db
+        .prepare("SELECT blob_id FROM folded_blobs WHERE family = ? AND content_hash = ?")
+        .bind(familyCode, hexToBlob(frame.content_hash))
+        .first<{ blob_id: number }>();
+    if (!row) {
+        throw new Error("folded_blobs row missing after insert");
+    }
+    return { inserted: inserted.meta.changes ?? 0, blob_id: row.blob_id };
+}
+
+// Same shape as v2 lookup, resolved against folded_blobs: segment hashes
+// not yet present in the family, plus the blob ids of the present ones.
+async function handleSegmentLookup(
+    db: D1Database,
+    family: Family,
+    contentHashes: string[],
+): Promise<{ missing: string[]; ids: Record<string, number> }> {
+    const familyCode = FAMILY_CODES[family];
+    const ids: Record<string, number> = {};
+    const missing: string[] = [];
+    for (const chunk of chunked([...new Set(contentHashes)], HASHES_PER_LOOKUP)) {
+        const placeholders = chunk.map(() => "?").join(", ");
+        const found = await db
+            .prepare(
+                "SELECT blob_id, content_hash FROM folded_blobs " +
+                    `WHERE family = ? AND content_hash IN (${placeholders})`,
+            )
+            .bind(familyCode, ...chunk.map(hexToBlob))
+            .all<{ blob_id: number; content_hash: ArrayBuffer }>();
+        const foundSet = new Set<string>();
+        for (const row of found.results) {
+            const hex = bytesToHex(new Uint8Array(row.content_hash));
+            ids[hex] = row.blob_id;
+            foundSet.add(hex);
+        }
+        for (const hash of chunk) {
+            if (!foundSet.has(hash)) {
+                missing.push(hash);
+            }
+        }
+    }
+    return { ids, missing };
+}
+
+// Per-snapshot segment links. Freeze-guarded like v2 register (fast-path
+// check, per-statement EXISTS guard, completed_at probe in the final
+// batch), but maintains no counter: v3 completion verifies SUM(entry_count)
+// over the link join instead.
+async function handleSegmentRegister(
+    db: D1Database,
+    serverId: string,
+    snapshotHash: string,
+    segments: SegmentLink[],
+): Promise<{ inserted: number }> {
+    const snapshot = await ensureSnapshot(db, serverId, snapshotHash);
+    if (snapshot.completed_at !== null) {
+        throw new SyncFailure({ error: "Snapshot already complete" });
+    }
+
+    // Referential integrity: every referenced blob id must exist and belong
+    // to the link's stated family.
+    const missing: { family: Family; blob_id: number }[] = [];
+    const byFamily = new Map<Family, number[]>();
+    for (const link of segments) {
+        const ids = byFamily.get(link.family) ?? [];
+        ids.push(link.blob_id);
+        byFamily.set(link.family, ids);
+    }
+    for (const [family, blobIds] of byFamily) {
+        const familyCode = FAMILY_CODES[family];
+        for (const chunk of chunked([...new Set(blobIds)], HASHES_PER_LOOKUP)) {
+            const placeholders = chunk.map(() => "?").join(", ");
+            const found = await db
+                .prepare(
+                    "SELECT blob_id FROM folded_blobs " +
+                        `WHERE family = ? AND blob_id IN (${placeholders})`,
+                )
+                .bind(familyCode, ...chunk)
+                .all<{ blob_id: number }>();
+            const foundSet = new Set(found.results.map((row) => row.blob_id));
+            for (const blobId of chunk) {
+                if (!foundSet.has(blobId)) {
+                    missing.push({ family, blob_id: blobId });
+                }
+            }
+        }
+    }
+    if (missing.length > 0) {
+        throw new SyncFailure({ error: "Unknown blob ids", missing: missing.slice(0, 100) });
+    }
+
+    let inserted = 0;
+    const statements: D1PreparedStatement[] = [];
+    for (const chunk of chunked(segments, REGISTER_ROWS_PER_STATEMENT)) {
+        const placeholders = chunk.map(() => "(?, ?, ?, ?)").join(", ");
+        const binds = [
+            ...chunk.flatMap((link) => [
+                snapshot.snapshot_id,
+                FAMILY_CODES[link.family],
+                link.seq,
+                link.blob_id,
+            ]),
+            snapshot.snapshot_id,
+        ];
+        // Same freeze guard as v2 register: every insert is conditional on
+        // the snapshot not being frozen (see handleRegister).
+        statements.push(
+            db
+                .prepare(
+                    "INSERT OR IGNORE INTO snapshot_family_segments " +
+                        "(snapshot_id, family, seq, blob_id) " +
+                        "SELECT column1, column2, column3, column4 " +
+                        `FROM (VALUES ${placeholders}) ` +
+                        "WHERE EXISTS (SELECT 1 FROM snapshots " +
+                        "WHERE snapshot_id = ? AND completed_at IS NULL)",
+                )
+                .bind(...binds),
+        );
+    }
+    // The final batch also probes completed_at, closing the race against a
+    // concurrent complete that bypassed the instance-level serialization
+    // (same argument as v2 register).
+    const batches = chunked(statements, STATEMENTS_PER_BATCH);
+    for (const [index, batch] of batches.entries()) {
+        const isLast = index === batches.length - 1;
+        if (isLast) {
+            batch.push(
+                db
+                    .prepare("SELECT completed_at FROM snapshots WHERE snapshot_id = ?")
+                    .bind(snapshot.snapshot_id),
+            );
+        }
+        const results = await db.batch(batch);
+        for (const result of isLast ? results.slice(0, -1) : results) {
+            inserted += result.meta.changes ?? 0;
+        }
+        if (isLast) {
+            const probe = results.at(-1)?.results[0] as { completed_at: string | null } | undefined;
+            if (probe?.completed_at != null) {
+                throw new SyncFailure({ error: "Snapshot already complete" });
+            }
+        }
+    }
+    return { inserted };
+}
+
+// The v3 freezing UPDATE: the count verification is SUM(folded_blobs.
+// entry_count) over the snapshot's segment links — a ~64-row join, µs — not
+// a maintained counter, so there is no divergence/repair path at all. The
+// SUM, the not-yet-frozen check, and the marker write are one statement, so
+// a concurrent register frame that bypassed the instance-level serialization
+// can never slip links in between the verification and the freeze.
+async function freezeSnapshotSegments(
+    db: D1Database,
+    snapshotId: number,
+    entryCount: number,
+): Promise<boolean> {
+    const result = await db
+        .prepare(
+            "UPDATE snapshots SET entry_count = ?, " +
+                "completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') " +
+                "WHERE snapshot_id = ? AND completed_at IS NULL AND " +
+                "(SELECT COALESCE(SUM(b.entry_count), 0) " +
+                "FROM snapshot_family_segments s " +
+                "JOIN folded_blobs b ON b.blob_id = s.blob_id " +
+                "WHERE s.snapshot_id = ?) = ?",
+        )
+        .bind(entryCount, snapshotId, snapshotId, entryCount)
+        .run();
+    return (result.meta.changes ?? 0) > 0;
+}
+
+async function sumSegmentEntries(db: D1Database, snapshotId: number): Promise<number> {
+    const row = await db
+        .prepare(
+            "SELECT COALESCE(SUM(b.entry_count), 0) AS n " +
+                "FROM snapshot_family_segments s " +
+                "JOIN folded_blobs b ON b.blob_id = s.blob_id " +
+                "WHERE s.snapshot_id = ?",
+        )
+        .bind(snapshotId)
+        .first<{ n: number }>();
+    return row?.n ?? 0;
+}
+
+async function handleSegmentComplete(
+    db: D1Database,
+    serverId: string,
+    snapshotHash: string,
+    entryCount: number,
+): Promise<Record<string, never>> {
+    const snapshot = await findSnapshot(db, serverId, snapshotHash);
+    if (!snapshot) {
+        throw new SyncFailure({
+            error: "Snapshot incomplete",
+            expected: entryCount,
+            registered: 0,
+        });
+    }
+
+    // Idempotent retry of a complete frame whose reply was lost.
+    if (snapshot.completed_at !== null) {
+        if (snapshot.entry_count === entryCount) {
+            return {};
+        }
+        throw new SyncFailure({ error: "Snapshot already complete" });
+    }
+
+    if (await freezeSnapshotSegments(db, snapshot.snapshot_id, entryCount)) {
+        return {};
+    }
+
+    // The conditional update matched no row: a concurrent complete won the
+    // race, or the segment-link SUM genuinely differs. Re-read the registry
+    // row, then report the real SUM — no counter to repair (v3 keeps none).
+    const state = await findSnapshot(db, serverId, snapshotHash);
+    if (state?.completed_at != null) {
+        if (state.entry_count === entryCount) {
+            return {};
+        }
+        throw new SyncFailure({ error: "Snapshot already complete" });
+    }
+    const registered = await sumSegmentEntries(db, snapshot.snapshot_id);
+    throw new SyncFailure({
+        error: "Snapshot incomplete",
+        expected: entryCount,
+        registered,
+    });
+}
+
 export class SyncSession extends DurableObject<Env> {
-    // Per-snapshot mutual exclusion between register and complete handlers.
-    // The freeze fast path trusts registered_count, which a register frame
-    // updates only after its insert batches commit; serializing the two
-    // handlers per snapshot guarantees no register frame is mid-flight when
-    // complete evaluates the counter. This is instance memory, so a
-    // restarted instance starts empty — safe, because an instance is never
-    // evicted while it is still processing a frame, and a crashed register
-    // frame's divergence is repaired by the complete fallback's COUNT(*).
-    // The per-statement freeze guards remain the SQL-level backstop.
+    // Per-snapshot mutual exclusion between register and complete handlers
+    // (v2 and v3 share the lock keyspace: a snapshot is frozen once,
+    // whichever protocol freezes it). For v2 the freeze fast path trusts
+    // registered_count, which a register frame updates only after its
+    // insert batches commit; serializing the two handlers per snapshot
+    // guarantees no register frame is mid-flight when complete evaluates
+    // the counter (v3's SUM check benefits the same way). This is instance
+    // memory, so a restarted instance starts empty — safe, because an
+    // instance is never evicted while it is still processing a frame, and
+    // a crashed v2 register frame's divergence is repaired by the complete
+    // fallback's COUNT(*). The per-statement freeze guards remain the
+    // SQL-level backstop.
     private readonly snapshotLocks = new Map<string, Promise<unknown>>();
 
     // Run `task` after every previously queued register/complete handler for
@@ -728,6 +1100,42 @@ export class SyncSession extends DurableObject<Env> {
                             this.env.PLATFORM_DB,
                             msg.server_id,
                             msg.snapshot_hash,
+                        ),
+                    );
+                    break;
+                case "segment":
+                    Object.assign(reply, await handleSegment(this.env.PLATFORM_DB, msg));
+                    break;
+                case "segment_lookup":
+                    Object.assign(
+                        reply,
+                        await handleSegmentLookup(
+                            this.env.PLATFORM_DB,
+                            msg.family,
+                            msg.content_hashes,
+                        ),
+                    );
+                    break;
+                case "segment_register":
+                    Object.assign(
+                        reply,
+                        await this.runSerialized(`${msg.server_id}:${msg.snapshot_hash}`, () =>
+                            handleSegmentRegister(
+                                this.env.PLATFORM_DB,
+                                msg.server_id,
+                                msg.snapshot_hash,
+                                msg.segments,
+                            ),
+                        ),
+                    );
+                    break;
+                case "segment_complete":
+                    await this.runSerialized(`${msg.server_id}:${msg.snapshot_hash}`, () =>
+                        handleSegmentComplete(
+                            this.env.PLATFORM_DB,
+                            msg.server_id,
+                            msg.snapshot_hash,
+                            msg.entry_count,
                         ),
                     );
                     break;

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -697,6 +697,33 @@ async function handleSnapshot(
 
 type SegmentLink = z.infer<typeof SegmentLinkSchema>;
 
+// Folded segment layout (mirrors bootstrap/data/d1/sync.py::fold_family and
+// the 0003_folded.sql comment): u32 count, then count x (i32 entry_id,
+// u32 offset, u32 length) index, then the concatenated payloads.
+const SEGMENT_HEADER_BYTES = 4;
+const SEGMENT_INDEX_ENTRY_BYTES = 12;
+
+// Parse a verified segment's own index. Returns null when the buffer is too
+// small to hold the index its header declares (or declares zero entries, in
+// which case first/last entry ids are undefined).
+function parseSegmentIndex(
+    content: Uint8Array,
+): { count: number; firstId: number; lastId: number } | null {
+    if (content.length < SEGMENT_HEADER_BYTES) {
+        return null;
+    }
+    const view = new DataView(content.buffer, content.byteOffset, content.byteLength);
+    const count = view.getUint32(0, true);
+    if (count < 1 || SEGMENT_HEADER_BYTES + count * SEGMENT_INDEX_ENTRY_BYTES > content.length) {
+        return null;
+    }
+    return {
+        count,
+        firstId: view.getInt32(SEGMENT_HEADER_BYTES, true),
+        lastId: view.getInt32(SEGMENT_HEADER_BYTES + (count - 1) * SEGMENT_INDEX_ENTRY_BYTES, true),
+    };
+}
+
 interface SegmentFrame {
     family: Family;
     content_hash: string;
@@ -743,6 +770,46 @@ async function handleSegment(
         });
     }
     const familyCode = FAMILY_CODES[frame.family];
+    // The hash proves the content, not the metadata: the stored entry_count
+    // and first/last id range are trusted verbatim by freezeSnapshotSegments
+    // (SUM over entry_count) and prefetch's subset routing (find_segment
+    // binary-searches the stored ranges). Parse the verified content's own
+    // index and reject a frame whose metadata disagrees — INSERT OR IGNORE
+    // keeps the first row for (family, content_hash), so a stored mismatch
+    // could never be repaired by a retry.
+    const index = parseSegmentIndex(content);
+    if (index === null) {
+        throw new SyncFailure({
+            error: "Content verification failed",
+            rejected: [
+                {
+                    family: frame.family,
+                    content_hash: frame.content_hash,
+                    reason: "malformed segment index",
+                },
+            ],
+        });
+    }
+    if (
+        index.count !== frame.entry_count ||
+        index.firstId !== frame.first_entry_id ||
+        index.lastId !== frame.last_entry_id
+    ) {
+        throw new SyncFailure({
+            error: "Content verification failed",
+            rejected: [
+                {
+                    family: frame.family,
+                    content_hash: frame.content_hash,
+                    reason:
+                        `metadata mismatch: index has count=${index.count} ` +
+                        `ids=[${index.firstId}, ${index.lastId}], frame declares ` +
+                        `count=${frame.entry_count} ` +
+                        `ids=[${frame.first_entry_id}, ${frame.last_entry_id}]`,
+                },
+            ],
+        });
+    }
     const inserted = await db
         .prepare(
             "INSERT OR IGNORE INTO folded_blobs " +

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -1028,6 +1028,68 @@ describe("v3 snapshot freeze", () => {
         ws.close();
     });
 
+    it("rejects frames linking the same blob id more than once per family", async () => {
+        const ws = await connect();
+        const serverId = "tranquility";
+        const snapshotHash = "fa".repeat(32);
+
+        const [segment] = await foldSegments([
+            { id: 1, content: new TextEncoder().encode("type-entry-1") },
+            { id: 2, content: new TextEncoder().encode("type-entry-2") },
+        ]);
+        const { blobId } = await uploadSegment(ws, 1, "types", segment);
+
+        // The same blob at two seq values would double-count entry_count in
+        // the freeze SUM and enumerate the segment twice in readers'
+        // catalogs; the frame is rejected before writing anything.
+        let reply = await call(ws, {
+            id: 2,
+            type: "segment_register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            segments: [
+                { family: "types", seq: 0, blob_id: blobId },
+                { family: "types", seq: 1, blob_id: blobId },
+            ],
+        });
+        expect(reply.id).toBe(2);
+        expect(reply.ok).toBe(false);
+        expect(reply.error).toBe("Duplicate segment links");
+        expect(reply.duplicates).toEqual([{ family: "types", blob_id: blobId }]);
+        expect(await linkStats(serverId, snapshotHash)).toEqual({ links: 0, entries: 0 });
+
+        // The same link registered once is fine, and a retry of the
+        // identical frame stays idempotent (primary-key dedup).
+        reply = await call(ws, {
+            id: 3,
+            type: "segment_register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            segments: [{ family: "types", seq: 0, blob_id: blobId }],
+        });
+        expect(reply).toEqual({ id: 3, ok: true, inserted: 1 });
+        reply = await call(ws, {
+            id: 4,
+            type: "segment_register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            segments: [{ family: "types", seq: 0, blob_id: blobId }],
+        });
+        expect(reply).toEqual({ id: 4, ok: true, inserted: 0 });
+
+        // The happy path still freezes at the real entry count.
+        reply = await call(ws, {
+            id: 5,
+            type: "segment_complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 2,
+        });
+        expect(reply).toEqual({ id: 5, ok: true });
+        expect(await linkStats(serverId, snapshotHash)).toEqual({ links: 1, entries: 2 });
+        ws.close();
+    });
+
     it("never freezes mid-registration even when register and complete race", async () => {
         // Port of the v2 register/complete race regression test to the v3
         // frames: whichever side runs first, a frozen snapshot's entry_count

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -797,6 +797,62 @@ describe("v3 segment content", () => {
         ws.close();
     });
 
+    it("rejects segment metadata that disagrees with the verified content", async () => {
+        const ws = await connect();
+        const [segment] = await foldSegments([
+            { id: 587, content: new TextEncoder().encode("type-entry-587") },
+            { id: 600, content: new TextEncoder().encode("type-entry-600") },
+        ]);
+        // entry_count, first/last_entry_id are not covered by the content
+        // hash; each mismatch must be rejected against the parsed index.
+        for (const metadata of [
+            { entry_count: 1, first_entry_id: 587, last_entry_id: 600 },
+            { entry_count: 3, first_entry_id: 587, last_entry_id: 600 },
+            { entry_count: 2, first_entry_id: 588, last_entry_id: 600 },
+            { entry_count: 2, first_entry_id: 587, last_entry_id: 599 },
+        ]) {
+            const reply = await call(ws, {
+                id: 1,
+                type: "segment",
+                family: "types",
+                content_hash: segment.hash,
+                ...metadata,
+                content_b64: toBase64(segment.bytes),
+            });
+            expect(reply.id).toBe(1);
+            expect(reply.ok).toBe(false);
+            expect(reply.error).toBe("Content verification failed");
+        }
+        // Nothing was stored: the same content with correct metadata still
+        // inserts (a retry repairs what INSERT OR IGNORE would otherwise
+        // have frozen in).
+        const { inserted } = await uploadSegment(ws, 2, "types", segment);
+        expect(inserted).toBe(1);
+        ws.close();
+    });
+
+    it("rejects segments whose index overruns the content", async () => {
+        const ws = await connect();
+        // Hash-valid content whose header declares more index entries than
+        // the buffer holds.
+        const bytes = new Uint8Array(4);
+        new DataView(bytes.buffer).setUint32(0, 2, true);
+        const reply = await call(ws, {
+            id: 1,
+            type: "segment",
+            family: "types",
+            content_hash: await sha256Hex(bytes),
+            entry_count: 2,
+            first_entry_id: 1,
+            last_entry_id: 2,
+            content_b64: toBase64(bytes),
+        });
+        expect(reply.id).toBe(1);
+        expect(reply.ok).toBe(false);
+        expect(reply.error).toBe("Content verification failed");
+        ws.close();
+    });
+
     it("rejects oversize segments", async () => {
         const ws = await connect();
         const reply = await call(ws, {

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -66,7 +66,13 @@ async function sha256Hex(data: Uint8Array): Promise<string> {
 }
 
 function toBase64(data: Uint8Array): string {
-    return btoa(String.fromCharCode(...data));
+    // Chunked: spreading a whole segment into fromCharCode overflows the
+    // call stack at ~512 KiB payloads.
+    let binary = "";
+    for (let i = 0; i < data.length; i += 0x8000) {
+        binary += String.fromCharCode(...data.subarray(i, i + 0x8000));
+    }
+    return btoa(binary);
 }
 
 function hexToBlob(hex: string): ArrayBuffer {
@@ -635,5 +641,425 @@ describe("entry_id validation", () => {
             expect(reply.error).toBe("Validation failed");
         }
         ws.close();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Storage v3: folded per-family segments (migrations/0003_folded.sql).
+// ---------------------------------------------------------------------------
+
+const SEGMENT_MAX = 512 * 1024;
+
+interface SegmentDef {
+    entries: { id: number; content: Uint8Array }[];
+    bytes: Uint8Array;
+    hash: string;
+}
+
+// Mirrors bootstrap/data/d1/sync.py::fold_family: sort by entry id, greedy
+// pack <=512 KiB at entry boundaries, u32 count + (i32 id, u32 off, u32 len)
+// index + concatenated payloads.
+async function foldSegments(entries: { id: number; content: Uint8Array }[]): Promise<SegmentDef[]> {
+    const sorted = [...entries].sort((a, b) => a.id - b.id);
+    const groups: { id: number; content: Uint8Array }[][] = [];
+    let current: { id: number; content: Uint8Array }[] = [];
+    let size = 4;
+    for (const entry of sorted) {
+        const entrySize = 12 + entry.content.length;
+        if (current.length > 0 && size + entrySize > SEGMENT_MAX) {
+            groups.push(current);
+            current = [];
+            size = 4;
+        }
+        current.push(entry);
+        size += entrySize;
+    }
+    if (current.length > 0) {
+        groups.push(current);
+    }
+    const segments: SegmentDef[] = [];
+    for (const group of groups) {
+        const bytes = new Uint8Array(
+            4 + group.length * 12 + group.reduce((n, e) => n + e.content.length, 0),
+        );
+        const view = new DataView(bytes.buffer);
+        view.setUint32(0, group.length, true);
+        let indexOffset = 4;
+        let dataOffset = 4 + group.length * 12;
+        for (const entry of group) {
+            view.setInt32(indexOffset, entry.id, true);
+            view.setUint32(indexOffset + 4, dataOffset, true);
+            view.setUint32(indexOffset + 8, entry.content.length, true);
+            bytes.set(entry.content, dataOffset);
+            indexOffset += 12;
+            dataOffset += entry.content.length;
+        }
+        segments.push({ entries: group, bytes, hash: await sha256Hex(bytes) });
+    }
+    return segments;
+}
+
+async function uploadSegment(
+    ws: WebSocket,
+    id: number,
+    family: string,
+    segment: SegmentDef,
+): Promise<{ blobId: number; inserted: number }> {
+    const reply = await call(ws, {
+        id,
+        type: "segment",
+        family,
+        content_hash: segment.hash,
+        entry_count: segment.entries.length,
+        first_entry_id: segment.entries[0].id,
+        last_entry_id: segment.entries[segment.entries.length - 1].id,
+        content_b64: toBase64(segment.bytes),
+    });
+    expect(reply.id).toBe(id);
+    expect(reply.ok).toBe(true);
+    return { blobId: reply.blob_id as number, inserted: reply.inserted as number };
+}
+
+async function linkStats(
+    serverId: string,
+    snapshotHash: string,
+): Promise<{ links: number; entries: number } | null> {
+    return await env.PLATFORM_DB.prepare(
+        "SELECT COUNT(*) AS links, COALESCE(SUM(b.entry_count), 0) AS entries " +
+            "FROM snapshot_family_segments s " +
+            "JOIN folded_blobs b ON b.blob_id = s.blob_id " +
+            "JOIN snapshots sn ON sn.snapshot_id = s.snapshot_id " +
+            "WHERE sn.server_id = ? AND sn.snapshot_hash = ?",
+    )
+        .bind(serverId, hexToBlob(snapshotHash))
+        .first<{ links: number; entries: number }>();
+}
+
+describe("v3 segment content", () => {
+    it("verifies hashes, resolves blob ids, and converges on rerun", async () => {
+        const ws = await connect();
+        const [segment] = await foldSegments([
+            { id: 587, content: new TextEncoder().encode("type-entry-587") },
+            { id: -64, content: new TextEncoder().encode("pseudo-entry") },
+        ]);
+
+        const before = await call(ws, {
+            id: 1,
+            type: "segment_lookup",
+            family: "types",
+            content_hashes: [segment.hash],
+        });
+        expect(before).toEqual({ id: 1, ok: true, missing: [segment.hash], ids: {} });
+
+        const { blobId, inserted } = await uploadSegment(ws, 2, "types", segment);
+        expect(inserted).toBe(1);
+        expect(blobId).toBeGreaterThan(0);
+
+        const after = await call(ws, {
+            id: 3,
+            type: "segment_lookup",
+            family: "types",
+            content_hashes: [segment.hash, "00".repeat(32)],
+        });
+        expect(after).toEqual({
+            id: 3,
+            ok: true,
+            missing: ["00".repeat(32)],
+            ids: { [segment.hash]: blobId },
+        });
+
+        // Rerun convergence: re-uploading the same segment inserts nothing
+        // and resolves the same blob id.
+        const rerun = await uploadSegment(ws, 4, "types", segment);
+        expect(rerun).toEqual({ blobId, inserted: 0 });
+
+        ws.close();
+    });
+
+    it("rejects segments whose content hashes differently", async () => {
+        const ws = await connect();
+        const [segment] = await foldSegments([
+            { id: 1, content: new TextEncoder().encode("type-entry-1") },
+        ]);
+        const reply = await call(ws, {
+            id: 1,
+            type: "segment",
+            family: "types",
+            content_hash: "00".repeat(32),
+            entry_count: 1,
+            first_entry_id: 1,
+            last_entry_id: 1,
+            content_b64: toBase64(segment.bytes),
+        });
+        expect(reply.id).toBe(1);
+        expect(reply.ok).toBe(false);
+        expect(reply.error).toBe("Content verification failed");
+        ws.close();
+    });
+
+    it("rejects oversize segments", async () => {
+        const ws = await connect();
+        const reply = await call(ws, {
+            id: 1,
+            type: "segment",
+            family: "types",
+            content_hash: "00".repeat(32),
+            entry_count: 1,
+            first_entry_id: 1,
+            last_entry_id: 1,
+            // Over the ~700 KiB base64 cap (512 KiB raw segments).
+            content_b64: "AAAA".repeat(200 * 1024),
+        });
+        expect(reply.id).toBe(1);
+        expect(reply.ok).toBe(false);
+        expect(reply.error).toBe("Validation failed");
+        ws.close();
+    });
+
+    it("rejects segment entry ids outside the int32 range", async () => {
+        const ws = await connect();
+        for (const entryId of [-2147483649, 2147483648]) {
+            const reply = await call(ws, {
+                id: 1,
+                type: "segment",
+                family: "types",
+                content_hash: "00".repeat(32),
+                entry_count: 1,
+                first_entry_id: entryId,
+                last_entry_id: entryId,
+                content_b64: toBase64(new Uint8Array([0])),
+            });
+            expect(reply.id).toBe(1);
+            expect(reply.ok).toBe(false);
+            expect(reply.error).toBe("Validation failed");
+        }
+        ws.close();
+    });
+});
+
+describe("v3 snapshot freeze", () => {
+    it("rejects segment_register after segment_complete and keeps the links frozen", async () => {
+        const ws = await connect();
+        const serverId = "tranquility";
+        const snapshotHash = "ab".repeat(32);
+
+        const segments = await foldSegments([
+            { id: 1, content: new TextEncoder().encode("type-entry-1") },
+            { id: 2, content: new TextEncoder().encode("type-entry-2") },
+            { id: 3, content: new TextEncoder().encode("type-entry-3") },
+        ]);
+        expect(segments).toHaveLength(1);
+        const { blobId } = await uploadSegment(ws, 1, "types", segments[0]);
+
+        let reply = await call(ws, {
+            id: 2,
+            type: "segment_register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            segments: [{ family: "types", seq: 0, blob_id: blobId }],
+        });
+        expect(reply).toEqual({ id: 2, ok: true, inserted: 1 });
+
+        reply = await call(ws, {
+            id: 3,
+            type: "segment_complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 3,
+        });
+        expect(reply).toEqual({ id: 3, ok: true });
+
+        // Idempotent retry of the same complete frame (lost reply).
+        reply = await call(ws, {
+            id: 4,
+            type: "segment_complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 3,
+        });
+        expect(reply).toEqual({ id: 4, ok: true });
+
+        reply = await call(ws, {
+            id: 5,
+            type: "segment_register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            segments: [{ family: "types", seq: 1, blob_id: blobId }],
+        });
+        expect(reply.id).toBe(5);
+        expect(reply.ok).toBe(false);
+        expect(reply.error).toBe("Snapshot already complete");
+
+        const stats = await linkStats(serverId, snapshotHash);
+        expect(stats).toEqual({ links: 1, entries: 3 });
+
+        reply = await call(ws, {
+            id: 6,
+            type: "snapshot",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+        });
+        expect(reply.complete).toBe(true);
+        expect(reply.entry_count).toBe(3);
+
+        ws.close();
+    });
+
+    it("never freezes a snapshot whose entry_count disagrees with the segment SUM", async () => {
+        const ws = await connect();
+        const serverId = "tranquility";
+        const snapshotHash = "cd".repeat(32);
+
+        const [segment] = await foldSegments([
+            { id: 1, content: new TextEncoder().encode("type-entry-1") },
+            { id: 2, content: new TextEncoder().encode("type-entry-2") },
+        ]);
+        const { blobId } = await uploadSegment(ws, 1, "types", segment);
+        await call(ws, {
+            id: 2,
+            type: "segment_register",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            segments: [{ family: "types", seq: 0, blob_id: blobId }],
+        });
+
+        // The link SUM is 2; claiming 3 fails with the real count reported,
+        // and the snapshot stays pending.
+        const failed = await call(ws, {
+            id: 3,
+            type: "segment_complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 3,
+        });
+        expect(failed.id).toBe(3);
+        expect(failed.ok).toBe(false);
+        expect(failed.error).toBe("Snapshot incomplete");
+        expect(failed.registered).toBe(2);
+
+        const probe = await call(ws, {
+            id: 4,
+            type: "snapshot",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+        });
+        expect(probe.complete).toBe(false);
+
+        // The corrected claim freezes.
+        const complete = await call(ws, {
+            id: 5,
+            type: "segment_complete",
+            server_id: serverId,
+            snapshot_hash: snapshotHash,
+            entry_count: 2,
+        });
+        expect(complete).toEqual({ id: 5, ok: true });
+        ws.close();
+    });
+
+    it("rejects registration of unknown blob ids", async () => {
+        const ws = await connect();
+        const reply = await call(ws, {
+            id: 1,
+            type: "segment_register",
+            server_id: "tranquility",
+            snapshot_hash: "ef".repeat(32),
+            segments: [{ family: "types", seq: 0, blob_id: 424242 }],
+        });
+        expect(reply.id).toBe(1);
+        expect(reply.ok).toBe(false);
+        expect(reply.error).toBe("Unknown blob ids");
+        ws.close();
+    });
+
+    it("never freezes mid-registration even when register and complete race", async () => {
+        // Port of the v2 register/complete race regression test to the v3
+        // frames: whichever side runs first, a frozen snapshot's entry_count
+        // must equal its actual segment-link SUM.
+        for (let round = 0; round < 5; round++) {
+            const ws1 = await connect();
+            const ws2 = await connect();
+            const serverId = "tranquility";
+            const snapshotHash = round.toString(16).padStart(2, "0").repeat(32);
+
+            // 16 KiB payloads: 48 entries fold into 2 segments (>512 KiB
+            // total), so registration spans multiple links.
+            const segments = await foldSegments(
+                Array.from({ length: 48 }, (_, i) => ({
+                    id: i + 1,
+                    content: new Uint8Array(16 * 1024).fill(i % 251),
+                })),
+            );
+            expect(segments.length).toBeGreaterThan(1);
+            const blobIds: number[] = [];
+            for (const [i, segment] of segments.entries()) {
+                blobIds.push((await uploadSegment(ws1, 100 + i, "types", segment)).blobId);
+            }
+            const firstCount = segments[0].entries.length;
+            const restCount = segments.slice(1).reduce((n, s) => n + s.entries.length, 0);
+
+            const first = await call(ws1, {
+                id: 1,
+                type: "segment_register",
+                server_id: serverId,
+                snapshot_hash: snapshotHash,
+                segments: [{ family: "types", seq: 0, blob_id: blobIds[0] }],
+            });
+            expect(first).toEqual({ id: 1, ok: true, inserted: 1 });
+
+            // Fire both frames without awaiting so the two events interleave
+            // at their D1 awaits.
+            const [registerReply, completeReply] = await Promise.all([
+                call(ws1, {
+                    id: 2,
+                    type: "segment_register",
+                    server_id: serverId,
+                    snapshot_hash: snapshotHash,
+                    segments: segments.slice(1).map((_, i) => ({
+                        family: "types",
+                        seq: i + 1,
+                        blob_id: blobIds[i + 1],
+                    })),
+                }),
+                call(ws2, {
+                    id: 3,
+                    type: "segment_complete",
+                    server_id: serverId,
+                    snapshot_hash: snapshotHash,
+                    entry_count: firstCount,
+                }),
+            ]);
+
+            const stats = await linkStats(serverId, snapshotHash);
+            const probe = await call(ws1, {
+                id: 4,
+                type: "snapshot",
+                server_id: serverId,
+                snapshot_hash: snapshotHash,
+            });
+
+            if (completeReply.ok) {
+                // Completion won before the register committed: the freeze
+                // guards must have rejected every later link insert.
+                expect(registerReply.ok).toBe(false);
+                expect(registerReply.error).toBe("Snapshot already complete");
+                expect(stats).toEqual({ links: 1, entries: firstCount });
+                expect(probe.complete).toBe(true);
+                expect(probe.entry_count).toBe(firstCount);
+            } else {
+                // The register committed links the SUM check then saw, so
+                // completion must have failed instead of freezing a lie.
+                expect(completeReply.error).toBe("Snapshot incomplete");
+                expect(registerReply.ok).toBe(true);
+                expect(stats).toEqual({
+                    links: segments.length,
+                    entries: firstCount + restCount,
+                });
+                expect(probe.complete).toBe(false);
+            }
+
+            ws1.close();
+            ws2.close();
+        }
     });
 });

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -853,6 +853,63 @@ describe("v3 segment content", () => {
         ws.close();
     });
 
+    it("rejects segments whose index entry ids are not strictly increasing", async () => {
+        const ws = await connect();
+        // Hash-valid content whose metadata (count, first/last) matches the
+        // parsed index, but the ids are unsorted or duplicated. Readers
+        // binary-search this index, and the stored blob is immutable
+        // (INSERT OR IGNORE keeps the first row), so accepting it would
+        // poison the family permanently.
+        const build = (ids: number[]): Uint8Array => {
+            const payload = new TextEncoder().encode("x");
+            const bytes = new Uint8Array(4 + ids.length * 12 + ids.length * payload.length);
+            const view = new DataView(bytes.buffer);
+            view.setUint32(0, ids.length, true);
+            let indexOffset = 4;
+            let dataOffset = 4 + ids.length * 12;
+            for (const id of ids) {
+                view.setInt32(indexOffset, id, true);
+                view.setUint32(indexOffset + 4, dataOffset, true);
+                view.setUint32(indexOffset + 8, payload.length, true);
+                bytes.set(payload, dataOffset);
+                indexOffset += 12;
+                dataOffset += payload.length;
+            }
+            return bytes;
+        };
+        for (const ids of [
+            [2, 1],
+            [1, 1],
+        ]) {
+            const bytes = build(ids);
+            const hash = await sha256Hex(bytes);
+            const reply = await call(ws, {
+                id: 1,
+                type: "segment",
+                family: "types",
+                content_hash: hash,
+                entry_count: ids.length,
+                first_entry_id: ids[0],
+                last_entry_id: ids[ids.length - 1],
+                content_b64: toBase64(bytes),
+            });
+            expect(reply.id).toBe(1);
+            expect(reply.ok).toBe(false);
+            expect(reply.error).toBe("Content verification failed");
+            expect(reply.rejected).toEqual([
+                { family: "types", content_hash: hash, reason: "malformed segment index" },
+            ]);
+            // Nothing was stored for the crafted hash.
+            const stored = await env.PLATFORM_DB.prepare(
+                "SELECT COUNT(*) AS n FROM folded_blobs WHERE content_hash = ?",
+            )
+                .bind(hexToBlob(hash))
+                .first<{ n: number }>();
+            expect(stored?.n).toBe(0);
+        }
+        ws.close();
+    });
+
     it("rejects oversize segments", async () => {
         const ws = await connect();
         const reply = await call(ws, {

--- a/worker/efa-platform-data-sync/wrangler.toml
+++ b/worker/efa-platform-data-sync/wrangler.toml
@@ -5,6 +5,7 @@ main = "src/index.ts"
 [[d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "efa-snapshot-registry"
+preview_database_id = "33351495-a249-4f46-b83d-888cdec56d85"
 database_id = "f75c61bb-7aca-4c6b-b67a-4332d172872c"
 migrations_dir = "migrations"
 

--- a/worker/efa-platform-data-sync/wrangler.toml
+++ b/worker/efa-platform-data-sync/wrangler.toml
@@ -2,6 +2,8 @@ name = "efa-platform-data-sync"
 compatibility_date = "2026-08-01"
 main = "src/index.ts"
 
+preview_urls = true
+
 [[d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "efa-snapshot-registry"

--- a/worker/efa-platform-fit-storage/README.md
+++ b/worker/efa-platform-fit-storage/README.md
@@ -59,10 +59,18 @@ Error responses are JSON `{ "error": <code>, "message": <string> }` (+ an
   (populated by `worker/efa-platform-data-sync`), addressed by the
   client-supplied `(server_id, snapshot_hash)`. The selector is resolved to
   the registry's `snapshot_id` (requiring `completed_at IS NOT NULL`, cached
-  per isolate), and rows are read from `snapshot_entries` ⋈ `entries` by
-  `(snapshot_id, family)`. A 3-round transitive-closure prefetch
-  (`src/prefetch.rs`) loads exactly the reachable rows; a `thread_local!`
-  isolate cache makes warm requests zero-query.
+  per isolate). Storage v3 stores each family as folded ≤512 KiB segments
+  (`folded_blobs` ⋈ `snapshot_family_segments`): subset reads route entry ids
+  through the segment catalog's `[first_entry_id, last_entry_id]` ranges and
+  binary-search the segment index; whole families fetch all segments. Raw
+  segments (content-addressed, shared across snapshots) and per-family
+  catalogs are cached in the isolate. Snapshots registered before v3 are
+  served by the legacy per-entry join (`snapshot_entries` ⋈ `entries`) via a
+  per-snapshot dual-read probe (v3 catalog first, v2 fallback, decision
+  cached per isolate — zero-downtime cutover, instant rollback). A 3-round
+  transitive-closure prefetch (`src/prefetch.rs`) loads exactly the
+  reachable rows; a `thread_local!` isolate cache makes warm requests
+  zero-query.
 - `eve-fit-os` is used with `default-features = false`; the worker decodes
   `efos.*` rows itself and implements `InfoProvider` (`src/provider.rs`).
   Getter misses degrade to zero-value placeholders and are counted/logged,

--- a/worker/efa-platform-fit-storage/src/d1.rs
+++ b/worker/efa-platform-fit-storage/src/d1.rs
@@ -8,6 +8,9 @@ use crate::prefetch::FetchRequest;
 /// D1's bound-parameter limit is 100; reserve 2 for snapshot_id/family.
 const MAX_ENTRY_IDS_PER_CHUNK: usize = 98;
 
+/// Segment-content chunk fetches bind blob ids only.
+const MAX_BLOB_IDS_PER_CHUNK: usize = 100;
+
 fn js_text(value: &str) -> JsValue {
     JsValue::from_str(value)
 }
@@ -115,6 +118,10 @@ async fn run_change_count(
 }
 
 /// Chunked family lookup (spec §7.2). `ids == None` fetches the whole family.
+///
+/// This is the v2 read path (per-entry `snapshot_entries` ⋈ `entries` join),
+/// kept as the dual-read fallback for snapshots registered before storage v3;
+/// the v3 folded-segment path lives in `prefetch::fetch_family`.
 pub async fn fetch_family(
     db: &D1Database,
     snapshot_id: i64,
@@ -150,6 +157,75 @@ pub async fn fetch_family(
                     out.push((row_int(row, 0)?, row_blob(row, 1)?));
                 }
             }
+        }
+    }
+    Ok(out)
+}
+
+/// One segment of a snapshot's folded family stream (storage v3,
+/// `snapshot_family_segments` ⋈ `folded_blobs`): the blob id plus the
+/// segment's entry-id range for subset routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CatalogEntry {
+    pub blob_id: i64,
+    pub first_entry_id: i32,
+    pub last_entry_id: i32,
+}
+
+/// Whether the snapshot has any v3 segment links — the dual-read layout
+/// probe. Snapshots are frozen at completion, so the answer never changes
+/// and is cached per isolate by the caller.
+pub async fn snapshot_has_segments(db: &D1Database, snapshot_id: i64) -> Result<bool, ApiError> {
+    let rows = raw_query(
+        db,
+        "SELECT 1 FROM snapshot_family_segments WHERE snapshot_id = ? LIMIT 1",
+        &[js_int(snapshot_id)],
+    )
+    .await?;
+    Ok(!rows.is_empty())
+}
+
+/// The ordered segment catalog of one (snapshot, family): blob ids and
+/// entry-id ranges in stream order. Frozen at snapshot completion.
+pub async fn fetch_catalog(
+    db: &D1Database,
+    snapshot_id: i64,
+    family_code: i64,
+) -> Result<Vec<CatalogEntry>, ApiError> {
+    let rows = raw_query(
+        db,
+        "SELECT s.blob_id, b.first_entry_id, b.last_entry_id \
+         FROM snapshot_family_segments s \
+         JOIN folded_blobs b ON b.blob_id = s.blob_id \
+         WHERE s.snapshot_id = ? AND s.family = ? ORDER BY s.seq",
+        &[js_int(snapshot_id), js_int(family_code)],
+    )
+    .await?;
+    rows.iter()
+        .map(|row| {
+            Ok(CatalogEntry {
+                blob_id: row_int64(row, 0)?,
+                first_entry_id: row_int(row, 1)?,
+                last_entry_id: row_int(row, 2)?,
+            })
+        })
+        .collect()
+}
+
+/// Chunked segment-content fetch by blob id, preserving request order.
+pub async fn fetch_segments(
+    db: &D1Database,
+    blob_ids: &[i64],
+) -> Result<Vec<(i64, Vec<u8>)>, ApiError> {
+    let mut out = Vec::new();
+    for chunk in blob_ids.chunks(MAX_BLOB_IDS_PER_CHUNK) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let sql =
+            format!("SELECT blob_id, content FROM folded_blobs WHERE blob_id IN ({placeholders})");
+        let params = chunk.iter().map(|id| js_int(*id)).collect::<Vec<_>>();
+        let rows = raw_query(db, &sql, &params).await?;
+        for row in &rows {
+            out.push((row_int64(row, 0)?, row_blob(row, 1)?));
         }
     }
     Ok(out)

--- a/worker/efa-platform-fit-storage/src/lib.rs
+++ b/worker/efa-platform-fit-storage/src/lib.rs
@@ -151,7 +151,7 @@ async fn handle_submit(mut req: Request, env: Env) -> Result<Response, ApiError>
         {
             let platform_db = &platform_db;
             let fetch = |request: prefetch::FetchRequest| async move {
-                d1::fetch_family(platform_db, snapshot_id, request).await
+                prefetch::fetch_family(platform_db, snapshot_id, request).await
             };
             prefetch::prefetch(&mut data, &canonical, fetch).await?;
         }

--- a/worker/efa-platform-fit-storage/src/prefetch.rs
+++ b/worker/efa-platform-fit-storage/src/prefetch.rs
@@ -245,17 +245,26 @@ fn segment_index(segment: &[u8]) -> Result<Vec<(i32, u32, u32)>, ApiError> {
             .ok_or_else(|| ApiError::internal("corrupt segment: truncated header"))
     };
     let count = read_u32(0)? as usize;
-    let index_bytes = SEGMENT_HEADER_BYTES + count * SEGMENT_INDEX_ENTRY_BYTES;
-    if segment.len() < index_bytes {
-        return Err(ApiError::internal("corrupt segment: truncated index"));
-    }
+    // Guard the header against unchecked 32-bit arithmetic on wasm32: an
+    // overflowing `count * SEGMENT_INDEX_ENTRY_BYTES` would wrap small
+    // enough to pass the truncation check, and Vec::with_capacity(count)
+    // on an unvalidated count would abort the instance. Only a count
+    // whose index provably fits in the segment reaches the allocation.
+    count
+        .checked_mul(SEGMENT_INDEX_ENTRY_BYTES)
+        .and_then(|bytes| bytes.checked_add(SEGMENT_HEADER_BYTES))
+        .filter(|&bytes| bytes <= segment.len())
+        .ok_or_else(|| ApiError::internal("corrupt segment: truncated index"))?;
     let mut entries = Vec::with_capacity(count);
     for i in 0..count {
         let at = SEGMENT_HEADER_BYTES + i * SEGMENT_INDEX_ENTRY_BYTES;
         let entry_id = read_u32(at)? as i32;
         let offset = read_u32(at + 4)?;
         let length = read_u32(at + 8)?;
-        if offset as usize + length as usize > segment.len() {
+        let in_bounds = (offset as usize)
+            .checked_add(length as usize)
+            .is_some_and(|end| end <= segment.len());
+        if !in_bounds {
             return Err(ApiError::internal("corrupt segment: payload out of bounds"));
         }
         entries.push((entry_id, offset, length));
@@ -830,6 +839,18 @@ mod tests {
         // The first (only) index entry's length field, at 4 + 0*12 + 8.
         corrupted[12..16].copy_from_slice(&u32::MAX.to_le_bytes()); // payload out of bounds
         assert!(segment_extract(&corrupted, None).is_err());
+
+        // A count that would overflow `count * SEGMENT_INDEX_ENTRY_BYTES`
+        // on a 32-bit target is rejected before any allocation.
+        let mut huge_count = segment.clone();
+        huge_count[0..4].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(segment_extract(&huge_count, None).is_err());
+
+        // offset + length overflowing u32 is rejected, not wrapped.
+        let mut wrapped_end = segment.clone();
+        wrapped_end[8..12].copy_from_slice(&u32::MAX.to_le_bytes()); // offset
+        wrapped_end[12..16].copy_from_slice(&2u32.to_le_bytes()); // length
+        assert!(segment_extract(&wrapped_end, None).is_err());
     }
 
     #[test]

--- a/worker/efa-platform-fit-storage/src/prefetch.rs
+++ b/worker/efa-platform-fit-storage/src/prefetch.rs
@@ -1,8 +1,11 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::future::Future;
+use std::rc::Rc;
 
 use prost::Message;
+use worker::d1::D1Database;
 
+use crate::d1::{self, CatalogEntry};
 use crate::error::ApiError;
 use crate::proto::{efos, fit as pb, platform_data};
 use crate::provider::{
@@ -31,6 +34,10 @@ const fn flatten_buff_pairs(pairs: [(i32, i32); 4]) -> [i32; 8] {
 
 /// Isolate-cache key: the engine data snapshot selector.
 pub type SnapshotKey = (String, String);
+
+/// Isolate-cache entry for a v3 segment catalog, keyed by
+/// `(snapshot_id, family code)`.
+type CatalogCache = HashMap<(i64, i64), Rc<Vec<CatalogEntry>>>;
 
 /// Accumulated decoded engine data for one `(server_id, snapshot_hash)`. The
 /// isolate cache is additive: warm requests skip already-seen rows entirely
@@ -124,6 +131,19 @@ thread_local! {
     // per isolate instead of one per request.
     static SNAPSHOT_IDS: std::cell::RefCell<HashMap<SnapshotKey, i64>> =
         std::cell::RefCell::new(HashMap::new());
+    // v3 dual-read layout decision per snapshot registry id (true = folded
+    // segments). Snapshots are frozen at completion, so this never changes.
+    static LAYOUTS: std::cell::RefCell<HashMap<i64, bool>> =
+        std::cell::RefCell::new(HashMap::new());
+    // v3 segment catalogs per (snapshot_id, family code), in stream order.
+    static CATALOGS: std::cell::RefCell<CatalogCache> =
+        std::cell::RefCell::new(HashMap::new());
+    // v3 raw segment bytes by blob id. Segments are content-addressed and
+    // shared verbatim across snapshots, so this cache is global, not keyed
+    // by snapshot. Sits under the decoded-entry cache: a warm segment cache
+    // hit skips the D1 round trip but still decodes the wanted entries.
+    static SEGMENTS: std::cell::RefCell<HashMap<i64, Rc<[u8]>>> =
+        std::cell::RefCell::new(HashMap::new());
 }
 
 /// Clone out the accumulated data for a snapshot (empty on cold isolates).
@@ -164,6 +184,211 @@ pub fn snapshot_id_put(key: SnapshotKey, snapshot_id: i64) {
 pub struct FetchRequest {
     pub family: Family,
     pub ids: Option<Vec<i32>>,
+}
+
+// ---------------------------------------------------------------------------
+// Storage v3: folded per-family segments (migrations/0003_folded.sql).
+//
+// Segment format (self-contained, entries sorted by entry id):
+//   u32 count
+//   count x { i32 entry_id, u32 offset, u32 length }  -- offset from segment
+//   payload bytes (concatenated per-entry protobufs, byte-identical to the
+//   v2 entries.content payloads, so the decode path is untouched)
+// ---------------------------------------------------------------------------
+
+const SEGMENT_HEADER_BYTES: usize = 4;
+const SEGMENT_INDEX_ENTRY_BYTES: usize = 12;
+
+fn layout_get(snapshot_id: i64) -> Option<bool> {
+    LAYOUTS.with(|layouts| layouts.borrow().get(&snapshot_id).copied())
+}
+
+fn layout_put(snapshot_id: i64, folded: bool) {
+    LAYOUTS.with(|layouts| {
+        layouts.borrow_mut().insert(snapshot_id, folded);
+    });
+}
+
+fn catalog_get(snapshot_id: i64, family_code: i64) -> Option<Rc<Vec<CatalogEntry>>> {
+    CATALOGS.with(|catalogs| catalogs.borrow().get(&(snapshot_id, family_code)).cloned())
+}
+
+fn catalog_put(snapshot_id: i64, family_code: i64, catalog: Rc<Vec<CatalogEntry>>) {
+    CATALOGS.with(|catalogs| {
+        catalogs
+            .borrow_mut()
+            .insert((snapshot_id, family_code), catalog);
+    });
+}
+
+fn segment_get(blob_id: i64) -> Option<Rc<[u8]>> {
+    SEGMENTS.with(|segments| segments.borrow().get(&blob_id).cloned())
+}
+
+fn segment_put_all(fetched: Vec<(i64, Vec<u8>)>) {
+    SEGMENTS.with(|segments| {
+        let mut segments = segments.borrow_mut();
+        for (blob_id, content) in fetched {
+            segments.insert(blob_id, Rc::from(content.into_boxed_slice()));
+        }
+    });
+}
+
+/// Parse a segment's index: `(entry_id, offset, length)` per entry, sorted
+/// by entry id. Bounds-checked; corrupt segments are an internal error,
+/// never a panic.
+fn segment_index(segment: &[u8]) -> Result<Vec<(i32, u32, u32)>, ApiError> {
+    let read_u32 = |at: usize| -> Result<u32, ApiError> {
+        segment
+            .get(at..at + 4)
+            .map(|b| u32::from_le_bytes(b.try_into().expect("slice of 4")))
+            .ok_or_else(|| ApiError::internal("corrupt segment: truncated header"))
+    };
+    let count = read_u32(0)? as usize;
+    let index_bytes = SEGMENT_HEADER_BYTES + count * SEGMENT_INDEX_ENTRY_BYTES;
+    if segment.len() < index_bytes {
+        return Err(ApiError::internal("corrupt segment: truncated index"));
+    }
+    let mut entries = Vec::with_capacity(count);
+    for i in 0..count {
+        let at = SEGMENT_HEADER_BYTES + i * SEGMENT_INDEX_ENTRY_BYTES;
+        let entry_id = read_u32(at)? as i32;
+        let offset = read_u32(at + 4)?;
+        let length = read_u32(at + 8)?;
+        if offset as usize + length as usize > segment.len() {
+            return Err(ApiError::internal("corrupt segment: payload out of bounds"));
+        }
+        entries.push((entry_id, offset, length));
+    }
+    Ok(entries)
+}
+
+/// Slice payloads out of a segment: `wanted == None` extracts every entry
+/// (whole-family fetch), otherwise binary-searches the sorted index per id
+/// and returns only the ids present.
+pub fn segment_extract(
+    segment: &[u8],
+    wanted: Option<&[i32]>,
+) -> Result<Vec<(i32, Vec<u8>)>, ApiError> {
+    let index = segment_index(segment)?;
+    match wanted {
+        None => Ok(index
+            .into_iter()
+            .map(|(id, offset, length)| {
+                (
+                    id,
+                    segment[offset as usize..(offset + length) as usize].to_vec(),
+                )
+            })
+            .collect()),
+        Some(ids) => {
+            let mut sorted: Vec<i32> = ids.to_vec();
+            sorted.sort_unstable();
+            sorted.dedup();
+            let mut out = Vec::new();
+            for id in sorted {
+                if let Ok(i) = index.binary_search_by_key(&id, |entry| entry.0) {
+                    let (_, offset, length) = index[i];
+                    out.push((
+                        id,
+                        segment[offset as usize..(offset + length) as usize].to_vec(),
+                    ));
+                }
+            }
+            Ok(out)
+        }
+    }
+}
+
+/// Route an entry id to its catalog segment by `[first, last]` range. The
+/// catalog is sorted by seq (= ascending id ranges, non-overlapping), so
+/// this is one binary search. Ids outside every range route nowhere — the
+/// family simply has no such row.
+pub fn find_segment(catalog: &[CatalogEntry], id: i32) -> Option<usize> {
+    let i = catalog.partition_point(|entry| entry.last_entry_id < id);
+    let entry = catalog.get(i)?;
+    (entry.first_entry_id <= id).then_some(i)
+}
+
+/// Family fetch with the v3 dual-read transition: probe the segment catalog
+/// first (decision cached per snapshot per isolate), fall back to the v2
+/// per-entry join for snapshots registered before storage v3. On the v3 path
+/// the catalog is cached per (snapshot, family) and raw segments per blob id
+/// — both are frozen at snapshot completion — so warm requests slice payloads
+/// straight from the isolate cache.
+pub async fn fetch_family(
+    db: &D1Database,
+    snapshot_id: i64,
+    request: FetchRequest,
+) -> anyhow::Result<Vec<(i32, Vec<u8>)>> {
+    let folded = match layout_get(snapshot_id) {
+        Some(folded) => folded,
+        None => {
+            let folded = d1::snapshot_has_segments(db, snapshot_id).await?;
+            layout_put(snapshot_id, folded);
+            folded
+        }
+    };
+    if !folded {
+        return d1::fetch_family(db, snapshot_id, request).await;
+    }
+
+    let family_code = request.family.code();
+    let catalog = match catalog_get(snapshot_id, family_code) {
+        Some(catalog) => catalog,
+        None => {
+            let catalog = Rc::new(d1::fetch_catalog(db, snapshot_id, family_code).await?);
+            catalog_put(snapshot_id, family_code, catalog.clone());
+            catalog
+        }
+    };
+
+    // Route the wanted ids to their segments: blob id -> ids within it
+    // (`None` = the whole segment).
+    let mut wanted: HashMap<i64, Option<Vec<i32>>> = HashMap::new();
+    match &request.ids {
+        None => {
+            for entry in catalog.iter() {
+                wanted.insert(entry.blob_id, None);
+            }
+        }
+        Some(ids) => {
+            for id in ids {
+                if let Some(i) = find_segment(&catalog, *id) {
+                    let blob_id = catalog[i].blob_id;
+                    match wanted.entry(blob_id) {
+                        std::collections::hash_map::Entry::Vacant(slot) => {
+                            slot.insert(Some(vec![*id]));
+                        }
+                        std::collections::hash_map::Entry::Occupied(mut slot) => {
+                            if let Some(ids) = slot.get_mut() {
+                                ids.push(*id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Fetch only the segments this isolate has not seen; content addressing
+    // makes segments shared across snapshots.
+    let missing: Vec<i64> = wanted
+        .keys()
+        .filter(|blob_id| segment_get(**blob_id).is_none())
+        .copied()
+        .collect();
+    if !missing.is_empty() {
+        segment_put_all(d1::fetch_segments(db, &missing).await?);
+    }
+
+    let mut out = Vec::new();
+    for (blob_id, ids) in wanted {
+        let segment = segment_get(blob_id)
+            .ok_or_else(|| anyhow::anyhow!("segment {blob_id} missing after fetch"))?;
+        out.extend(segment_extract(&segment, ids.as_deref())?);
+    }
+    Ok(out)
 }
 
 /// The fit's seed type set (spec §7.3, round 0): ship, modules, charges,
@@ -446,34 +671,198 @@ mod tests {
 
     type FetchResult = std::future::Ready<anyhow::Result<Vec<(i32, Vec<u8>)>>>;
 
+    /// Fold rows into segments, mirroring `bootstrap/data/d1/sync.py`'s
+    /// `fold_family` (u32 count + (i32 id, u32 off, u32 len) index +
+    /// payloads, greedy-packed at entry boundaries). Fixtures use a small
+    /// cap so families split into several segments and exercise routing.
+    fn fold_rows(
+        rows: &[(i32, Vec<u8>)],
+        max_bytes: usize,
+        next_blob_id: &mut i64,
+    ) -> (Vec<CatalogEntry>, HashMap<i64, Vec<u8>>) {
+        let mut sorted = rows.to_vec();
+        sorted.sort_by_key(|(id, _)| *id);
+        let mut catalog = Vec::new();
+        let mut blobs = HashMap::new();
+        let mut current: Vec<(i32, Vec<u8>)> = Vec::new();
+        let mut size = SEGMENT_HEADER_BYTES;
+        let mut flush = |current: &mut Vec<(i32, Vec<u8>)>, catalog: &mut Vec<CatalogEntry>| {
+            if current.is_empty() {
+                return;
+            }
+            let mut bytes = Vec::with_capacity(
+                current.iter().map(|(_, c)| c.len()).sum::<usize>()
+                    + SEGMENT_HEADER_BYTES
+                    + SEGMENT_INDEX_ENTRY_BYTES * current.len(),
+            );
+            bytes.extend_from_slice(&(current.len() as u32).to_le_bytes());
+            let mut data_offset =
+                (SEGMENT_HEADER_BYTES + SEGMENT_INDEX_ENTRY_BYTES * current.len()) as u32;
+            let mut payloads = Vec::new();
+            for (id, content) in current.iter() {
+                bytes.extend_from_slice(&id.to_le_bytes());
+                bytes.extend_from_slice(&data_offset.to_le_bytes());
+                bytes.extend_from_slice(&(content.len() as u32).to_le_bytes());
+                payloads.extend_from_slice(content);
+                data_offset += content.len() as u32;
+            }
+            bytes.extend_from_slice(&payloads);
+            *next_blob_id += 1;
+            catalog.push(CatalogEntry {
+                blob_id: *next_blob_id,
+                first_entry_id: current.first().unwrap().0,
+                last_entry_id: current.last().unwrap().0,
+            });
+            blobs.insert(*next_blob_id, bytes);
+            current.clear();
+        };
+        for (id, content) in sorted {
+            let entry_size = SEGMENT_INDEX_ENTRY_BYTES + content.len();
+            if !current.is_empty() && size + entry_size > max_bytes {
+                flush(&mut current, &mut catalog);
+                size = SEGMENT_HEADER_BYTES;
+            }
+            current.push((id, content));
+            size += entry_size;
+        }
+        flush(&mut current, &mut catalog);
+        (catalog, blobs)
+    }
+
+    /// Segment-backed fixture: rows are folded into segments and served
+    /// through the production routing/extraction path.
     struct Fixture {
-        rows: HashMap<Family, HashMap<i32, Vec<u8>>>,
+        catalogs: HashMap<Family, Vec<CatalogEntry>>,
+        blobs: HashMap<i64, Vec<u8>>,
         requests: std::cell::RefCell<Vec<FetchRequest>>,
     }
 
     impl Fixture {
+        fn new() -> Fixture {
+            Fixture {
+                catalogs: HashMap::new(),
+                blobs: HashMap::new(),
+                requests: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+
+        fn insert_family(&mut self, family: Family, rows: Vec<(i32, Vec<u8>)>) {
+            let mut next_blob_id = self.blobs.keys().copied().max().unwrap_or(0);
+            // Small cap: fixture families split into multiple segments.
+            let (catalog, blobs) = fold_rows(&rows, 128, &mut next_blob_id);
+            self.catalogs.insert(family, catalog);
+            self.blobs.extend(blobs);
+        }
+
         fn fetcher(&self) -> impl FnMut(FetchRequest) -> FetchResult + '_ {
             move |req| {
+                let catalog = self.catalogs.get(&req.family).cloned().unwrap_or_default();
                 let rows = match &req.ids {
-                    None => self
-                        .rows
-                        .get(&req.family)
-                        .map(|m| m.iter().map(|(id, b)| (*id, b.clone())).collect::<Vec<_>>())
-                        .unwrap_or_default(),
-                    Some(ids) => ids
+                    None => catalog
                         .iter()
-                        .filter_map(|id| {
-                            self.rows
-                                .get(&req.family)
-                                .and_then(|m| m.get(id))
-                                .map(|b| (*id, b.clone()))
+                        .flat_map(|entry| {
+                            segment_extract(&self.blobs[&entry.blob_id], None)
+                                .expect("fixture segments are well-formed")
                         })
                         .collect(),
+                    Some(ids) => {
+                        let mut by_segment: HashMap<i64, Vec<i32>> = HashMap::new();
+                        for id in ids {
+                            if let Some(i) = find_segment(&catalog, *id) {
+                                by_segment.entry(catalog[i].blob_id).or_default().push(*id);
+                            }
+                        }
+                        by_segment
+                            .into_iter()
+                            .flat_map(|(blob_id, ids)| {
+                                segment_extract(&self.blobs[&blob_id], Some(&ids))
+                                    .expect("fixture segments are well-formed")
+                            })
+                            .collect()
+                    }
                 };
                 self.requests.borrow_mut().push(req);
                 std::future::ready(Ok(rows))
             }
         }
+    }
+
+    #[test]
+    fn segment_extract_whole_and_subset() {
+        let rows = vec![
+            (-64, b"negative".to_vec()),
+            (10, b"ten".to_vec()),
+            (11, b"eleven".to_vec()),
+        ];
+        let mut next_blob_id = 0;
+        let (catalog, blobs) = fold_rows(&rows, usize::MAX, &mut next_blob_id);
+        assert_eq!(catalog.len(), 1);
+        let segment = &blobs[&catalog[0].blob_id];
+
+        let all = segment_extract(segment, None).unwrap();
+        assert_eq!(
+            all,
+            vec![
+                (-64, b"negative".to_vec()),
+                (10, b"ten".to_vec()),
+                (11, b"eleven".to_vec())
+            ]
+        );
+
+        // Binary search finds present ids and skips missing ones.
+        let subset = segment_extract(segment, Some(&[11, 999, -64])).unwrap();
+        assert_eq!(
+            subset,
+            vec![(-64, b"negative".to_vec()), (11, b"eleven".to_vec())]
+        );
+    }
+
+    #[test]
+    fn segment_extract_rejects_corrupt_segments() {
+        let rows = vec![(1, b"payload".to_vec())];
+        let mut next_blob_id = 0;
+        let (catalog, blobs) = fold_rows(&rows, usize::MAX, &mut next_blob_id);
+        let segment = &blobs[&catalog[0].blob_id];
+
+        assert!(segment_extract(&segment[..2], None).is_err()); // truncated count
+        assert!(segment_extract(&segment[..8], None).is_err()); // truncated index
+        let mut corrupted = segment.clone();
+        // The first (only) index entry's length field, at 4 + 0*12 + 8.
+        corrupted[12..16].copy_from_slice(&u32::MAX.to_le_bytes()); // payload out of bounds
+        assert!(segment_extract(&corrupted, None).is_err());
+    }
+
+    #[test]
+    fn find_segment_routes_by_entry_id_range() {
+        let catalog = vec![
+            CatalogEntry {
+                blob_id: 1,
+                first_entry_id: -10,
+                last_entry_id: 0,
+            },
+            CatalogEntry {
+                blob_id: 2,
+                first_entry_id: 1,
+                last_entry_id: 10,
+            },
+            CatalogEntry {
+                blob_id: 3,
+                first_entry_id: 20,
+                last_entry_id: 30,
+            },
+        ];
+        // Boundaries and interiors route to their segment.
+        assert_eq!(find_segment(&catalog, -10), Some(0));
+        assert_eq!(find_segment(&catalog, 0), Some(0));
+        assert_eq!(find_segment(&catalog, 5), Some(1));
+        assert_eq!(find_segment(&catalog, 10), Some(1));
+        assert_eq!(find_segment(&catalog, 20), Some(2));
+        assert_eq!(find_segment(&catalog, 30), Some(2));
+        // Outside every range: nowhere.
+        assert_eq!(find_segment(&catalog, -11), None);
+        assert_eq!(find_segment(&catalog, 15), None);
+        assert_eq!(find_segment(&catalog, 31), None);
+        assert_eq!(find_segment(&[], 1), None);
     }
 
     fn ty(group_id: i32) -> Vec<u8> {
@@ -602,75 +991,49 @@ mod tests {
     }
 
     fn full_fixture() -> Fixture {
-        let mut fixture = Fixture {
-            rows: HashMap::new(),
-            requests: std::cell::RefCell::new(Vec::new()),
-        };
-        for id in [100, 200, 201, 300, 400] {
-            fixture
-                .rows
-                .entry(Family::Types)
-                .or_default()
-                .insert(id, ty(1));
-        }
+        let mut fixture = Fixture::new();
+        fixture.insert_family(
+            Family::Types,
+            [100, 200, 201, 300, 400]
+                .into_iter()
+                .map(|id| (id, ty(1)))
+                .collect(),
+        );
         // ship: attr 10; module 200: attrs 11, 12 + effect 1000;
         // charge 300: attr 13; dynamic base 201: attr 14; skill 400: attr 15.
-        let dogmas = [
-            (100, dogma(&[(10, 1.0)], &[])),
-            (200, dogma(&[(11, 1.0), (12, 2.0)], &[1000])),
-            (201, dogma(&[(14, 1.0)], &[])),
-            (300, dogma(&[(13, 1.0)], &[])),
-            (400, dogma(&[(15, 1.0)], &[])),
-        ];
-        for (id, row) in dogmas {
-            fixture
-                .rows
-                .entry(Family::TypeDogma)
-                .or_default()
-                .insert(id, row);
-        }
-        fixture
-            .rows
-            .entry(Family::DogmaEffects)
-            .or_default()
-            .insert(1000, effect(Some(20), Some(21)));
-        for id in [10, 11, 12, 13, 14, 15, 20, 21] {
-            fixture
-                .rows
-                .entry(Family::DogmaAttributes)
-                .or_default()
-                .insert(id, attr());
-        }
-        for id in WARFARE_BUFF_ATTRIBUTE_IDS {
-            fixture
-                .rows
-                .entry(Family::DogmaAttributes)
-                .or_default()
-                .insert(id, attr());
-        }
-        fixture
-            .rows
-            .entry(Family::Buffs)
-            .or_default()
-            .insert(1, buff(30));
-        fixture
-            .rows
-            .entry(Family::DogmaAttributes)
-            .or_default()
-            .insert(30, attr());
-        for id in [100, 200, 201, 300, 400] {
-            fixture
-                .rows
-                .entry(Family::TypeMeta)
-                .or_default()
-                .insert(id, meta("Name"));
-        }
-        // Mutated type of the dynamic item: metadata only, not an engine type.
-        fixture
-            .rows
-            .entry(Family::TypeMeta)
-            .or_default()
-            .insert(210, meta("Mutated"));
+        fixture.insert_family(
+            Family::TypeDogma,
+            vec![
+                (100, dogma(&[(10, 1.0)], &[])),
+                (200, dogma(&[(11, 1.0), (12, 2.0)], &[1000])),
+                (201, dogma(&[(14, 1.0)], &[])),
+                (300, dogma(&[(13, 1.0)], &[])),
+                (400, dogma(&[(15, 1.0)], &[])),
+            ],
+        );
+        fixture.insert_family(
+            Family::DogmaEffects,
+            vec![(1000, effect(Some(20), Some(21)))],
+        );
+        fixture.insert_family(
+            Family::DogmaAttributes,
+            [10, 11, 12, 13, 14, 15, 20, 21, 30]
+                .into_iter()
+                .chain(WARFARE_BUFF_ATTRIBUTE_IDS)
+                .map(|id| (id, attr()))
+                .collect(),
+        );
+        fixture.insert_family(Family::Buffs, vec![(1, buff(30))]);
+        fixture.insert_family(
+            Family::TypeMeta,
+            [100, 200, 201, 300, 400]
+                .into_iter()
+                .map(|id| (id, meta("Name")))
+                // Mutated type of the dynamic item: metadata only, not an
+                // engine type.
+                .chain([(210, meta("Mutated"))])
+                .collect(),
+        );
         fixture
     }
 
@@ -701,10 +1064,7 @@ mod tests {
 
     #[test]
     fn prefetch_unknown_seed_type_is_422() {
-        let fixture = Fixture {
-            rows: HashMap::new(),
-            requests: std::cell::RefCell::new(Vec::new()),
-        };
+        let fixture = Fixture::new();
         let mut data = SnapshotData::default();
         let err = run(prefetch(&mut data, &simple_state(), fixture.fetcher())).unwrap_err();
         assert_eq!(err.status, 422);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Storage v3 support for folded, content-addressed data segments up to 512 KiB.
  - Added segment-based synchronization with deduplication, registration, and snapshot completion.
  - Added efficient whole-family and subset reads using segment catalogs and ID ranges.
  - Added caching for segment content and family catalogs.

- **Bug Fixes**
  - Improved handling of large payloads.
  - Added validation for corrupted, oversized, unknown, or incorrectly hashed segments.

- **Compatibility**
  - Existing snapshots continue to work through the legacy storage fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->