### PR TITLE
refactor(platform)!: remove storage v2 protocol and dual-read path

### DIFF
--- a/bootstrap/data/d1/sync.py
+++ b/bootstrap/data/d1/sync.py
@@ -33,8 +33,8 @@ dense. Content addressing still deduplicates segments shared verbatim
 across servers (e.g. identical snapshots on two servers).
 
 Uploads run over a single WebSocket to the worker's ``SyncSession`` Durable
-Object: every frame is a small JSON message (``segment``/
-``segment_lookup``/``segment_register``/``segment_complete``/``snapshot``)
+Object: every frame is a small JSON message (``content``/
+``lookup``/``register``/``complete``/``snapshot``)
 answered by one JSON reply carrying the same client-chosen ``id``. Each
 frame is a separate Durable Object event with its own CPU budget, which
 replaced the old multi-request HTTP API whose large per-request batches
@@ -43,9 +43,9 @@ regularly failed with 503s.
 All operations are idempotent, so the transport reconnects and resends an
 unacknowledged frame on connection failures, and a rerun of the whole sync
 converges: the ``snapshot`` frame skips already-completed snapshots and the
-``segment_lookup`` frame skips already-uploaded segments. A snapshot is only
+``lookup`` frame skips already-uploaded segments. A snapshot is only
 complete once the uploader has posted every segment and link frame and then
-frozen it in the ``snapshots`` registry (``segment_complete``, verified
+frozen it in the ``snapshots`` registry (``complete``, verified
 server-side via ``SUM(entry_count)`` over the segment links); readers must
 check that registry before serving data.
 """
@@ -139,8 +139,8 @@ class Segment:
 class SyncTransport(Protocol):
     """Send one frame payload to the worker and return the decoded reply.
 
-    ``path`` is the frame type (``segment``, ``segment_lookup``,
-    ``segment_register``, ``segment_complete``, ``snapshot``); the payload
+    ``path`` is the frame type (``content``, ``lookup``,
+    ``register``, ``complete``, ``snapshot``); the payload
     carries the frame's remaining fields. Raises on ``ok: false`` replies.
     """
 
@@ -468,7 +468,7 @@ def run_sync(
     deduplicated across servers by content hash before uploading, and segment
     links are registered per (snapshot, family). Reruns converge: snapshots
     already marked complete are skipped, and already-uploaded segments are
-    filtered out via ``segment_lookup`` frames. ``batch_size`` chunks the
+    filtered out via ``lookup`` frames. ``batch_size`` chunks the
     lookup frames.
     """
     if not 1 <= batch_size <= 2_000:
@@ -538,9 +538,7 @@ def run_sync(
         for family in ALL_FAMILIES:
             family_hashes = sorted(h for f, h in pending_segments if f == family)
             for chunk in _batched(family_hashes, batch_size):
-                reply = transport.post(
-                    "segment_lookup", {"family": family, "content_hashes": chunk}
-                )
+                reply = transport.post("lookup", {"family": family, "content_hashes": chunk})
                 missing.update((family, h) for h in reply.get("missing", []))
                 for h, blob_id in reply.get("ids", {}).items():
                     blob_ids[(family, h)] = blob_id
@@ -551,7 +549,7 @@ def run_sync(
         for family, segment_hash in sorted(missing):
             segment = segments[(family, segment_hash)]
             reply = transport.post(
-                "segment",
+                "content",
                 {
                     "family": family,
                     "content_hash": segment.hash,
@@ -583,7 +581,7 @@ def run_sync(
                 if not family_segments:
                     continue
                 transport.post(
-                    "segment_register",
+                    "register",
                     {
                         "server_id": server_id,
                         "snapshot_hash": snapshot_hash,
@@ -605,7 +603,7 @@ def run_sync(
             # verifies SUM(entry_count) over the links before freezing.
             # Readers treat a snapshot without this marker as incomplete.
             transport.post(
-                "segment_complete",
+                "complete",
                 {
                     "server_id": server_id,
                     "snapshot_hash": snapshot_hash,

--- a/bootstrap/tests/test_d1_sync.py
+++ b/bootstrap/tests/test_d1_sync.py
@@ -341,7 +341,7 @@ class _FakeTransport:
 
     def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         self.posts.append((path, payload))
-        if path == "segment_lookup":
+        if path == "lookup":
             present = [
                 h for h in payload["content_hashes"] if (payload["family"], h) in self._existing
             ]
@@ -356,10 +356,10 @@ class _FakeTransport:
         if path == "snapshot":
             complete = (payload["server_id"], payload["snapshot_hash"]) in self._completed
             return {"ok": True, "complete": complete}
-        if path == "segment":
+        if path == "content":
             blob_id = self._ensure_id(payload["family"], payload["content_hash"])
             return {"ok": True, "inserted": 1, "blob_id": blob_id}
-        if path == "segment_register":
+        if path == "register":
             return {"ok": True, "inserted": len(payload["segments"])}
         return {"ok": True}
 
@@ -560,8 +560,8 @@ class TestRunSync:
         transport = _FakeTransport()
         run_sync({"alpha": hash_a, "beta": hash_b}, schema_root, transport, batch_size=2000)
 
-        segment_posts = [p for p in transport.posts if p[0] == "segment"]
-        register_posts = [p for p in transport.posts if p[0] == "segment_register"]
+        segment_posts = [p for p in transport.posts if p[0] == "content"]
+        register_posts = [p for p in transport.posts if p[0] == "register"]
 
         # Identical snapshots: segments uploaded once, deduplicated by hash.
         segment_hashes = [payload["content_hash"] for _path, payload in segment_posts]
@@ -587,7 +587,7 @@ class TestRunSync:
         }
         assert per_server["alpha"] == per_server["beta"]
 
-        complete_posts = [p for p in transport.posts if p[0] == "segment_complete"]
+        complete_posts = [p for p in transport.posts if p[0] == "complete"]
         assert len(complete_posts) == 2
         complete_servers = {payload["server_id"] for _path, payload in complete_posts}
         assert complete_servers == {"alpha", "beta"}
@@ -608,8 +608,8 @@ class TestRunSync:
         run_sync({"alpha": hash_a, "beta": hash_b}, schema_root, transport, batch_size=2000)
 
         # Nothing is re-registered or re-completed for the finished snapshot.
-        register_posts = [p for p in transport.posts if p[0] == "segment_register"]
-        complete_posts = [p for p in transport.posts if p[0] == "segment_complete"]
+        register_posts = [p for p in transport.posts if p[0] == "register"]
+        complete_posts = [p for p in transport.posts if p[0] == "complete"]
         assert {payload["server_id"] for _path, payload in register_posts} == {"beta"}
         assert {payload["server_id"] for _path, payload in complete_posts} == {"beta"}
 
@@ -633,7 +633,7 @@ class TestRunSync:
         transport = _FakeTransport(existing=existing)
         run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
 
-        segment_posts = [p for p in transport.posts if p[0] == "segment"]
+        segment_posts = [p for p in transport.posts if p[0] == "content"]
         assert "types" not in {payload["family"] for _path, payload in segment_posts}
         assert len(segment_posts) == 7  # 8 families minus the existing types segment
 
@@ -645,14 +645,14 @@ class TestRunSync:
 
         class _FailingTransport(_FakeTransport):
             def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
-                if path == "segment_register":
+                if path == "register":
                     raise RuntimeError("boom")
                 return super().post(path, payload)
 
         transport = _FailingTransport()
         with pytest.raises(RuntimeError, match="boom"):
             run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
-        assert [p for p in transport.posts if p[0] == "segment_complete"] == []
+        assert [p for p in transport.posts if p[0] == "complete"] == []
 
     def test_fails_when_server_withholds_blob_ids(self, schema_root: Path) -> None:
         from bootstrap.data.d1.sync import run_sync
@@ -663,14 +663,14 @@ class TestRunSync:
         class _IdlessTransport(_FakeTransport):
             def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
                 reply = super().post(path, payload)
-                if path == "segment":
+                if path == "content":
                     reply.pop("blob_id", None)
                 return reply
 
         transport = _IdlessTransport()
         with pytest.raises(RuntimeError, match="did not return blob ids"):
             run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=2000)
-        assert [p for p in transport.posts if p[0] == "segment_register"] == []
+        assert [p for p in transport.posts if p[0] == "register"] == []
 
     def test_identical_segment_bytes_across_families_stay_distinct(
         self, schema_root: Path, monkeypatch: pytest.MonkeyPatch
@@ -686,24 +686,20 @@ class TestRunSync:
         transport = _FakeTransport()
         sync.run_sync({"alpha": "dd" * 32}, schema_root, transport, batch_size=2000)
 
-        segment_posts = [payload for path, payload in transport.posts if path == "segment"]
+        segment_posts = [payload for path, payload in transport.posts if path == "content"]
         assert len(segment_posts) == 2
         assert {payload["family"] for payload in segment_posts} == {"types", "buffs"}
         assert segment_posts[0]["content_hash"] == segment_posts[1]["content_hash"]
 
         # The shared hash resolves to a distinct blob id per family, and
         # both registrations complete.
-        register_posts = [
-            payload for path, payload in transport.posts if path == "segment_register"
-        ]
+        register_posts = [payload for path, payload in transport.posts if path == "register"]
         blob_ids = {
             payload["segments"][0]["family"]: payload["segments"][0]["blob_id"]
             for payload in register_posts
         }
         assert blob_ids["types"] != blob_ids["buffs"]
-        complete_posts = [
-            payload for path, payload in transport.posts if path == "segment_complete"
-        ]
+        complete_posts = [payload for path, payload in transport.posts if path == "complete"]
         assert len(complete_posts) == 1
         assert complete_posts[0]["entry_count"] == 2
 
@@ -742,9 +738,9 @@ class TestRunSync:
         run_sync({"alpha": snapshot_hash}, schema_root, transport, batch_size=batch_size)
 
         for path, payload in transport.posts:
-            if path == "segment_lookup":
+            if path == "lookup":
                 assert len(payload["content_hashes"]) <= batch_size
-        assert [p for p in transport.posts if p[0] == "segment_complete"] != []
+        assert [p for p in transport.posts if p[0] == "complete"] != []
 
 
 class TestCli:

--- a/worker/efa-platform-data-sync/README.md
+++ b/worker/efa-platform-data-sync/README.md
@@ -13,57 +13,34 @@ Eight families: the five native engine collections (`types`, `type_dogma`,
 (`type_meta`, `dogma_attribute_meta`, `dogma_effect_meta`), each with a fixed
 integer code (`types=0` … `dogma_effect_meta=7`, see `src/session.ts`).
 
-Storage v3 (folded per-family segments, `migrations/0003_folded.sql`,
-additive) is the current layout:
+Folded per-family segments (`migrations/0003_folded.sql`; the v2 per-entry
+tables and the `registered_count` counter were dropped by
+`migrations/0004_drop_v2.sql`):
 
 - `folded_blobs` — `(blob_id INTEGER PRIMARY KEY, family, content_hash BLOB,
   entry_count, first_entry_id, last_entry_id, content BLOB, UNIQUE (family,
   content_hash))`: the only content store. Each row is one self-contained,
   content-addressed ≤512 KiB segment of a family's folded stream (`u32
   count` + `count × (i32 entry_id, u32 offset, u32 length)` + concatenated
-  per-entry protobuf payloads, byte-identical to v2 `entries.content`).
+  per-entry protobuf payloads).
   `first_entry_id`/`last_entry_id` bound the segment's id range for subset
   routing; `blob_id` is a dense database-local integer that must never leak
   outside the sync protocol.
 - `snapshot_family_segments` — `(snapshot_id, family, seq, blob_id)`:
   per-snapshot segment links, no content.
-- `snapshots` — unchanged registry + freeze semantics. v3 keeps no
-  `registered_count`: `segment_complete` verifies `SUM(entry_count)` over
-  the segment-link join inside the freezing `UPDATE`.
-
-The v2 tables (`entries`, `snapshot_entries`) stay in place for the rollback
-window — 0003 deliberately drops nothing — and the v2 frames below stay
-operational until cutover; migration 0004 drops the v2 tables and the v2
-frames are removed in the same step.
-
-Storage v2 (`migrations/0001_init.sql`, legacy after cutover):
-
-- `entries` — `(content_id INTEGER PRIMARY KEY, family, content_hash BLOB,
-  content BLOB, UNIQUE (family, content_hash))`: content-addressed
-  single-entry protobuf payloads (efos `efos.*` entry messages for the engine
-  families, `efa.v2`-style `platform_data.*` messages for metadata). Hashes
-  are raw 32-byte BLOBs; `content_id` is a dense database-local integer that
-  must never leak outside the sync protocol.
-- `snapshot_entries` — `(snapshot_id, family, entry_id, content_id)`:
-  registration rows mapping a snapshot's entries onto content rows,
-  referencing integer ids only (~25 B/row; the v1 schema repeated both full
-  hex hashes per row at ~344 B/row including indexes).
 - `snapshots` — `(snapshot_id INTEGER PRIMARY KEY, server_id, snapshot_hash
-  BLOB, entry_count, completed_at, registered_count, UNIQUE (server_id,
-  snapshot_hash))`: the completeness registry. The first `register` frame
-  creates the row with `completed_at = NULL`; each register frame adds its
-  actually-inserted row count to `registered_count`, and the uploader's
-  `complete` frame freezes the snapshot after verifying that counter against
-  the expected entry count (O(1); a real `COUNT(*)` scan only runs to repair
-  a counter diverged by a crash or a pre-migration pending snapshot).
-  **Readers must check `completed_at IS NOT NULL` and treat any other
-  `(server_id, snapshot_hash)` as incomplete.**
+  BLOB, entry_count, completed_at, UNIQUE (server_id, snapshot_hash))`: the
+  completeness registry. The first `register` frame creates the row with
+  `completed_at = NULL`, and the uploader's `complete` frame freezes the
+  snapshot after verifying `SUM(entry_count)` over the segment-link join
+  inside the freezing `UPDATE`. **Readers must check `completed_at IS NOT
+  NULL` and treat any other `(server_id, snapshot_hash)` as incomplete.**
 
 An upload spans many WebSocket frames (one D1 transaction each), so a failed
-sync leaves partial `snapshot_entries` rows behind — always guarded by the
-pending `snapshots` row above.
+sync leaves partial `snapshot_family_segments` rows behind — always guarded
+by the pending `snapshots` row above.
 
-See `migrations/0001_init.sql` and `data/schema/platform_data.proto`.
+See `data/schema/platform_data.proto`.
 
 ## Transport
 
@@ -91,83 +68,6 @@ HTTP GET probes below are public.
 {
   "type": "content",
   "id": 1,
-  "entries": [
-    { "family": "types", "content_hash": "sha256-hex", "content_b64": "..." }
-  ]
-}
-```
-
-`INSERT OR IGNORE`s every row into `entries` (dedup by content hash); each
-payload is verified against its SHA-256 hash. At most 2000 entries per frame.
-Replies `{ "id": 1, "ok": true, "inserted": n, "ids": { "<hash>": 123 } }`
-where `ids` resolves the frame's hashes to their content ids — freshly
-inserted and pre-existing alike. (`ids` is keyed by hash alone; a frame must
-not carry identical content bytes under two families — the reference uploader
-sends one family per frame.)
-
-### Frame: `lookup`
-
-```json
-{ "type": "lookup", "id": 2, "family": "types", "content_hashes": ["sha256-hex"] }
-```
-
-Returns the subset of the given hashes not yet present in the family (at most
-5000 hashes per frame) plus the content ids of the present ones:
-`{ "id": 2, "ok": true, "missing": ["sha256-hex"], "ids": { "<hash>": 123 } }`.
-Uploaders use this to skip already-synced content on reruns and to resolve
-content ids for registration.
-
-### Frame: `register`
-
-```json
-{
-  "type": "register",
-  "id": 3,
-  "server_id": "tranquility",
-  "snapshot_hash": "sha256-hex",
-  "entries": [{ "family": "types", "entry_id": 587, "content_id": 123 }]
-}
-```
-
-Resolves-or-creates the pending `snapshots` row, verifies every referenced
-content id exists in the entry's family (error reply with a `missing` list
-otherwise), then `INSERT OR IGNORE`s the registration rows (immutable per
-primary key, so re-runs are free of write quota). Once `complete` has frozen
-a snapshot, further registrations for it fail with
-`Snapshot already complete`. At most 2000 entries per frame. Replies
-`{ "id": 3, "ok": true, "inserted": n }`.
-
-### Frame: `complete`
-
-```json
-{ "type": "complete", "id": 4, "server_id": "tranquility", "snapshot_hash": "sha256-hex", "entry_count": 8 }
-```
-
-Marks a snapshot complete. Verifies server-side that the register-maintained
-`registered_count` equals `entry_count` (error reply otherwise); the count
-check and the freeze are a single conditional `UPDATE`, and every
-registration insert is guarded by `completed_at IS NULL`, so a concurrent
-`register` frame can never extend an already frozen registration set. A
-counter diverged by a crash (or a pre-migration pending snapshot) is repaired
-with one real `COUNT(*)` before the freeze; a retry of the same `complete`
-frame after a lost reply succeeds. Replies `{ "id": 4, "ok": true }`.
-
-### Frame: `snapshot`
-
-```json
-{ "type": "snapshot", "id": 5, "server_id": "tranquility", "snapshot_hash": "sha256-hex" }
-```
-
-Completeness probe, same semantics as the HTTP GET below:
-`{ "id": 5, "ok": true, "complete": false }` or
-`{ "id": 5, "ok": true, "complete": true, "entry_count": n, "completed_at": "..." }`.
-
-### Frame: `segment` (v3)
-
-```json
-{
-  "type": "segment",
-  "id": 6,
   "family": "types",
   "content_hash": "sha256-hex",
   "entry_count": 137,
@@ -180,53 +80,67 @@ Completeness probe, same semantics as the HTTP GET below:
 Uploads one folded segment: base64-decoded, verified against its SHA-256
 content hash, `INSERT OR IGNORE`d into `folded_blobs`. One segment per frame,
 ≤512 KiB raw (base64 capped at ~700 KiB, keeping the frame under the 1 MiB
-WebSocket message limit). Replies `{ "id": 6, "ok": true, "inserted": n,
+WebSocket message limit). Replies `{ "id": 1, "ok": true, "inserted": n,
 "blob_id": 123 }` — the blob id of the freshly inserted or pre-existing row.
 
-### Frame: `segment_lookup` (v3)
+### Frame: `lookup`
 
 ```json
-{ "type": "segment_lookup", "id": 7, "family": "types", "content_hashes": ["sha256-hex"] }
+{ "type": "lookup", "id": 2, "family": "types", "content_hashes": ["sha256-hex"] }
 ```
 
-Same shape as v2 `lookup`, resolved against `folded_blobs`: the segment
-hashes not yet present in the family (at most 5000 per frame) plus the blob
-ids of the present ones.
+Returns the segment hashes not yet present in the family (at most 5000 hashes
+per frame) plus the blob ids of the present ones:
+`{ "id": 2, "ok": true, "missing": ["sha256-hex"], "ids": { "<hash>": 123 } }`.
+Uploaders use this to skip already-synced segments on reruns and to resolve
+blob ids for registration.
 
-### Frame: `segment_register` (v3)
+### Frame: `register`
 
 ```json
 {
-  "type": "segment_register",
-  "id": 8,
+  "type": "register",
+  "id": 3,
   "server_id": "tranquility",
   "snapshot_hash": "sha256-hex",
   "segments": [{ "family": "types", "seq": 0, "blob_id": 123 }]
 }
 ```
 
-Links a snapshot's segments (one frame per family). Every referenced blob id
-must exist in the link's family (error reply with a `missing` list
-otherwise), and a frame may link each blob id at most once per family — a
-duplicate fails with `Duplicate segment links` and inserts nothing (the
-freeze `SUM(entry_count)` counts once per link row, so a duplicated blob id
-would be double-counted). Links are freeze-guarded exactly like v2
-`register`: once
-`segment_complete` has frozen a snapshot, further registrations fail with
-`Snapshot already complete`. Replies `{ "id": 8, "ok": true, "inserted": n }`.
+Links a snapshot's segments (one frame per family). Resolves-or-creates the
+pending `snapshots` row, then verifies every referenced blob id exists in the
+link's family (error reply with a `missing` list otherwise), and a frame may
+link each blob id at most once per family — a duplicate fails with
+`Duplicate segment links` and inserts nothing (the freeze `SUM(entry_count)`
+counts once per link row, so a duplicated blob id would be double-counted).
+Links are `INSERT OR IGNORE`d (immutable per primary key, so re-runs are free
+of write quota) and freeze-guarded: once `complete` has frozen a snapshot,
+further registrations fail with `Snapshot already complete`. Replies
+`{ "id": 3, "ok": true, "inserted": n }`.
 
-### Frame: `segment_complete` (v3)
+### Frame: `complete`
 
 ```json
-{ "type": "segment_complete", "id": 9, "server_id": "tranquility", "snapshot_hash": "sha256-hex", "entry_count": 8 }
+{ "type": "complete", "id": 4, "server_id": "tranquility", "snapshot_hash": "sha256-hex", "entry_count": 8 }
 ```
 
 Marks a snapshot complete. Verifies server-side that
 `SUM(folded_blobs.entry_count)` over the snapshot's segment links equals
 `entry_count` (error reply carrying the real sum otherwise); the SUM check
-and the freeze are a single conditional `UPDATE`. v3 keeps no counter, so
-there is no divergence/repair path. A retry of the same frame after a lost
-reply succeeds. Replies `{ "id": 9, "ok": true }`.
+and the freeze are a single conditional `UPDATE`, and every link insert is
+guarded by `completed_at IS NULL`, so a concurrent `register` frame can never
+extend an already frozen link set. A retry of the same `complete` frame after
+a lost reply succeeds. Replies `{ "id": 4, "ok": true }`.
+
+### Frame: `snapshot`
+
+```json
+{ "type": "snapshot", "id": 5, "server_id": "tranquility", "snapshot_hash": "sha256-hex" }
+```
+
+Completeness probe, same semantics as the HTTP GET below:
+`{ "id": 5, "ok": true, "complete": false }` or
+`{ "id": 5, "ok": true, "complete": true, "entry_count": n, "completed_at": "..." }`.
 
 ### `GET /platform/storage/data-sync/health`
 

--- a/worker/efa-platform-data-sync/migrations/0004_drop_v2.sql
+++ b/worker/efa-platform-data-sync/migrations/0004_drop_v2.sql
@@ -1,0 +1,7 @@
+-- Storage v2 teardown (the drops deferred from 0003_folded.sql).
+--
+-- D1 enforces foreign-key constraints on every query and migration
+-- (equivalent to PRAGMA foreign_keys = on), so child tables drop first.
+DROP TABLE snapshot_entries; -- references entries + snapshots
+DROP TABLE entries;
+ALTER TABLE snapshots DROP COLUMN registered_count;

--- a/worker/efa-platform-data-sync/src/session.ts
+++ b/worker/efa-platform-data-sync/src/session.ts
@@ -14,66 +14,46 @@
 // unacknowledged frame — or rerun the whole sync, which converges via the
 // `lookup`/`snapshot` frames.
 //
-// Storage v2 (see migrations/0001_init.sql): hashes cross the wire as
-// lowercase hex but are stored as raw 32-byte BLOBs, and registration rows
-// reference dense database-local integer ids (snapshot_id, content_id)
-// instead of repeating both hashes per row.
+// Storage (folded per-family segments, see migrations/0003_folded.sql): each
+// family is folded into self-contained, content-addressed <=512 KiB segments
+// stored in folded_blobs; per-snapshot links live in snapshot_family_segments.
+// Hashes cross the wire as lowercase hex but are stored as raw 32-byte BLOBs,
+// and link rows reference dense database-local integer ids (snapshot_id,
+// blob_id) instead of repeating both hashes per row.
+//
+// Segment format (self-contained, entries sorted by entry id):
+//   u32 count
+//   count x { i32 entry_id, u32 offset, u32 length }  -- offset from segment
+//   payload bytes (concatenated per-entry protobufs)
 //
 // Client frames:
-//   {type: "content",  id, entries: [{family, content_hash, content_b64}]}
-//       -> {id, ok: true, inserted, ids: {content_hash: content_id}} —
-//          INSERT OR IGNORE per-entry payloads, each verified against its
-//          SHA-256 content hash, then the content ids of the frame's entries
-//          (present and freshly inserted alike) are resolved for the client.
-//          `ids` is keyed by hash alone: ids are only unique per
-//          (family, hash), so a frame must not carry identical content bytes
-//          under two families (the uploader sends one family per frame).
-//   {type: "lookup",   id, family, content_hashes: [hex]}
-//       -> {id, ok: true, missing: [hex], ids: {content_hash: content_id}} —
-//          hashes not yet present in the family, plus the content ids of the
-//          present ones (resume support).
-//   {type: "register", id, server_id, snapshot_hash, entries: [{family, entry_id, content_id}]}
-//       -> {id, ok: true, inserted} — registration rows, conditional on the
-//          snapshot not being frozen by a `complete` marker yet.
-//   {type: "complete", id, server_id, snapshot_hash, entry_count}
-//       -> {id, ok: true} — freezes the snapshot after verifying the
-//          registration count server-side. The check compares the
-//          register-maintained registered_count counter in one atomic
-//          conditional UPDATE (a real COUNT(*) scan only runs to repair a
-//          counter diverged by a crash), and a retry of the same frame
-//          after a lost reply succeeds. Register and complete frames for
-//          the same snapshot are serialized in instance memory
-//          (runSerialized), so the counter is settled whenever complete
-//          evaluates it; the per-statement freeze guards remain as the
-//          SQL-level backstop.
-//   {type: "snapshot", id, server_id, snapshot_hash}
-//       -> {id, ok: true, complete: bool, entry_count?, completed_at?} —
-//          completeness probe so reruns can skip finished snapshots.
-//
-// Storage v3 (folded per-family segments, see migrations/0003_folded.sql)
-// adds a parallel frame set; the v2 frames above stay operational until
-// cutover (additive deploy, rollback window — the v2 tables are dropped by
-// migration 0004, not 0003):
-//   {type: "segment", id, family, content_hash, entry_count,
+//   {type: "content",  id, family, content_hash, entry_count,
 //    first_entry_id, last_entry_id, content_b64}
 //       -> {id, ok: true, inserted, blob_id} — one folded segment (<=512 KiB
 //          raw, ~700 KiB base64 cap), SHA-256-verified, INSERT OR IGNORE
 //          into folded_blobs; the reply resolves the database-local blob id.
-//   {type: "segment_lookup", id, family, content_hashes: [hex]}
+//   {type: "lookup",   id, family, content_hashes: [hex]}
 //       -> {id, ok: true, missing: [hex], ids: {content_hash: blob_id}} —
-//          same shape as v2 lookup, resolved against folded_blobs.
-//   {type: "segment_register", id, server_id, snapshot_hash,
+//          segment hashes not yet present in the family, plus the blob ids
+//          of the present ones (resume support).
+//   {type: "register", id, server_id, snapshot_hash,
 //    segments: [{family, seq, blob_id}]}
-//       -> {id, ok: true, inserted} — per-snapshot segment links, guarded
-//          against frozen snapshots exactly like v2 register. A frame
-//          linking the same blob id more than once per family is rejected
-//          (the freeze SUM counts entry_count once per link row).
-//   {type: "segment_complete", id, server_id, snapshot_hash, entry_count}
+//       -> {id, ok: true, inserted} — per-snapshot segment links, conditional
+//          on the snapshot not being frozen by a `complete` marker yet. A
+//          frame linking the same blob id more than once per family is
+//          rejected (the freeze SUM counts entry_count once per link row).
+//   {type: "complete", id, server_id, snapshot_hash, entry_count}
 //       -> {id, ok: true} — freezes the snapshot after verifying
 //          SUM(folded_blobs.entry_count) over the segment-link join inside
-//          the single conditional UPDATE; v3 keeps no registered_count
-//          counter, so there is no crash-repair path — the SUM is the check.
-//          A retry of the same frame after a lost reply succeeds.
+//          the single conditional UPDATE. Register and complete frames for
+//          the same snapshot are serialized in instance memory
+//          (runSerialized), so the SUM is settled whenever complete
+//          evaluates it; the per-statement freeze guards remain as the
+//          SQL-level backstop. A retry of the same frame after a lost reply
+//          succeeds.
+//   {type: "snapshot", id, server_id, snapshot_hash}
+//       -> {id, ok: true, complete: bool, entry_count?, completed_at?} —
+//          completeness probe so reruns can skip finished snapshots.
 //
 // Error replies carry {id, ok: false, error, ...details}.
 
@@ -102,35 +82,18 @@ const IdSchema = z.number().int().nonnegative();
 
 // Per-frame caps. Frames are deliberately small: each one is a separate Durable
 // Object event with its own CPU budget, so modest frames keep every event far
-// below the limit and give the uploader fast acks. The lookup cap also keeps
-// the reply (hash -> id map) well under the 1 MiB WebSocket message limit.
-const CONTENT_ENTRIES_PER_FRAME = 2000;
-const REGISTER_ENTRIES_PER_FRAME = 2000;
-const LOOKUP_HASHES_PER_FRAME = 5000;
-
-// v3 (folded segments): one segment per content frame, <=512 KiB raw. The
-// base64 cap (~700 KiB) keeps the JSON frame well under the 1 MiB WebSocket
-// message limit. Register frames carry one family's segment links (the
-// largest family folds to ~25 segments at 512 KiB); 1000 is generous
-// headroom, not an expected size.
+// below the limit and give the uploader fast acks. One segment per content
+// frame, <=512 KiB raw; the base64 cap (~700 KiB) keeps the JSON frame well
+// under the 1 MiB WebSocket message limit. Register frames carry one family's
+// segment links (the largest family folds to ~25 segments at 512 KiB); 1000 is
+// generous headroom, not an expected size. The lookup cap also keeps the reply
+// (hash -> id map) well under the 1 MiB WebSocket message limit.
 const SEGMENT_CONTENT_B64_MAX = 700 * 1024;
 const SEGMENT_LINKS_PER_FRAME = 1000;
 const SEGMENT_LOOKUP_HASHES_PER_FRAME = 5000;
 
 // Engine-internal pseudo attributes/effects carry negative int32 IDs.
 const EntryIdSchema = z.number().int().gte(-2147483648).lte(2147483647);
-
-const ContentEntrySchema = z.object({
-    family: FamilySchema,
-    content_hash: z.string().regex(HASH_RE),
-    content_b64: z.base64().min(1),
-});
-
-const RegisterEntrySchema = z.object({
-    family: FamilySchema,
-    entry_id: EntryIdSchema,
-    content_id: z.number().int().positive(),
-});
 
 const SegmentLinkSchema = z.object({
     family: FamilySchema,
@@ -147,19 +110,27 @@ const ClientMessageSchema = z.discriminatedUnion("type", [
     z.object({
         type: z.literal("content"),
         id: IdSchema,
-        entries: z.array(ContentEntrySchema).min(1).max(CONTENT_ENTRIES_PER_FRAME),
+        family: FamilySchema,
+        content_hash: z.string().regex(HASH_RE),
+        entry_count: z.number().int().positive(),
+        first_entry_id: EntryIdSchema,
+        last_entry_id: EntryIdSchema,
+        content_b64: z.base64().min(1).max(SEGMENT_CONTENT_B64_MAX),
     }),
     z.object({
         type: z.literal("lookup"),
         id: IdSchema,
         family: FamilySchema,
-        content_hashes: z.array(z.string().regex(HASH_RE)).min(1).max(LOOKUP_HASHES_PER_FRAME),
+        content_hashes: z
+            .array(z.string().regex(HASH_RE))
+            .min(1)
+            .max(SEGMENT_LOOKUP_HASHES_PER_FRAME),
     }),
     z.object({
         type: z.literal("register"),
         id: IdSchema,
         ...SnapshotSelectorSchema.shape,
-        entries: z.array(RegisterEntrySchema).min(1).max(REGISTER_ENTRIES_PER_FRAME),
+        segments: z.array(SegmentLinkSchema).min(1).max(SEGMENT_LINKS_PER_FRAME),
     }),
     z.object({
         type: z.literal("complete"),
@@ -172,42 +143,9 @@ const ClientMessageSchema = z.discriminatedUnion("type", [
         id: IdSchema,
         ...SnapshotSelectorSchema.shape,
     }),
-    // Storage v3 (folded segments); see the header comment.
-    z.object({
-        type: z.literal("segment"),
-        id: IdSchema,
-        family: FamilySchema,
-        content_hash: z.string().regex(HASH_RE),
-        entry_count: z.number().int().positive(),
-        first_entry_id: EntryIdSchema,
-        last_entry_id: EntryIdSchema,
-        content_b64: z.base64().min(1).max(SEGMENT_CONTENT_B64_MAX),
-    }),
-    z.object({
-        type: z.literal("segment_lookup"),
-        id: IdSchema,
-        family: FamilySchema,
-        content_hashes: z
-            .array(z.string().regex(HASH_RE))
-            .min(1)
-            .max(SEGMENT_LOOKUP_HASHES_PER_FRAME),
-    }),
-    z.object({
-        type: z.literal("segment_register"),
-        id: IdSchema,
-        ...SnapshotSelectorSchema.shape,
-        segments: z.array(SegmentLinkSchema).min(1).max(SEGMENT_LINKS_PER_FRAME),
-    }),
-    z.object({
-        type: z.literal("segment_complete"),
-        id: IdSchema,
-        ...SnapshotSelectorSchema.shape,
-        entry_count: z.number().int().nonnegative(),
-    }),
 ]);
 
 // D1 allows at most 100 bound parameters per statement.
-const CONTENT_ROWS_PER_STATEMENT = 32; // 3 params per row
 const REGISTER_ROWS_PER_STATEMENT = 24; // 4 params per row + 1 freeze-guard param
 const HASHES_PER_LOOKUP = 49; // 2 params per hash (family + hash)
 const STATEMENTS_PER_BATCH = 50;
@@ -264,14 +202,12 @@ class SyncFailure extends Error {
     }
 }
 
-type ContentEntry = z.infer<typeof ContentEntrySchema>;
-type RegisterEntry = z.infer<typeof RegisterEntrySchema>;
+type SegmentLink = z.infer<typeof SegmentLinkSchema>;
 
 interface SnapshotRow {
     snapshot_id: number;
     entry_count: number | null;
     completed_at: string | null;
-    registered_count: number;
 }
 
 // Resolve (server_id, snapshot_hash) to its registry row, if any.
@@ -282,16 +218,16 @@ async function findSnapshot(
 ): Promise<SnapshotRow | null> {
     return await db
         .prepare(
-            "SELECT snapshot_id, entry_count, completed_at, registered_count FROM snapshots " +
+            "SELECT snapshot_id, entry_count, completed_at FROM snapshots " +
                 "WHERE server_id = ? AND snapshot_hash = ?",
         )
         .bind(serverId, hexToBlob(snapshotHash))
         .first<SnapshotRow>();
 }
 
-// Resolve-or-create the pending registry row for a snapshot. Registration
-// rows reference snapshot_id, so the row must exist before the first
-// register frame; `complete` later fills entry_count/completed_at.
+// Resolve-or-create the pending registry row for a snapshot. Link rows
+// reference snapshot_id, so the row must exist before the first register
+// frame; `complete` later fills entry_count/completed_at.
 async function ensureSnapshot(
     db: D1Database,
     serverId: string,
@@ -306,369 +242,6 @@ async function ensureSnapshot(
         throw new Error("snapshots row missing after insert");
     }
     return row;
-}
-
-// Resolve the content ids of the given hashes in one family. Returns the
-// hash -> id map for present rows and the list of missing hashes.
-async function resolveContentIds(
-    db: D1Database,
-    family: Family,
-    contentHashes: string[],
-): Promise<{ ids: Record<string, number>; missing: string[] }> {
-    const familyCode = FAMILY_CODES[family];
-    const ids: Record<string, number> = {};
-    const missing: string[] = [];
-    for (const chunk of chunked([...new Set(contentHashes)], HASHES_PER_LOOKUP)) {
-        const placeholders = chunk.map(() => "?").join(", ");
-        const found = await db
-            .prepare(
-                "SELECT content_id, content_hash FROM entries " +
-                    `WHERE family = ? AND content_hash IN (${placeholders})`,
-            )
-            .bind(familyCode, ...chunk.map(hexToBlob))
-            .all<{ content_id: number; content_hash: ArrayBuffer }>();
-        const foundSet = new Set<string>();
-        for (const row of found.results) {
-            const hex = bytesToHex(new Uint8Array(row.content_hash));
-            ids[hex] = row.content_id;
-            foundSet.add(hex);
-        }
-        for (const hash of chunk) {
-            if (!foundSet.has(hash)) {
-                missing.push(hash);
-            }
-        }
-    }
-    return { ids, missing };
-}
-
-async function handleContent(
-    db: D1Database,
-    entries: ContentEntry[],
-): Promise<{ inserted: number; ids: Record<string, number> }> {
-    const byFamily = new Map<Family, { hash: string; content: Uint8Array }[]>();
-    const rejected: { family: Family; content_hash: string; reason: string }[] = [];
-    for (const entry of entries) {
-        let content: Uint8Array;
-        try {
-            content = base64ToBytes(entry.content_b64);
-        } catch {
-            rejected.push({
-                family: entry.family,
-                content_hash: entry.content_hash,
-                reason: "invalid base64",
-            });
-            continue;
-        }
-        const actual = await sha256Hex(content);
-        if (actual !== entry.content_hash) {
-            rejected.push({
-                family: entry.family,
-                content_hash: entry.content_hash,
-                reason: `hash mismatch: content hashes to ${actual}`,
-            });
-            continue;
-        }
-        const rows = byFamily.get(entry.family) ?? [];
-        rows.push({ hash: entry.content_hash, content });
-        byFamily.set(entry.family, rows);
-    }
-    if (rejected.length > 0) {
-        throw new SyncFailure({
-            error: "Content verification failed",
-            rejected: rejected.slice(0, 100),
-        });
-    }
-
-    let inserted = 0;
-    const ids: Record<string, number> = {};
-    for (const [family, rows] of byFamily) {
-        const statements: D1PreparedStatement[] = [];
-        for (const chunk of chunked(rows, CONTENT_ROWS_PER_STATEMENT)) {
-            const placeholders = chunk.map(() => "(?, ?, ?)").join(", ");
-            const binds: (number | ArrayBuffer)[] = chunk.flatMap((row) => [
-                FAMILY_CODES[family],
-                hexToBlob(row.hash),
-                row.content.buffer as ArrayBuffer,
-            ]);
-            statements.push(
-                db
-                    .prepare(
-                        "INSERT OR IGNORE INTO entries (family, content_hash, content) " +
-                            `VALUES ${placeholders}`,
-                    )
-                    .bind(...binds),
-            );
-        }
-        for (const batch of chunked(statements, STATEMENTS_PER_BATCH)) {
-            const results = await db.batch(batch);
-            for (const result of results) {
-                inserted += result.meta.changes ?? 0;
-            }
-        }
-        // Resolve the ids of every row in the frame, freshly inserted and
-        // pre-existing alike (INSERT OR IGNORE does not report which).
-        const resolved = await resolveContentIds(
-            db,
-            family,
-            rows.map((row) => row.hash),
-        );
-        Object.assign(ids, resolved.ids);
-    }
-    return { inserted, ids };
-}
-
-async function handleLookup(
-    db: D1Database,
-    family: Family,
-    contentHashes: string[],
-): Promise<{ missing: string[]; ids: Record<string, number> }> {
-    return await resolveContentIds(db, family, contentHashes);
-}
-
-async function handleRegister(
-    db: D1Database,
-    serverId: string,
-    snapshotHash: string,
-    entries: RegisterEntry[],
-): Promise<{ inserted: number }> {
-    const snapshot = await ensureSnapshot(db, serverId, snapshotHash);
-    // Fast path only. The authoritative freeze check is the guard on every
-    // insert plus the completed_at probe in the final batch below. Register
-    // and complete handlers for the same snapshot are serialized in the
-    // Durable Object (runSerialized), but that is instance memory — these
-    // SQL guards are the backstop for any writer that bypasses it.
-    if (snapshot.completed_at !== null) {
-        throw new SyncFailure({ error: "Snapshot already complete" });
-    }
-
-    // Referential integrity: every referenced content id must exist and
-    // belong to the entry's stated family.
-    const missing: { family: Family; content_id: number }[] = [];
-    const byFamily = new Map<Family, number[]>();
-    for (const entry of entries) {
-        const ids = byFamily.get(entry.family) ?? [];
-        ids.push(entry.content_id);
-        byFamily.set(entry.family, ids);
-    }
-    for (const [family, contentIds] of byFamily) {
-        const familyCode = FAMILY_CODES[family];
-        for (const chunk of chunked([...new Set(contentIds)], HASHES_PER_LOOKUP)) {
-            const placeholders = chunk.map(() => "?").join(", ");
-            const found = await db
-                .prepare(
-                    "SELECT content_id FROM entries " +
-                        `WHERE family = ? AND content_id IN (${placeholders})`,
-                )
-                .bind(familyCode, ...chunk)
-                .all<{ content_id: number }>();
-            const foundSet = new Set(found.results.map((row) => row.content_id));
-            for (const contentId of chunk) {
-                if (!foundSet.has(contentId)) {
-                    missing.push({ family, content_id: contentId });
-                }
-            }
-        }
-    }
-    if (missing.length > 0) {
-        throw new SyncFailure({ error: "Unknown content ids", missing: missing.slice(0, 100) });
-    }
-
-    const byFamilyEntries = new Map<Family, { id: number; contentId: number }[]>();
-    for (const entry of entries) {
-        const rows = byFamilyEntries.get(entry.family) ?? [];
-        rows.push({ id: entry.entry_id, contentId: entry.content_id });
-        byFamilyEntries.set(entry.family, rows);
-    }
-
-    let inserted = 0;
-    const statements: D1PreparedStatement[] = [];
-    for (const [family, rows] of byFamilyEntries) {
-        const familyCode = FAMILY_CODES[family];
-        for (const chunk of chunked(rows, REGISTER_ROWS_PER_STATEMENT)) {
-            const placeholders = chunk.map(() => "(?, ?, ?, ?)").join(", ");
-            const binds = [
-                ...chunk.flatMap((row) => [
-                    snapshot.snapshot_id,
-                    familyCode,
-                    row.id,
-                    row.contentId,
-                ]),
-                snapshot.snapshot_id,
-            ];
-            // Every insert is conditional on the snapshot not being frozen:
-            // INSERT OR IGNORE alone would silently add rows to an already
-            // completed snapshot if a complete event won the race after the
-            // fast-path check above. (SQLite names the columns of a VALUES
-            // subquery column1..column4.)
-            statements.push(
-                db
-                    .prepare(
-                        "INSERT OR IGNORE INTO snapshot_entries " +
-                            "(snapshot_id, family, entry_id, content_id) " +
-                            "SELECT column1, column2, column3, column4 " +
-                            `FROM (VALUES ${placeholders}) ` +
-                            "WHERE EXISTS (SELECT 1 FROM snapshots " +
-                            "WHERE snapshot_id = ? AND completed_at IS NULL)",
-                    )
-                    .bind(...binds),
-            );
-        }
-    }
-    // The final batch also probes completed_at. A batch commits atomically,
-    // so a concurrent complete that bypassed the instance-level
-    // serialization either committed before it (the guards above inserted
-    // nothing and the probe observes the freeze, rejecting this frame) or
-    // runs after it (and counts these rows in its own atomic
-    // count-and-freeze update). Registration and completion therefore cannot
-    // interleave into a frozen snapshot whose entry_count disagrees with its
-    // registration set.
-    const batches = chunked(statements, STATEMENTS_PER_BATCH);
-    for (const [index, batch] of batches.entries()) {
-        const isLast = index === batches.length - 1;
-        if (isLast) {
-            batch.push(
-                db
-                    .prepare("SELECT completed_at FROM snapshots WHERE snapshot_id = ?")
-                    .bind(snapshot.snapshot_id),
-            );
-        }
-        const results = await db.batch(batch);
-        for (const result of isLast ? results.slice(0, -1) : results) {
-            inserted += result.meta.changes ?? 0;
-        }
-        if (isLast) {
-            const probe = results.at(-1)?.results[0] as { completed_at: string | null } | undefined;
-            if (probe?.completed_at != null) {
-                throw new SyncFailure({ error: "Snapshot already complete" });
-            }
-        }
-    }
-    // Maintain the O(1) completion counter: add only the rows this frame
-    // actually inserted (INSERT OR IGNORE conflicts contribute 0, so re-sent
-    // frames never inflate it). The UPDATE commits separately from the
-    // insert batches above; a crash in between leaves the counter short,
-    // which the complete frame's fallback detects and repairs with one real
-    // COUNT(*). Incrementing an already-frozen snapshot is harmless: frozen
-    // rows are never re-verified.
-    if (inserted > 0) {
-        await db
-            .prepare(
-                "UPDATE snapshots SET registered_count = registered_count + ? " +
-                    "WHERE snapshot_id = ?",
-            )
-            .bind(inserted, snapshot.snapshot_id)
-            .run();
-    }
-    return { inserted };
-}
-
-// The freezing UPDATE: the count verification, the not-yet-frozen check, and
-// the marker write are a single statement, so a concurrent register frame
-// that bypassed the instance-level serialization can never slip rows in
-// between the verification and the freeze. The count check compares
-// registered_count — maintained incrementally by register frames — instead
-// of scanning snapshot_entries: a COUNT(*) here costs a full index-range
-// scan of the snapshot's registration rows.
-async function freezeSnapshot(
-    db: D1Database,
-    snapshotId: number,
-    entryCount: number,
-): Promise<boolean> {
-    const result = await db
-        .prepare(
-            "UPDATE snapshots SET entry_count = ?, " +
-                "completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') " +
-                "WHERE snapshot_id = ? AND completed_at IS NULL AND registered_count = ?",
-        )
-        .bind(entryCount, snapshotId, entryCount)
-        .run();
-    return (result.meta.changes ?? 0) > 0;
-}
-
-async function countRegistrations(db: D1Database, snapshotId: number): Promise<number> {
-    const row = await db
-        .prepare("SELECT COUNT(*) AS n FROM snapshot_entries WHERE snapshot_id = ?")
-        .bind(snapshotId)
-        .first<{ n: number }>();
-    return row?.n ?? 0;
-}
-
-async function handleComplete(
-    db: D1Database,
-    serverId: string,
-    snapshotHash: string,
-    entryCount: number,
-): Promise<Record<string, never>> {
-    const snapshot = await findSnapshot(db, serverId, snapshotHash);
-    if (!snapshot) {
-        throw new SyncFailure({
-            error: "Snapshot incomplete",
-            expected: entryCount,
-            registered: 0,
-        });
-    }
-
-    // Idempotent retry of a complete frame whose reply was lost.
-    if (snapshot.completed_at !== null) {
-        if (snapshot.entry_count === entryCount) {
-            return {};
-        }
-        throw new SyncFailure({ error: "Snapshot already complete" });
-    }
-
-    if (await freezeSnapshot(db, snapshot.snapshot_id, entryCount)) {
-        return {};
-    }
-
-    // The conditional update matched no row: a concurrent complete won the
-    // race, the registration count genuinely differs, or the counter
-    // diverged from the rows (a crash between a register frame's inserts and
-    // its counter update, or a pre-0002 pending snapshot). Re-read the
-    // registry row, then fall back to one real COUNT(*) to disambiguate.
-    const state = await findSnapshot(db, serverId, snapshotHash);
-    if (state?.completed_at != null) {
-        if (state.entry_count === entryCount) {
-            return {};
-        }
-        throw new SyncFailure({ error: "Snapshot already complete" });
-    }
-    const registered = await countRegistrations(db, snapshot.snapshot_id);
-    if (registered !== entryCount) {
-        throw new SyncFailure({
-            error: "Snapshot incomplete",
-            expected: entryCount,
-            registered,
-        });
-    }
-
-    // Complete row set behind a diverged counter: repair it (CAS on the
-    // value read above, so a concurrent register frame's increment is kept)
-    // and retry the freeze once.
-    await db
-        .prepare(
-            "UPDATE snapshots SET registered_count = ? " +
-                "WHERE snapshot_id = ? AND registered_count = ?",
-        )
-        .bind(registered, snapshot.snapshot_id, state?.registered_count ?? 0)
-        .run();
-    if (await freezeSnapshot(db, snapshot.snapshot_id, entryCount)) {
-        return {};
-    }
-    // The retry matched no row: a concurrent complete or register won the
-    // race in between. Report from a fresh read.
-    const final = await findSnapshot(db, serverId, snapshotHash);
-    if (final?.completed_at != null) {
-        if (final.entry_count === entryCount) {
-            return {};
-        }
-        throw new SyncFailure({ error: "Snapshot already complete" });
-    }
-    throw new SyncFailure({
-        error: "Snapshot incomplete",
-        expected: entryCount,
-        registered: final?.registered_count ?? registered,
-    });
 }
 
 async function handleSnapshot(
@@ -694,10 +267,8 @@ async function handleSnapshot(
 }
 
 // ---------------------------------------------------------------------------
-// Storage v3: folded per-family segments (migrations/0003_folded.sql).
+// Folded per-family segments (migrations/0003_folded.sql).
 // ---------------------------------------------------------------------------
-
-type SegmentLink = z.infer<typeof SegmentLinkSchema>;
 
 // Folded segment layout (mirrors bootstrap/data/d1/sync.py::fold_family and
 // the 0003_folded.sql comment): u32 count, then count x (i32 entry_id,
@@ -747,7 +318,7 @@ interface SegmentFrame {
 // hash, INSERT OR IGNORE, then resolve the database-local blob id (the row
 // may have pre-existed, so the id is read back rather than derived from the
 // insert result).
-async function handleSegment(
+async function handleContent(
     db: D1Database,
     frame: SegmentFrame,
 ): Promise<{ inserted: number; blob_id: number }> {
@@ -781,7 +352,7 @@ async function handleSegment(
     }
     const familyCode = FAMILY_CODES[frame.family];
     // The hash proves the content, not the metadata: the stored entry_count
-    // and first/last id range are trusted verbatim by freezeSnapshotSegments
+    // and first/last id range are trusted verbatim by freezeSnapshot
     // (SUM over entry_count) and prefetch's subset routing (find_segment
     // binary-searches the stored ranges). Parse the verified content's own
     // index and reject a frame whose metadata disagrees — INSERT OR IGNORE
@@ -845,9 +416,9 @@ async function handleSegment(
     return { inserted: inserted.meta.changes ?? 0, blob_id: row.blob_id };
 }
 
-// Same shape as v2 lookup, resolved against folded_blobs: segment hashes
-// not yet present in the family, plus the blob ids of the present ones.
-async function handleSegmentLookup(
+// Segment hashes not yet present in the family, plus the blob ids of the
+// present ones (resume support).
+async function handleLookup(
     db: D1Database,
     family: Family,
     contentHashes: string[],
@@ -879,29 +450,33 @@ async function handleSegmentLookup(
     return { ids, missing };
 }
 
-// Per-snapshot segment links. Freeze-guarded like v2 register (fast-path
-// check, per-statement EXISTS guard, completed_at probe in the final
-// batch), but maintains no counter: v3 completion verifies SUM(entry_count)
-// over the link join instead.
-async function handleSegmentRegister(
+// Per-snapshot segment links. Freeze-guarded (fast-path check, per-statement
+// EXISTS guard, completed_at probe in the final batch) and maintains no
+// counter: completion verifies SUM(entry_count) over the link join instead.
+async function handleRegister(
     db: D1Database,
     serverId: string,
     snapshotHash: string,
     segments: SegmentLink[],
 ): Promise<{ inserted: number }> {
     const snapshot = await ensureSnapshot(db, serverId, snapshotHash);
+    // Fast path only. The authoritative freeze check is the guard on every
+    // insert plus the completed_at probe in the final batch below. Register
+    // and complete handlers for the same snapshot are serialized in the
+    // Durable Object (runSerialized), but that is instance memory — these
+    // SQL guards are the backstop for any writer that bypasses it.
     if (snapshot.completed_at !== null) {
         throw new SyncFailure({ error: "Snapshot already complete" });
     }
 
     // Referential integrity: every referenced blob id must exist and belong
     // to the link's stated family. Within one frame, each blob id may be
-    // linked at most once per family: freezeSnapshotSegments sums
-    // entry_count once per link row, so a duplicated blob id would be
-    // double-counted (and enumerated twice by readers' catalogs). Reject
-    // before any insert so a bad frame writes nothing. Cross-frame replays
-    // are unaffected — they carry identical (family, seq, blob_id) rows,
-    // which the INSERT OR IGNORE below dedupes by primary key.
+    // linked at most once per family: freezeSnapshot sums entry_count once
+    // per link row, so a duplicated blob id would be double-counted (and
+    // enumerated twice by readers' catalogs). Reject before any insert so a
+    // bad frame writes nothing. Cross-frame replays are unaffected — they
+    // carry identical (family, seq, blob_id) rows, which the INSERT OR IGNORE
+    // below dedupes by primary key.
     const duplicates: { family: Family; blob_id: number }[] = [];
     const frameLinks = new Set<string>();
     const missing: { family: Family; blob_id: number }[] = [];
@@ -959,8 +534,11 @@ async function handleSegmentRegister(
             ]),
             snapshot.snapshot_id,
         ];
-        // Same freeze guard as v2 register: every insert is conditional on
-        // the snapshot not being frozen (see handleRegister).
+        // Every insert is conditional on the snapshot not being frozen:
+        // INSERT OR IGNORE alone would silently add rows to an already
+        // completed snapshot if a complete event won the race after the
+        // fast-path check above. (SQLite names the columns of a VALUES
+        // subquery column1..column4.)
         statements.push(
             db
                 .prepare(
@@ -974,9 +552,14 @@ async function handleSegmentRegister(
                 .bind(...binds),
         );
     }
-    // The final batch also probes completed_at, closing the race against a
-    // concurrent complete that bypassed the instance-level serialization
-    // (same argument as v2 register).
+    // The final batch also probes completed_at. A batch commits atomically,
+    // so a concurrent complete that bypassed the instance-level
+    // serialization either committed before it (the guards above inserted
+    // nothing and the probe observes the freeze, rejecting this frame) or
+    // runs after it (and counts these rows in its own atomic
+    // sum-and-freeze update). Registration and completion therefore cannot
+    // interleave into a frozen snapshot whose entry_count disagrees with its
+    // link set.
     const batches = chunked(statements, STATEMENTS_PER_BATCH);
     for (const [index, batch] of batches.entries()) {
         const isLast = index === batches.length - 1;
@@ -1001,13 +584,13 @@ async function handleSegmentRegister(
     return { inserted };
 }
 
-// The v3 freezing UPDATE: the count verification is SUM(folded_blobs.
+// The freezing UPDATE: the count verification is SUM(folded_blobs.
 // entry_count) over the snapshot's segment links — a ~64-row join, µs — not
 // a maintained counter, so there is no divergence/repair path at all. The
 // SUM, the not-yet-frozen check, and the marker write are one statement, so
 // a concurrent register frame that bypassed the instance-level serialization
 // can never slip links in between the verification and the freeze.
-async function freezeSnapshotSegments(
+async function freezeSnapshot(
     db: D1Database,
     snapshotId: number,
     entryCount: number,
@@ -1040,7 +623,7 @@ async function sumSegmentEntries(db: D1Database, snapshotId: number): Promise<nu
     return row?.n ?? 0;
 }
 
-async function handleSegmentComplete(
+async function handleComplete(
     db: D1Database,
     serverId: string,
     snapshotHash: string,
@@ -1063,13 +646,13 @@ async function handleSegmentComplete(
         throw new SyncFailure({ error: "Snapshot already complete" });
     }
 
-    if (await freezeSnapshotSegments(db, snapshot.snapshot_id, entryCount)) {
+    if (await freezeSnapshot(db, snapshot.snapshot_id, entryCount)) {
         return {};
     }
 
     // The conditional update matched no row: a concurrent complete won the
     // race, or the segment-link SUM genuinely differs. Re-read the registry
-    // row, then report the real SUM — no counter to repair (v3 keeps none).
+    // row, then report the real SUM — there is no counter to repair.
     const state = await findSnapshot(db, serverId, snapshotHash);
     if (state?.completed_at != null) {
         if (state.entry_count === entryCount) {
@@ -1086,18 +669,12 @@ async function handleSegmentComplete(
 }
 
 export class SyncSession extends DurableObject<Env> {
-    // Per-snapshot mutual exclusion between register and complete handlers
-    // (v2 and v3 share the lock keyspace: a snapshot is frozen once,
-    // whichever protocol freezes it). For v2 the freeze fast path trusts
-    // registered_count, which a register frame updates only after its
-    // insert batches commit; serializing the two handlers per snapshot
-    // guarantees no register frame is mid-flight when complete evaluates
-    // the counter (v3's SUM check benefits the same way). This is instance
+    // Per-snapshot mutual exclusion between register and complete handlers:
+    // serializing the two handlers per snapshot guarantees no register frame
+    // is mid-flight when complete evaluates the link SUM. This is instance
     // memory, so a restarted instance starts empty — safe, because an
-    // instance is never evicted while it is still processing a frame, and
-    // a crashed v2 register frame's divergence is repaired by the complete
-    // fallback's COUNT(*). The per-statement freeze guards remain the
-    // SQL-level backstop.
+    // instance is never evicted while it is still processing a frame. The
+    // per-statement freeze guards remain the SQL-level backstop.
     private readonly snapshotLocks = new Map<string, Promise<unknown>>();
 
     // Run `task` after every previously queued register/complete handler for
@@ -1159,7 +736,7 @@ export class SyncSession extends DurableObject<Env> {
             const reply: Record<string, unknown> = { id: msg.id, ok: true };
             switch (msg.type) {
                 case "content":
-                    Object.assign(reply, await handleContent(this.env.PLATFORM_DB, msg.entries));
+                    Object.assign(reply, await handleContent(this.env.PLATFORM_DB, msg));
                     break;
                 case "lookup":
                     Object.assign(
@@ -1175,7 +752,7 @@ export class SyncSession extends DurableObject<Env> {
                                 this.env.PLATFORM_DB,
                                 msg.server_id,
                                 msg.snapshot_hash,
-                                msg.entries,
+                                msg.segments,
                             ),
                         ),
                     );
@@ -1197,42 +774,6 @@ export class SyncSession extends DurableObject<Env> {
                             this.env.PLATFORM_DB,
                             msg.server_id,
                             msg.snapshot_hash,
-                        ),
-                    );
-                    break;
-                case "segment":
-                    Object.assign(reply, await handleSegment(this.env.PLATFORM_DB, msg));
-                    break;
-                case "segment_lookup":
-                    Object.assign(
-                        reply,
-                        await handleSegmentLookup(
-                            this.env.PLATFORM_DB,
-                            msg.family,
-                            msg.content_hashes,
-                        ),
-                    );
-                    break;
-                case "segment_register":
-                    Object.assign(
-                        reply,
-                        await this.runSerialized(`${msg.server_id}:${msg.snapshot_hash}`, () =>
-                            handleSegmentRegister(
-                                this.env.PLATFORM_DB,
-                                msg.server_id,
-                                msg.snapshot_hash,
-                                msg.segments,
-                            ),
-                        ),
-                    );
-                    break;
-                case "segment_complete":
-                    await this.runSerialized(`${msg.server_id}:${msg.snapshot_hash}`, () =>
-                        handleSegmentComplete(
-                            this.env.PLATFORM_DB,
-                            msg.server_id,
-                            msg.snapshot_hash,
-                            msg.entry_count,
                         ),
                     );
                     break;

--- a/worker/efa-platform-data-sync/test/index.test.ts
+++ b/worker/efa-platform-data-sync/test/index.test.ts
@@ -128,524 +128,8 @@ describe("frame validation", () => {
     });
 });
 
-describe("lookup", () => {
-    it("reports missing hashes and resolves ids for present rows", async () => {
-        const ws = await connect();
-        const content = new TextEncoder().encode("type-entry-1");
-        const contentHash = await sha256Hex(content);
-
-        const before = await call(ws, {
-            id: 1,
-            type: "lookup",
-            family: "types",
-            content_hashes: [contentHash],
-        });
-        expect(before).toEqual({ id: 1, ok: true, missing: [contentHash], ids: {} });
-
-        const upload = await call(ws, {
-            id: 2,
-            type: "content",
-            entries: [
-                { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
-            ],
-        });
-        const ids = upload.ids as Record<string, number>;
-        expect(ids[contentHash]).toBeGreaterThan(0);
-
-        const after = await call(ws, {
-            id: 3,
-            type: "lookup",
-            family: "types",
-            content_hashes: [contentHash, "00".repeat(32)],
-        });
-        expect(after).toEqual({
-            id: 3,
-            ok: true,
-            missing: ["00".repeat(32)],
-            ids: { [contentHash]: ids[contentHash] },
-        });
-
-        ws.close();
-    });
-});
-
-describe("snapshot freeze", () => {
-    it("rejects register after complete and keeps the registration set frozen", async () => {
-        const ws = await connect();
-        const serverId = "tranquility";
-        const snapshotHash = "ab".repeat(32);
-
-        const content = new TextEncoder().encode("type-entry-1");
-        const contentHash = await sha256Hex(content);
-
-        let reply = await call(ws, {
-            id: 1,
-            type: "content",
-            entries: [
-                { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
-            ],
-        });
-        expect(reply.id).toBe(1);
-        expect(reply.ok).toBe(true);
-        expect(reply.inserted).toBe(1);
-        const contentId = (reply.ids as Record<string, number>)[contentHash];
-        expect(contentId).toBeGreaterThan(0);
-
-        reply = await call(ws, {
-            id: 2,
-            type: "register",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
-        });
-        expect(reply).toEqual({ id: 2, ok: true, inserted: 1 });
-
-        reply = await call(ws, {
-            id: 3,
-            type: "complete",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entry_count: 1,
-        });
-        expect(reply).toEqual({ id: 3, ok: true });
-
-        reply = await call(ws, {
-            id: 4,
-            type: "register",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entries: [{ family: "types", entry_id: 2, content_id: contentId }],
-        });
-        expect(reply.id).toBe(4);
-        expect(reply.ok).toBe(false);
-        expect(reply.error).toBe("Snapshot already complete");
-
-        const regCount = await env.PLATFORM_DB.prepare(
-            "SELECT COUNT(*) AS n FROM snapshot_entries se " +
-                "JOIN snapshots s ON s.snapshot_id = se.snapshot_id " +
-                "WHERE s.server_id = ? AND s.snapshot_hash = ?",
-        )
-            .bind(serverId, hexToBlob(snapshotHash))
-            .first<{ n: number }>();
-        expect(regCount?.n).toBe(1);
-
-        // The snapshot probe agrees over both the WS frame and the public
-        // HTTP GET route.
-        reply = await call(ws, {
-            id: 5,
-            type: "snapshot",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-        });
-        expect(reply.id).toBe(5);
-        expect(reply.ok).toBe(true);
-        expect(reply.complete).toBe(true);
-        expect(reply.entry_count).toBe(1);
-
-        const res = await get(`/snapshot?server_id=${serverId}&snapshot_hash=${snapshotHash}`);
-        expect(res.status).toBe(200);
-        const snapshot = (await res.json()) as {
-            ok: boolean;
-            complete: boolean;
-            entry_count: number;
-        };
-        expect(snapshot.complete).toBe(true);
-        expect(snapshot.entry_count).toBe(1);
-
-        ws.close();
-    });
-
-    it("never freezes a snapshot whose entry_count disagrees with its rows", async () => {
-        // Regression test for the register/complete race: register and
-        // complete frames for the same snapshot are serialized in the
-        // Durable Object (runSerialized), and the per-statement freeze
-        // guards plus the counter check are the SQL-level backstop. The
-        // register frame below spans multiple D1 batches (2000 entries at
-        // 24 rows/statement over 50-statement batches), so without the
-        // serialization a complete event would have real windows to
-        // interleave. Whichever side runs first, the invariant must hold:
-        // a frozen snapshot's entry_count equals its actual registration
-        // row count.
-        const content = new TextEncoder().encode("type-entry-1");
-        const contentHash = await sha256Hex(content);
-
-        for (let round = 0; round < 5; round++) {
-            const ws1 = await connect();
-            const ws2 = await connect();
-            const serverId = "tranquility";
-            const snapshotHash = round.toString(16).padStart(2, "0").repeat(32);
-
-            const upload = await call(ws1, {
-                id: 1,
-                type: "content",
-                entries: [
-                    { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
-                ],
-            });
-            const contentId = (upload.ids as Record<string, number>)[contentHash];
-
-            const first = await call(ws1, {
-                id: 2,
-                type: "register",
-                server_id: serverId,
-                snapshot_hash: snapshotHash,
-                entries: [{ family: "types", entry_id: 1, content_id: contentId }],
-            });
-            expect(first).toEqual({ id: 2, ok: true, inserted: 1 });
-
-            // Fire both frames without awaiting so the two events interleave
-            // at their D1 awaits.
-            const [registerReply, completeReply] = await Promise.all([
-                call(ws1, {
-                    id: 3,
-                    type: "register",
-                    server_id: serverId,
-                    snapshot_hash: snapshotHash,
-                    entries: Array.from({ length: 2000 }, (_, i) => ({
-                        family: "types",
-                        entry_id: i + 2,
-                        content_id: contentId,
-                    })),
-                }),
-                call(ws2, {
-                    id: 4,
-                    type: "complete",
-                    server_id: serverId,
-                    snapshot_hash: snapshotHash,
-                    entry_count: 1,
-                }),
-            ]);
-
-            const regCount = await env.PLATFORM_DB.prepare(
-                "SELECT COUNT(*) AS n FROM snapshot_entries se " +
-                    "JOIN snapshots s ON s.snapshot_id = se.snapshot_id " +
-                    "WHERE s.server_id = ? AND s.snapshot_hash = ?",
-            )
-                .bind(serverId, hexToBlob(snapshotHash))
-                .first<{ n: number }>();
-
-            const probe = await call(ws1, {
-                id: 5,
-                type: "snapshot",
-                server_id: serverId,
-                snapshot_hash: snapshotHash,
-            });
-
-            if (completeReply.ok) {
-                // Completion won before any register batch committed: the
-                // freeze guards must have rejected every later insert.
-                expect(registerReply.ok).toBe(false);
-                expect(registerReply.error).toBe("Snapshot already complete");
-                expect(regCount?.n).toBe(1);
-                expect(probe.complete).toBe(true);
-                expect(probe.entry_count).toBe(1);
-            } else {
-                // The register committed rows the count check then saw, so
-                // completion must have failed instead of freezing a lie.
-                expect(completeReply.error).toBe("Snapshot incomplete");
-                expect(registerReply.ok).toBe(true);
-                expect(regCount?.n).toBe(2001);
-                expect(probe.complete).toBe(false);
-            }
-
-            ws1.close();
-            ws2.close();
-        }
-    });
-
-    it("reports pending (registered but not completed) snapshots as incomplete", async () => {
-        const ws = await connect();
-        const serverId = "tranquility";
-        const snapshotHash = "12".repeat(32);
-
-        const content = new TextEncoder().encode("type-entry-1");
-        const contentHash = await sha256Hex(content);
-        const upload = await call(ws, {
-            id: 1,
-            type: "content",
-            entries: [
-                { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
-            ],
-        });
-        const contentId = (upload.ids as Record<string, number>)[contentHash];
-
-        await call(ws, {
-            id: 2,
-            type: "register",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
-        });
-
-        const reply = await call(ws, {
-            id: 3,
-            type: "snapshot",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-        });
-        expect(reply).toEqual({ id: 3, ok: true, complete: false });
-
-        const res = await get(`/snapshot?server_id=${serverId}&snapshot_hash=${snapshotHash}`);
-        const snapshot = (await res.json()) as { complete: boolean };
-        expect(snapshot.complete).toBe(false);
-
-        ws.close();
-    });
-
-    it("rejects registration of unknown content ids", async () => {
-        const ws = await connect();
-        const reply = await call(ws, {
-            id: 1,
-            type: "register",
-            server_id: "tranquility",
-            snapshot_hash: "cd".repeat(32),
-            entries: [{ family: "types", entry_id: 1, content_id: 424242 }],
-        });
-        expect(reply.id).toBe(1);
-        expect(reply.ok).toBe(false);
-        expect(reply.error).toBe("Unknown content ids");
-        ws.close();
-    });
-});
-
-describe("registration counter", () => {
-    async function snapshotRow(
-        serverId: string,
-        snapshotHash: string,
-    ): Promise<{
-        snapshot_id: number;
-        entry_count: number | null;
-        completed_at: string | null;
-        registered_count: number;
-    } | null> {
-        return await env.PLATFORM_DB.prepare(
-            "SELECT snapshot_id, entry_count, completed_at, registered_count FROM snapshots " +
-                "WHERE server_id = ? AND snapshot_hash = ?",
-        )
-            .bind(serverId, hexToBlob(snapshotHash))
-            .first<{
-                snapshot_id: number;
-                entry_count: number | null;
-                completed_at: string | null;
-                registered_count: number;
-            }>();
-    }
-
-    async function uploadType(ws: WebSocket, id: number, label: string): Promise<number> {
-        const content = new TextEncoder().encode(label);
-        const contentHash = await sha256Hex(content);
-        const reply = await call(ws, {
-            id,
-            type: "content",
-            entries: [
-                { family: "types", content_hash: contentHash, content_b64: toBase64(content) },
-            ],
-        });
-        expect(reply.ok).toBe(true);
-        return (reply.ids as Record<string, number>)[contentHash];
-    }
-
-    it("tracks registrations across frames and freezes via the counter", async () => {
-        const ws = await connect();
-        const serverId = "tranquility";
-        const snapshotHash = "aa".repeat(32);
-        const contentId = await uploadType(ws, 1, "type-entry-1");
-
-        for (let frame = 0; frame < 3; frame++) {
-            const reply = await call(ws, {
-                id: 10 + frame,
-                type: "register",
-                server_id: serverId,
-                snapshot_hash: snapshotHash,
-                entries: [{ family: "types", entry_id: frame + 1, content_id: contentId }],
-            });
-            expect(reply).toEqual({ id: 10 + frame, ok: true, inserted: 1 });
-        }
-        expect((await snapshotRow(serverId, snapshotHash))?.registered_count).toBe(3);
-
-        const complete = await call(ws, {
-            id: 20,
-            type: "complete",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entry_count: 3,
-        });
-        expect(complete).toEqual({ id: 20, ok: true });
-
-        const row = await snapshotRow(serverId, snapshotHash);
-        expect(row?.completed_at).not.toBeNull();
-        expect(row?.entry_count).toBe(3);
-        ws.close();
-    });
-
-    it("does not inflate the counter on re-sent register frames", async () => {
-        const ws = await connect();
-        const serverId = "tranquility";
-        const snapshotHash = "bb".repeat(32);
-        const contentId = await uploadType(ws, 1, "type-entry-1");
-
-        const frame = {
-            type: "register",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
-        };
-        expect(await call(ws, { id: 2, ...frame })).toEqual({ id: 2, ok: true, inserted: 1 });
-        // Idempotent re-send (lost reply): all rows conflict, so the counter
-        // must stay at 1.
-        expect(await call(ws, { id: 3, ...frame })).toEqual({ id: 3, ok: true, inserted: 0 });
-        expect((await snapshotRow(serverId, snapshotHash))?.registered_count).toBe(1);
-
-        const complete = await call(ws, {
-            id: 4,
-            type: "complete",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entry_count: 1,
-        });
-        expect(complete).toEqual({ id: 4, ok: true });
-        ws.close();
-    });
-
-    it("repairs a diverged counter before freezing", async () => {
-        const ws = await connect();
-        const serverId = "tranquility";
-        const snapshotHash = "cc".repeat(32);
-        const contentId = await uploadType(ws, 1, "type-entry-1");
-
-        const register = await call(ws, {
-            id: 2,
-            type: "register",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
-        });
-        expect(register).toEqual({ id: 2, ok: true, inserted: 1 });
-
-        // Simulate a crash between a register frame's inserts and its
-        // counter update: the row exists but registered_count does not
-        // reflect it (also the state of a pre-0002 pending snapshot).
-        const row = await snapshotRow(serverId, snapshotHash);
-        await env.PLATFORM_DB.prepare(
-            "INSERT INTO snapshot_entries (snapshot_id, family, entry_id, content_id) " +
-                "VALUES (?, 0, 2, ?)",
-        )
-            .bind(row?.snapshot_id, contentId)
-            .run();
-        expect((await snapshotRow(serverId, snapshotHash))?.registered_count).toBe(1);
-
-        const complete = await call(ws, {
-            id: 3,
-            type: "complete",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entry_count: 2,
-        });
-        expect(complete).toEqual({ id: 3, ok: true });
-
-        const repaired = await snapshotRow(serverId, snapshotHash);
-        expect(repaired?.completed_at).not.toBeNull();
-        expect(repaired?.entry_count).toBe(2);
-        expect(repaired?.registered_count).toBe(2);
-        ws.close();
-    });
-
-    it("reports a genuinely incomplete snapshot with the real row count", async () => {
-        const ws = await connect();
-        const serverId = "tranquility";
-        const snapshotHash = "dd".repeat(32);
-        const contentId = await uploadType(ws, 1, "type-entry-1");
-
-        await call(ws, {
-            id: 2,
-            type: "register",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entries: [{ family: "types", entry_id: 1, content_id: contentId }],
-        });
-        const row = await snapshotRow(serverId, snapshotHash);
-        await env.PLATFORM_DB.prepare(
-            "INSERT INTO snapshot_entries (snapshot_id, family, entry_id, content_id) " +
-                "VALUES (?, 0, 2, ?)",
-        )
-            .bind(row?.snapshot_id, contentId)
-            .run();
-
-        // Counter says 1, the uploader claims 3, the truth is 2: the error
-        // must report the real row count, and the snapshot stays pending.
-        const reply = await call(ws, {
-            id: 3,
-            type: "complete",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entry_count: 3,
-        });
-        expect(reply.id).toBe(3);
-        expect(reply.ok).toBe(false);
-        expect(reply.error).toBe("Snapshot incomplete");
-        expect(reply.registered).toBe(2);
-        expect((await snapshotRow(serverId, snapshotHash))?.completed_at).toBeNull();
-        ws.close();
-    });
-});
-
-describe("entry_id validation", () => {
-    it("accepts negative entry IDs used by engine-internal pseudo entries", async () => {
-        const ws = await connect();
-        const serverId = "tranquility";
-        const snapshotHash = "cd".repeat(32);
-
-        const content = new TextEncoder().encode("pseudo-effect");
-        const contentHash = await sha256Hex(content);
-
-        let reply = await call(ws, {
-            id: 1,
-            type: "content",
-            entries: [
-                {
-                    family: "dogma_effects",
-                    content_hash: contentHash,
-                    content_b64: toBase64(content),
-                },
-            ],
-        });
-        expect(reply.id).toBe(1);
-        expect(reply.ok).toBe(true);
-        expect(reply.inserted).toBe(1);
-        const contentId = (reply.ids as Record<string, number>)[contentHash];
-
-        reply = await call(ws, {
-            id: 2,
-            type: "register",
-            server_id: serverId,
-            snapshot_hash: snapshotHash,
-            entries: [{ family: "dogma_effects", entry_id: -64, content_id: contentId }],
-        });
-        expect(reply).toEqual({ id: 2, ok: true, inserted: 1 });
-
-        ws.close();
-    });
-
-    it("rejects entry IDs outside the int32 range", async () => {
-        const ws = await connect();
-        for (const entryId of [-2147483649, 2147483648]) {
-            const reply = await call(ws, {
-                id: 1,
-                type: "register",
-                server_id: "tranquility",
-                snapshot_hash: "ef".repeat(32),
-                entries: [{ family: "types", entry_id: entryId, content_id: 1 }],
-            });
-            expect(reply.id).toBe(1);
-            expect(reply.ok).toBe(false);
-            expect(reply.error).toBe("Validation failed");
-        }
-        ws.close();
-    });
-});
-
 // ---------------------------------------------------------------------------
-// Storage v3: folded per-family segments (migrations/0003_folded.sql).
+// Folded per-family segments (migrations/0003_folded.sql).
 // ---------------------------------------------------------------------------
 
 const SEGMENT_MAX = 512 * 1024;
@@ -707,7 +191,7 @@ async function uploadSegment(
 ): Promise<{ blobId: number; inserted: number }> {
     const reply = await call(ws, {
         id,
-        type: "segment",
+        type: "content",
         family,
         content_hash: segment.hash,
         entry_count: segment.entries.length,
@@ -735,7 +219,7 @@ async function linkStats(
         .first<{ links: number; entries: number }>();
 }
 
-describe("v3 segment content", () => {
+describe("segment content", () => {
     it("verifies hashes, resolves blob ids, and converges on rerun", async () => {
         const ws = await connect();
         const [segment] = await foldSegments([
@@ -745,7 +229,7 @@ describe("v3 segment content", () => {
 
         const before = await call(ws, {
             id: 1,
-            type: "segment_lookup",
+            type: "lookup",
             family: "types",
             content_hashes: [segment.hash],
         });
@@ -757,7 +241,7 @@ describe("v3 segment content", () => {
 
         const after = await call(ws, {
             id: 3,
-            type: "segment_lookup",
+            type: "lookup",
             family: "types",
             content_hashes: [segment.hash, "00".repeat(32)],
         });
@@ -783,7 +267,7 @@ describe("v3 segment content", () => {
         ]);
         const reply = await call(ws, {
             id: 1,
-            type: "segment",
+            type: "content",
             family: "types",
             content_hash: "00".repeat(32),
             entry_count: 1,
@@ -813,7 +297,7 @@ describe("v3 segment content", () => {
         ]) {
             const reply = await call(ws, {
                 id: 1,
-                type: "segment",
+                type: "content",
                 family: "types",
                 content_hash: segment.hash,
                 ...metadata,
@@ -839,7 +323,7 @@ describe("v3 segment content", () => {
         new DataView(bytes.buffer).setUint32(0, 2, true);
         const reply = await call(ws, {
             id: 1,
-            type: "segment",
+            type: "content",
             family: "types",
             content_hash: await sha256Hex(bytes),
             entry_count: 2,
@@ -885,7 +369,7 @@ describe("v3 segment content", () => {
             const hash = await sha256Hex(bytes);
             const reply = await call(ws, {
                 id: 1,
-                type: "segment",
+                type: "content",
                 family: "types",
                 content_hash: hash,
                 entry_count: ids.length,
@@ -914,7 +398,7 @@ describe("v3 segment content", () => {
         const ws = await connect();
         const reply = await call(ws, {
             id: 1,
-            type: "segment",
+            type: "content",
             family: "types",
             content_hash: "00".repeat(32),
             entry_count: 1,
@@ -934,7 +418,7 @@ describe("v3 segment content", () => {
         for (const entryId of [-2147483649, 2147483648]) {
             const reply = await call(ws, {
                 id: 1,
-                type: "segment",
+                type: "content",
                 family: "types",
                 content_hash: "00".repeat(32),
                 entry_count: 1,
@@ -950,8 +434,8 @@ describe("v3 segment content", () => {
     });
 });
 
-describe("v3 snapshot freeze", () => {
-    it("rejects segment_register after segment_complete and keeps the links frozen", async () => {
+describe("snapshot freeze", () => {
+    it("rejects register after complete and keeps the links frozen", async () => {
         const ws = await connect();
         const serverId = "tranquility";
         const snapshotHash = "ab".repeat(32);
@@ -966,7 +450,7 @@ describe("v3 snapshot freeze", () => {
 
         let reply = await call(ws, {
             id: 2,
-            type: "segment_register",
+            type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             segments: [{ family: "types", seq: 0, blob_id: blobId }],
@@ -975,7 +459,7 @@ describe("v3 snapshot freeze", () => {
 
         reply = await call(ws, {
             id: 3,
-            type: "segment_complete",
+            type: "complete",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             entry_count: 3,
@@ -985,7 +469,7 @@ describe("v3 snapshot freeze", () => {
         // Idempotent retry of the same complete frame (lost reply).
         reply = await call(ws, {
             id: 4,
-            type: "segment_complete",
+            type: "complete",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             entry_count: 3,
@@ -994,7 +478,7 @@ describe("v3 snapshot freeze", () => {
 
         reply = await call(ws, {
             id: 5,
-            type: "segment_register",
+            type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             segments: [{ family: "types", seq: 1, blob_id: blobId }],
@@ -1030,7 +514,7 @@ describe("v3 snapshot freeze", () => {
         const { blobId } = await uploadSegment(ws, 1, "types", segment);
         await call(ws, {
             id: 2,
-            type: "segment_register",
+            type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             segments: [{ family: "types", seq: 0, blob_id: blobId }],
@@ -1040,7 +524,7 @@ describe("v3 snapshot freeze", () => {
         // and the snapshot stays pending.
         const failed = await call(ws, {
             id: 3,
-            type: "segment_complete",
+            type: "complete",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             entry_count: 3,
@@ -1061,7 +545,7 @@ describe("v3 snapshot freeze", () => {
         // The corrected claim freezes.
         const complete = await call(ws, {
             id: 5,
-            type: "segment_complete",
+            type: "complete",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             entry_count: 2,
@@ -1074,7 +558,7 @@ describe("v3 snapshot freeze", () => {
         const ws = await connect();
         const reply = await call(ws, {
             id: 1,
-            type: "segment_register",
+            type: "register",
             server_id: "tranquility",
             snapshot_hash: "ef".repeat(32),
             segments: [{ family: "types", seq: 0, blob_id: 424242 }],
@@ -1101,7 +585,7 @@ describe("v3 snapshot freeze", () => {
         // catalogs; the frame is rejected before writing anything.
         let reply = await call(ws, {
             id: 2,
-            type: "segment_register",
+            type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             segments: [
@@ -1119,7 +603,7 @@ describe("v3 snapshot freeze", () => {
         // identical frame stays idempotent (primary-key dedup).
         reply = await call(ws, {
             id: 3,
-            type: "segment_register",
+            type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             segments: [{ family: "types", seq: 0, blob_id: blobId }],
@@ -1127,7 +611,7 @@ describe("v3 snapshot freeze", () => {
         expect(reply).toEqual({ id: 3, ok: true, inserted: 1 });
         reply = await call(ws, {
             id: 4,
-            type: "segment_register",
+            type: "register",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             segments: [{ family: "types", seq: 0, blob_id: blobId }],
@@ -1137,7 +621,7 @@ describe("v3 snapshot freeze", () => {
         // The happy path still freezes at the real entry count.
         reply = await call(ws, {
             id: 5,
-            type: "segment_complete",
+            type: "complete",
             server_id: serverId,
             snapshot_hash: snapshotHash,
             entry_count: 2,
@@ -1148,9 +632,12 @@ describe("v3 snapshot freeze", () => {
     });
 
     it("never freezes mid-registration even when register and complete race", async () => {
-        // Port of the v2 register/complete race regression test to the v3
-        // frames: whichever side runs first, a frozen snapshot's entry_count
-        // must equal its actual segment-link SUM.
+        // Register/complete race regression test: register and complete
+        // frames for the same snapshot are serialized in the Durable Object
+        // (runSerialized), and the per-statement freeze guards plus the SUM
+        // check are the SQL-level backstop. Whichever side runs first, a
+        // frozen snapshot's entry_count must equal its actual segment-link
+        // SUM.
         for (let round = 0; round < 5; round++) {
             const ws1 = await connect();
             const ws2 = await connect();
@@ -1175,7 +662,7 @@ describe("v3 snapshot freeze", () => {
 
             const first = await call(ws1, {
                 id: 1,
-                type: "segment_register",
+                type: "register",
                 server_id: serverId,
                 snapshot_hash: snapshotHash,
                 segments: [{ family: "types", seq: 0, blob_id: blobIds[0] }],
@@ -1187,7 +674,7 @@ describe("v3 snapshot freeze", () => {
             const [registerReply, completeReply] = await Promise.all([
                 call(ws1, {
                     id: 2,
-                    type: "segment_register",
+                    type: "register",
                     server_id: serverId,
                     snapshot_hash: snapshotHash,
                     segments: segments.slice(1).map((_, i) => ({
@@ -1198,7 +685,7 @@ describe("v3 snapshot freeze", () => {
                 }),
                 call(ws2, {
                     id: 3,
-                    type: "segment_complete",
+                    type: "complete",
                     server_id: serverId,
                     snapshot_hash: snapshotHash,
                     entry_count: firstCount,

--- a/worker/efa-platform-fit-storage/README.md
+++ b/worker/efa-platform-fit-storage/README.md
@@ -59,15 +59,12 @@ Error responses are JSON `{ "error": <code>, "message": <string> }` (+ an
   (populated by `worker/efa-platform-data-sync`), addressed by the
   client-supplied `(server_id, snapshot_hash)`. The selector is resolved to
   the registry's `snapshot_id` (requiring `completed_at IS NOT NULL`, cached
-  per isolate). Storage v3 stores each family as folded ≤512 KiB segments
+  per isolate). Each family is stored as folded ≤512 KiB segments
   (`folded_blobs` ⋈ `snapshot_family_segments`): subset reads route entry ids
   through the segment catalog's `[first_entry_id, last_entry_id]` ranges and
   binary-search the segment index; whole families fetch all segments. Raw
   segments (content-addressed, shared across snapshots) and per-family
-  catalogs are cached in the isolate. Snapshots registered before v3 are
-  served by the legacy per-entry join (`snapshot_entries` ⋈ `entries`) via a
-  per-snapshot dual-read probe (v3 catalog first, v2 fallback, decision
-  cached per isolate — zero-downtime cutover, instant rollback). A 3-round
+  catalogs are cached in the isolate. A 3-round
   transitive-closure prefetch (`src/prefetch.rs`) loads exactly the
   reachable rows; a `thread_local!` isolate cache makes warm requests
   zero-query.

--- a/worker/efa-platform-fit-storage/src/d1.rs
+++ b/worker/efa-platform-fit-storage/src/d1.rs
@@ -3,10 +3,6 @@ use worker::wasm_bindgen::JsCast;
 use worker::{js_sys, wasm_bindgen::JsValue};
 
 use crate::error::ApiError;
-use crate::prefetch::FetchRequest;
-
-/// D1's bound-parameter limit is 100; reserve 2 for snapshot_id/family.
-const MAX_ENTRY_IDS_PER_CHUNK: usize = 98;
 
 /// Segment-content chunk fetches bind blob ids only.
 const MAX_BLOB_IDS_PER_CHUNK: usize = 100;
@@ -117,72 +113,14 @@ async fn run_change_count(
     Ok(changes)
 }
 
-/// Chunked family lookup (spec §7.2). `ids == None` fetches the whole family.
-///
-/// This is the v2 read path (per-entry `snapshot_entries` ⋈ `entries` join),
-/// kept as the dual-read fallback for snapshots registered before storage v3;
-/// the v3 folded-segment path lives in `prefetch::fetch_family`.
-pub async fn fetch_family(
-    db: &D1Database,
-    snapshot_id: i64,
-    request: FetchRequest,
-) -> anyhow::Result<Vec<(i32, Vec<u8>)>> {
-    let family = request.family;
-    let family_code = family.code();
-    let mut out = Vec::new();
-
-    match request.ids {
-        None => {
-            let sql = "SELECT se.entry_id, e.content FROM snapshot_entries se \
-                 JOIN entries e ON e.content_id = se.content_id \
-                 WHERE se.snapshot_id = ? AND se.family = ?";
-            let rows = raw_query(db, sql, &[js_int(snapshot_id), js_int(family_code)]).await?;
-            for row in &rows {
-                out.push((row_int(row, 0)?, row_blob(row, 1)?));
-            }
-        }
-        Some(ids) => {
-            for chunk in ids.chunks(MAX_ENTRY_IDS_PER_CHUNK) {
-                let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-                let sql = format!(
-                    "SELECT se.entry_id, e.content FROM snapshot_entries se \
-                     JOIN entries e ON e.content_id = se.content_id \
-                     WHERE se.snapshot_id = ? AND se.family = ? \
-                     AND se.entry_id IN ({placeholders})"
-                );
-                let mut params = vec![js_int(snapshot_id), js_int(family_code)];
-                params.extend(chunk.iter().map(|id| js_int(*id as i64)));
-                let rows = raw_query(db, &sql, &params).await?;
-                for row in &rows {
-                    out.push((row_int(row, 0)?, row_blob(row, 1)?));
-                }
-            }
-        }
-    }
-    Ok(out)
-}
-
-/// One segment of a snapshot's folded family stream (storage v3,
-/// `snapshot_family_segments` ⋈ `folded_blobs`): the blob id plus the
+/// One segment of a snapshot's folded family stream
+/// (`snapshot_family_segments` ⋈ `folded_blobs`): the blob id plus the
 /// segment's entry-id range for subset routing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CatalogEntry {
     pub blob_id: i64,
     pub first_entry_id: i32,
     pub last_entry_id: i32,
-}
-
-/// Whether the snapshot has any v3 segment links — the dual-read layout
-/// probe. Snapshots are frozen at completion, so the answer never changes
-/// and is cached per isolate by the caller.
-pub async fn snapshot_has_segments(db: &D1Database, snapshot_id: i64) -> Result<bool, ApiError> {
-    let rows = raw_query(
-        db,
-        "SELECT 1 FROM snapshot_family_segments WHERE snapshot_id = ? LIMIT 1",
-        &[js_int(snapshot_id)],
-    )
-    .await?;
-    Ok(!rows.is_empty())
 }
 
 /// The ordered segment catalog of one (snapshot, family): blob ids and

--- a/worker/efa-platform-fit-storage/src/prefetch.rs
+++ b/worker/efa-platform-fit-storage/src/prefetch.rs
@@ -35,7 +35,7 @@ const fn flatten_buff_pairs(pairs: [(i32, i32); 4]) -> [i32; 8] {
 /// Isolate-cache key: the engine data snapshot selector.
 pub type SnapshotKey = (String, String);
 
-/// Isolate-cache entry for a v3 segment catalog, keyed by
+/// Isolate-cache entry for a segment catalog, keyed by
 /// `(snapshot_id, family code)`.
 type CatalogCache = HashMap<(i64, i64), Rc<Vec<CatalogEntry>>>;
 
@@ -131,14 +131,11 @@ thread_local! {
     // per isolate instead of one per request.
     static SNAPSHOT_IDS: std::cell::RefCell<HashMap<SnapshotKey, i64>> =
         std::cell::RefCell::new(HashMap::new());
-    // v3 dual-read layout decision per snapshot registry id (true = folded
-    // segments). Snapshots are frozen at completion, so this never changes.
-    static LAYOUTS: std::cell::RefCell<HashMap<i64, bool>> =
-        std::cell::RefCell::new(HashMap::new());
-    // v3 segment catalogs per (snapshot_id, family code), in stream order.
+    // Segment catalogs per (snapshot_id, family code), in stream order.
+    // Frozen at snapshot completion.
     static CATALOGS: std::cell::RefCell<CatalogCache> =
         std::cell::RefCell::new(HashMap::new());
-    // v3 raw segment bytes by blob id. Segments are content-addressed and
+    // Raw segment bytes by blob id. Segments are content-addressed and
     // shared verbatim across snapshots, so this cache is global, not keyed
     // by snapshot. Sits under the decoded-entry cache: a warm segment cache
     // hit skips the D1 round trip but still decodes the wanted entries.
@@ -187,27 +184,16 @@ pub struct FetchRequest {
 }
 
 // ---------------------------------------------------------------------------
-// Storage v3: folded per-family segments (migrations/0003_folded.sql).
+// Folded per-family segments (migrations/0003_folded.sql).
 //
 // Segment format (self-contained, entries sorted by entry id):
 //   u32 count
 //   count x { i32 entry_id, u32 offset, u32 length }  -- offset from segment
-//   payload bytes (concatenated per-entry protobufs, byte-identical to the
-//   v2 entries.content payloads, so the decode path is untouched)
+//   payload bytes (concatenated per-entry protobufs)
 // ---------------------------------------------------------------------------
 
 const SEGMENT_HEADER_BYTES: usize = 4;
 const SEGMENT_INDEX_ENTRY_BYTES: usize = 12;
-
-fn layout_get(snapshot_id: i64) -> Option<bool> {
-    LAYOUTS.with(|layouts| layouts.borrow().get(&snapshot_id).copied())
-}
-
-fn layout_put(snapshot_id: i64, folded: bool) {
-    LAYOUTS.with(|layouts| {
-        layouts.borrow_mut().insert(snapshot_id, folded);
-    });
-}
 
 fn catalog_get(snapshot_id: i64, family_code: i64) -> Option<Rc<Vec<CatalogEntry>>> {
     CATALOGS.with(|catalogs| catalogs.borrow().get(&(snapshot_id, family_code)).cloned())
@@ -319,29 +305,15 @@ pub fn find_segment(catalog: &[CatalogEntry], id: i32) -> Option<usize> {
     (entry.first_entry_id <= id).then_some(i)
 }
 
-/// Family fetch with the v3 dual-read transition: probe the segment catalog
-/// first (decision cached per snapshot per isolate), fall back to the v2
-/// per-entry join for snapshots registered before storage v3. On the v3 path
-/// the catalog is cached per (snapshot, family) and raw segments per blob id
-/// — both are frozen at snapshot completion — so warm requests slice payloads
-/// straight from the isolate cache.
+/// Family fetch over folded segments: the catalog is cached per
+/// (snapshot, family) and raw segments per blob id — both are frozen at
+/// snapshot completion — so warm requests slice payloads straight from the
+/// isolate cache.
 pub async fn fetch_family(
     db: &D1Database,
     snapshot_id: i64,
     request: FetchRequest,
 ) -> anyhow::Result<Vec<(i32, Vec<u8>)>> {
-    let folded = match layout_get(snapshot_id) {
-        Some(folded) => folded,
-        None => {
-            let folded = d1::snapshot_has_segments(db, snapshot_id).await?;
-            layout_put(snapshot_id, folded);
-            folded
-        }
-    };
-    if !folded {
-        return d1::fetch_family(db, snapshot_id, request).await;
-    }
-
     let family_code = request.family.code();
     let catalog = match catalog_get(snapshot_id, family_code) {
         Some(catalog) => catalog,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Unified data synchronization around folded family segments using the `content`, `lookup`, `register`, and `complete` operations.
  - Snapshot completion now validates segment-linked entry totals directly.
  - Snapshot retrieval now uses the folded-segment storage path exclusively.

- **Migration**
  - Removed legacy per-entry storage, compatibility fallback reads, and obsolete synchronization operations.
  - Added a database migration to remove legacy tables and the retired snapshot counter.

- **Documentation**
  - Updated synchronization and storage documentation to describe the current folded-segment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->