### PR TITLE
feat(fit): enumerate booster picker from slot metadata instead of market tree

### DIFF
--- a/apps/eve-fit-assistant/l10n/app_en.arb
+++ b/apps/eve-fit-assistant/l10n/app_en.arb
@@ -383,6 +383,7 @@
   "fitSkillPolicyUnsupportedDescription": "Fits are simulated without character skill modifiers. Implants and boosters still apply.",
   "fitAddItemDialogTitle": "Add Item: {slotName}",
   "fitAddItemDialogTitleWithIndex": "Add Item: {slotName} #{index}",
+  "fitBoosterFamilyOther": "Other",
   "fitImplantSetDialogTitle": "Apply Implant Set",
   "fitSlotEmpty": "{slotName} (Empty)",
   "fitActionFill": "Fill",

--- a/apps/eve-fit-assistant/l10n/app_zh.arb
+++ b/apps/eve-fit-assistant/l10n/app_zh.arb
@@ -862,6 +862,7 @@
     }
   },
   "fitImplantSetDialogTitle": "应用植入体套装",
+  "fitBoosterFamilyOther": "其他",
   "fitSlotEmpty": "{slotName}（空）",
   "@fitSlotEmpty": {
     "placeholders": {

--- a/apps/eve-fit-assistant/lib/pages/fit/components/booster_select_list.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/components/booster_select_list.dart
@@ -63,13 +63,20 @@ List<BoosterSlotSection> buildBoosterSlotSections({
   required String otherLabel,
   int? slotFilter,
 }) {
-  final eligible = <int, int>{}; // typeId -> slotIndex
+  // Hierarchy decisions (subtree slot sets, section groups) must see every
+  // published slot: filtering first would let a lone slot claim aggregate
+  // groups like "Booster" as its section. The slot filter applies only when
+  // constructing the visible section contents below.
+  final publishedSlots = <int, int>{}; // typeId -> slotIndex
   for (final entry in boosterSlots.entries) {
     final typeId = entry.key;
-    final slotIndex = entry.value.slotIndex;
-    if (slotFilter != null && slotIndex != slotFilter) continue;
     if (typeOf(typeId)?.published != true) continue;
-    eligible[typeId] = slotIndex;
+    publishedSlots[typeId] = entry.value.slotIndex;
+  }
+  final visible = <int, int>{};
+  for (final entry in publishedSlots.entries) {
+    if (slotFilter != null && entry.value != slotFilter) continue;
+    visible[entry.key] = entry.value;
   }
 
   final groupsById = {for (final group in marketGroups) group.marketGroupId: group};
@@ -82,7 +89,7 @@ List<BoosterSlotSection> buildBoosterSlotSections({
     final seen = (visiting ?? {})..add(groupId);
     final slots = <int>{};
     for (final typeId in group.types) {
-      final slot = eligible[typeId];
+      final slot = publishedSlots[typeId];
       if (slot != null) slots.add(slot);
     }
     for (final childId in group.groups) {
@@ -141,7 +148,7 @@ List<BoosterSlotSection> buildBoosterSlotSections({
   String nameOf(pb_market.MarketGroup group) => names[group.marketGroupName.id] ?? "";
   final sections = <BoosterSlotSection>[];
   final bySlotIndex = <int, List<int>>{};
-  for (final entry in eligible.entries) {
+  for (final entry in visible.entries) {
     bySlotIndex.putIfAbsent(entry.value, () => []).add(entry.key);
   }
 

--- a/apps/eve-fit-assistant/lib/pages/fit/components/booster_select_list.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/components/booster_select_list.dart
@@ -1,0 +1,356 @@
+import "package:efa_constant/eve.dart";
+import "package:efa_proto/fit.pb.dart";
+import "package:efa_proto/market_groups.pb.dart" as pb_market;
+import "package:efa_proto/types.pb.dart" as pb_types;
+import "package:efa_proto/utils.pb.dart" as pb_utils;
+import "package:eve_fit_assistant/components/dialog/dialog.dart";
+import "package:eve_fit_assistant/components/icon/eve_icon.dart";
+import "package:eve_fit_assistant/components/list/eve_list_tile.dart";
+import "package:eve_fit_assistant/components/list/select_list.dart";
+import "package:eve_fit_assistant/constant/assets.dart";
+import "package:eve_fit_assistant/pages/item-detail/page.dart";
+import "package:eve_fit_assistant/storage/repo/collection.dart";
+import "package:eve_fit_assistant/storage/repo/localization_db.dart";
+import "package:eve_fit_assistant/storage/setting/setting.dart";
+import "package:eve_fit_assistant/utils/context.dart";
+import "package:eve_fit_assistant/utils/type_sort.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+/// One family bucket inside a booster slot section: the types sharing a leaf
+/// market group, or the catch-all "Other" bucket for types without one.
+class BoosterFamilyGroup {
+  const BoosterFamilyGroup({required this.label, required this.typeIds, this.icon});
+
+  final String label;
+  final List<int> typeIds;
+  final pb_utils.Icon? icon;
+}
+
+/// One booster slot section of the picker: every published type carrying this
+/// booster slot, subdivided into market-group families where available.
+class BoosterSlotSection {
+  const BoosterSlotSection({
+    required this.slotIndex,
+    required this.label,
+    required this.families,
+    this.icon,
+  });
+
+  final int slotIndex;
+  final String label;
+  final List<BoosterFamilyGroup> families;
+  final pb_utils.Icon? icon;
+}
+
+/// Assembles the booster picker content from slot metadata instead of the
+/// market tree: many boosters (Serenity harvest doses, cerebral accelerators,
+/// event items) carry a booster slot but sit outside the Boosters market
+/// group — or any market group at all — so a market-tree picker can never
+/// show them.
+///
+/// [names] maps localization ids (market group names) to resolved strings.
+/// Market groups serve only as *labels*: a section takes its name/icon from
+/// the topmost market group whose published booster subtree shares exactly
+/// its slot; families take leaf group names, everything else falls into a
+/// trailing "Other" bucket.
+List<BoosterSlotSection> buildBoosterSlotSections({
+  required Map<int, Slots_BoosterSlot> boosterSlots,
+  required pb_types.Type? Function(int typeId) typeOf,
+  required Iterable<pb_market.MarketGroup> marketGroups,
+  required Map<int, String> names,
+  required String Function(int slotIndex) slotFallbackLabel,
+  required String otherLabel,
+  int? slotFilter,
+}) {
+  final eligible = <int, int>{}; // typeId -> slotIndex
+  for (final entry in boosterSlots.entries) {
+    final typeId = entry.key;
+    final slotIndex = entry.value.slotIndex;
+    if (slotFilter != null && slotIndex != slotFilter) continue;
+    if (typeOf(typeId)?.published != true) continue;
+    eligible[typeId] = slotIndex;
+  }
+
+  final groupsById = {for (final group in marketGroups) group.marketGroupId: group};
+  final subtreeSlotSets = <int, Set<int>>{};
+  Set<int> subtreeSlotSetOf(int groupId, [Set<int>? visiting]) {
+    final cached = subtreeSlotSets[groupId];
+    if (cached != null) return cached;
+    final group = groupsById[groupId];
+    if (group == null) return const {};
+    final seen = (visiting ?? {})..add(groupId);
+    final slots = <int>{};
+    for (final typeId in group.types) {
+      final slot = eligible[typeId];
+      if (slot != null) slots.add(slot);
+    }
+    for (final childId in group.groups) {
+      if (seen.contains(childId)) continue;
+      slots.addAll(subtreeSlotSetOf(childId, seen));
+    }
+    if (visiting == null) subtreeSlotSets[groupId] = slots;
+    return slots;
+  }
+
+  // Section label candidate for a slot: the shallowest market group below the
+  // booster root's parent ("Implants & Boosters") whose published booster
+  // subtree occupies exactly that slot — e.g. the "Booster Slot 01" branch or
+  // the "Cerebral Accelerators" sibling, never the aggregate roots and never
+  // a single-family leaf like "Blue Pill".
+  final groupDepths = <int, int>{};
+  final boosterRoot = groupsById[EveConstMarketGroupId.booster];
+  final sectionRoot = boosterRoot != null && boosterRoot.hasParentGroupId()
+      ? groupsById[boosterRoot.parentGroupId]
+      : null;
+  if (sectionRoot != null) {
+    final visited = <int>{sectionRoot.marketGroupId};
+    var frontier = sectionRoot.groups.toList();
+    var depth = 1;
+    while (frontier.isNotEmpty) {
+      final next = <int>[];
+      for (final groupId in frontier) {
+        if (!visited.add(groupId)) continue;
+        groupDepths[groupId] = depth;
+        next.addAll(groupsById[groupId]?.groups ?? const []);
+      }
+      frontier = next;
+      depth++;
+    }
+  }
+
+  int? sectionGroupOf(int slotIndex) {
+    int? best;
+    for (final group in groupsById.values) {
+      final depth = groupDepths[group.marketGroupId];
+      if (depth == null) continue;
+      final slots = subtreeSlotSetOf(group.marketGroupId);
+      if (slots.length != 1 || slots.single != slotIndex) continue;
+      if (best == null) {
+        best = group.marketGroupId;
+        continue;
+      }
+      final bestDepth = groupDepths[best]!;
+      if (depth < bestDepth || (depth == bestDepth && group.marketGroupId < best)) {
+        best = group.marketGroupId;
+      }
+    }
+    return best;
+  }
+
+  String nameOf(pb_market.MarketGroup group) => names[group.marketGroupName.id] ?? "";
+  final sections = <BoosterSlotSection>[];
+  final bySlotIndex = <int, List<int>>{};
+  for (final entry in eligible.entries) {
+    bySlotIndex.putIfAbsent(entry.value, () => []).add(entry.key);
+  }
+
+  for (final slotIndex in bySlotIndex.keys.toList()..sort()) {
+    final typeIds = bySlotIndex[slotIndex]!;
+    final sectionGroupId = sectionGroupOf(slotIndex);
+    final sectionGroup = sectionGroupId == null ? null : groupsById[sectionGroupId];
+
+    final familyTypeIds = <int, List<int>>{}; // marketGroupId -> typeIds
+    final otherTypeIds = <int>[];
+    for (final typeId in typeIds) {
+      final marketGroupId = typeOf(typeId)?.marketGroupId ?? 0;
+      final group = groupsById[marketGroupId];
+      final isOwnFamily =
+          group != null &&
+          marketGroupId != sectionGroupId &&
+          subtreeSlotSetOf(marketGroupId).length == 1;
+      if (isOwnFamily) {
+        familyTypeIds.putIfAbsent(marketGroupId, () => []).add(typeId);
+      } else {
+        otherTypeIds.add(typeId);
+      }
+    }
+
+    int compareTypeIds(int left, int right) {
+      final leftType = typeOf(left);
+      final rightType = typeOf(right);
+      if (leftType == null || rightType == null) return left.compareTo(right);
+      return compareTypesByMeta(leftType, rightType);
+    }
+
+    final families = <BoosterFamilyGroup>[
+      for (final entry in familyTypeIds.entries)
+        BoosterFamilyGroup(
+          label: nameOf(groupsById[entry.key]!),
+          icon: groupsById[entry.key]!.icon,
+          typeIds: entry.value..sort(compareTypeIds),
+        ),
+    ]..sort((left, right) => left.label.compareTo(right.label));
+    if (otherTypeIds.isNotEmpty) {
+      families.add(
+        BoosterFamilyGroup(label: otherLabel, typeIds: otherTypeIds..sort(compareTypeIds)),
+      );
+    }
+
+    final sectionName = sectionGroup == null ? "" : nameOf(sectionGroup);
+    sections.add(
+      BoosterSlotSection(
+        slotIndex: slotIndex,
+        label: sectionName.isEmpty ? slotFallbackLabel(slotIndex) : sectionName,
+        icon: sectionGroup?.icon,
+        families: families,
+      ),
+    );
+  }
+
+  return sections;
+}
+
+/// Collects the localization ids whose resolution [buildBoosterSlotSections]
+/// needs in its names map: section and family market group names.
+Set<int> collectBoosterSectionNameIds(Iterable<pb_market.MarketGroup> marketGroups) => {
+  for (final group in marketGroups) group.marketGroupName.id,
+};
+
+/// Shows the booster picker dialog, returning the chosen type id.
+///
+/// Resolves the market group names used as section/family labels up front so
+/// the list itself can stay synchronous.
+Future<int?> showBoosterSelectDialog({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String title,
+  int? slotFilter,
+}) async {
+  final collection = ref.read(repoCollectionProvider);
+  if (collection == null) return null;
+
+  final locale = ref.read(localeProvider).name;
+  final localization = await ref.read(localizationDbServiceProvider.future);
+  final names =
+      await localization?.localizedNames(
+        collectBoosterSectionNameIds(collection.getAllMarketGroups()),
+        locale,
+      ) ??
+      const {};
+  if (!context.mounted) return null;
+
+  final sections = buildBoosterSlotSections(
+    boosterSlots: collection.slots.boosterSlots,
+    typeOf: collection.getType,
+    marketGroups: collection.getAllMarketGroups(),
+    names: names,
+    slotFallbackLabel: (slotIndex) => "${context.l10n.boosterSlot} $slotIndex",
+    otherLabel: context.l10n.fitBoosterFamilyOther,
+    slotFilter: slotFilter,
+  );
+  if (sections.isEmpty) return null;
+  if (!context.mounted) return null;
+
+  return showDialog<int>(
+    context: context,
+    builder: (context) =>
+        _BoosterSelectDialog(title: title, sections: sections, slotFiltered: slotFilter != null),
+  );
+}
+
+sealed class _BoosterPickNode {
+  const _BoosterPickNode();
+}
+
+final class _BoosterPickRoot extends _BoosterPickNode {
+  const _BoosterPickRoot();
+}
+
+final class _BoosterPickSlot extends _BoosterPickNode {
+  const _BoosterPickSlot(this.section);
+
+  final BoosterSlotSection section;
+}
+
+final class _BoosterPickFamily extends _BoosterPickNode {
+  const _BoosterPickFamily(this.family);
+
+  final BoosterFamilyGroup family;
+}
+
+final class _BoosterPickType extends _BoosterPickNode {
+  const _BoosterPickType(this.typeId);
+
+  final int typeId;
+}
+
+class _BoosterSelectDialog extends ConsumerWidget {
+  const _BoosterSelectDialog({
+    required this.title,
+    required this.sections,
+    required this.slotFiltered,
+  });
+
+  final String title;
+  final List<BoosterSlotSection> sections;
+  final bool slotFiltered;
+
+  List<_BoosterPickNode> _childrenOf(_BoosterPickNode node) => switch (node) {
+    _BoosterPickRoot() => [
+      // With a slot filter the slot level is redundant: start at families.
+      if (slotFiltered)
+        for (final family in sections.single.families) _BoosterPickFamily(family)
+      else
+        for (final section in sections) _BoosterPickSlot(section),
+    ],
+    _BoosterPickSlot(:final section) => [
+      for (final family in section.families) _BoosterPickFamily(family),
+    ],
+    _BoosterPickFamily(:final family) => [
+      for (final typeId in family.typeIds) _BoosterPickType(typeId),
+    ],
+    _BoosterPickType() => const [],
+  };
+  @override
+  Widget build(BuildContext context, WidgetRef ref) => AppDialog(
+    title: title,
+    content: SizedBox(
+      width: double.maxFinite,
+      child: SelectList<_BoosterPickNode>(
+        root: const _BoosterPickRoot(),
+        fetchChildren: (node, ref) => _childrenOf(node),
+        shallSelect: (node) => node is _BoosterPickType,
+        onSelect: (node) => switch (node) {
+          _BoosterPickType(:final typeId) => Navigator.of(context).pop(typeId),
+          _ => {},
+        },
+        returnBehavior: ref.watch(
+          appSettingServiceProvider.select((setting) => setting.typeListReturnBehavior),
+        ),
+        breadcrumbBuilder: (node) => Padding(
+          padding: const .symmetric(horizontal: 4),
+          child: switch (node) {
+            _BoosterPickRoot() => Text(title),
+            _BoosterPickSlot(:final section) => Text(section.label),
+            _BoosterPickFamily(:final family) => Text(family.label),
+            _BoosterPickType(:final typeId) => TypeNameText(typeId: typeId),
+          },
+        ),
+        itemBuilder: (node, onTap) => switch (node) {
+          _BoosterPickSlot(:final section) => ListTile(
+            leading: section.icon == null
+                ? const Icon(Icons.list)
+                : EveIcon(icon: section.icon!, acceptGraphic: false),
+            title: Text(section.label),
+            onTap: onTap,
+          ),
+          _BoosterPickFamily(:final family) => ListTile(
+            leading: family.icon == null
+                ? const Icon(Icons.list)
+                : EveIcon(icon: family.icon!, acceptGraphic: false),
+            title: Text(family.label),
+            onTap: onTap,
+          ),
+          _BoosterPickType(:final typeId) => TypeListTile(
+            typeId: typeId,
+            fallbackLeading: const Image(image: ImageAssets.unknownIcon, height: 32),
+            onTap: onTap,
+            onLongPress: () => showItemDetailPage(context, typeId: typeId),
+          ),
+          _BoosterPickRoot() => const SizedBox.shrink(),
+        },
+      ),
+    ),
+  );
+}

--- a/apps/eve-fit-assistant/lib/pages/fit/page.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/page.dart
@@ -34,6 +34,7 @@ import "package:eve_fit_assistant/native/api/storage.dart" as native_storage;
 import "package:eve_fit_assistant/native/api/validation.dart" as native_validation;
 import "package:eve_fit_assistant/pages/fit/components/add_item_dialog.dart";
 import "package:eve_fit_assistant/pages/fit/components/attribute/damage_profile_dialog.dart";
+import "package:eve_fit_assistant/pages/fit/components/booster_select_list.dart";
 import "package:eve_fit_assistant/pages/fit/components/equipment/slot_row/related_values_logic.dart";
 import "package:eve_fit_assistant/pages/fit/components/slidable_edge_zone.dart";
 import "package:eve_fit_assistant/pages/item-detail/page.dart";

--- a/apps/eve-fit-assistant/lib/pages/fit/tabs/character.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/tabs/character.dart
@@ -417,15 +417,10 @@ class _CharacterBoosterTabState extends ConsumerState<_CharacterBoosterTab>
 
   Future<void> _handleAddBooster(BuildContext context, WidgetRef ref) async {
     const slotIdent = SlotIdentifier.booster(slotId: 1);
-    final typeId = await showAddItemDialog(
+    final typeId = await showBoosterSelectDialog(
       context: context,
+      ref: ref,
       title: slotIdent.localizedAddItemDialogTitle(context),
-      initialMarketGroupId: slotIdent.baseMarketGroupId,
-      validator: (node) => switch (node) {
-        EveSelectListRootType(:final typeId) =>
-          ref.read(repoCollectionProvider)?.slots.boosterSlots.containsKey(typeId) ?? false,
-        _ => true,
-      },
     );
     if (typeId == null) return;
 
@@ -669,23 +664,16 @@ class _BoosterRow extends ConsumerWidget {
 
   Future<void> _handleReplace(BuildContext context, WidgetRef ref) async {
     final slotIdent = SlotIdentifier.booster(slotId: slotId);
-    final typeId = await showAddItemDialog(
+    final typeId = await showBoosterSelectDialog(
       context: context,
+      ref: ref,
       title: slotIdent.localizedAddItemDialogTitle(context),
-      initialMarketGroupId: slotIdent.baseMarketGroupId,
-      validator: _boosterValidator(ref, slotId),
+      slotFilter: slotId,
     );
     if (typeId == null) return;
     await fitContext.fitWrapper.setBooster(slotId, typeId);
   }
 }
-
-bool Function(EveSelectListRoot) _boosterValidator(WidgetRef ref, int slotId) =>
-    (node) => switch (node) {
-      EveSelectListRootType(:final typeId) =>
-        ref.read(repoCollectionProvider)?.slots.boosterSlots[typeId]?.slotIndex == slotId,
-      _ => true,
-    };
 
 Map<int, int> _buildImplantAssignments(FitStorage fit, WidgetRef ref) {
   final slotsInfo = ref.watch(repoCollectionProvider)?.slots;

--- a/apps/eve-fit-assistant/test/pages/fit/booster_select_list_test.dart
+++ b/apps/eve-fit-assistant/test/pages/fit/booster_select_list_test.dart
@@ -1,0 +1,193 @@
+import "package:efa_proto/fit.pb.dart";
+import "package:efa_proto/market_groups.pb.dart" as pb_market;
+import "package:efa_proto/types.pb.dart" as pb_types;
+import "package:efa_proto/utils.pb.dart" as pb_utils;
+import "package:eve_fit_assistant/pages/fit/components/booster_select_list.dart";
+import "package:flutter_test/flutter_test.dart";
+
+pb_types.Type _type(int typeId, {bool published = true, int marketGroupId = 0}) =>
+    pb_types.Type(typeId: typeId, published: published, marketGroupId: marketGroupId);
+
+pb_market.MarketGroup _marketGroup(
+  int id, {
+  int nameId = 0,
+  int parentGroupId = 0,
+  List<int> groups = const [],
+  List<int> types = const [],
+}) {
+  final group = pb_market.MarketGroup(
+    marketGroupId: id,
+    marketGroupName: pb_utils.LocalizationID(id: nameId),
+    groups: groups,
+    types: types,
+  );
+  if (parentGroupId != 0) group.parentGroupId = parentGroupId;
+  return group;
+}
+
+void main() {
+  // Market tree mirroring the real bundle layout:
+  //   24 Implants & Boosters
+  //   +- 977 Booster
+  //   |  +- 2488 "Booster Slot 01"
+  //   |  |  `- 2491 "Blue Pill" (types 100, 101)
+  //   |  `- 2489 "Booster Slot 02"
+  //   |     `- 2496 "Drop" (type 200)
+  //   `- 2487 "Cerebral Accelerators" (type 400)
+  const mgRoot = 24;
+  const mgBoosters = 977;
+  const mgSlot1 = 2488;
+  const mgBluePill = 2491;
+  const mgSlot2 = 2489;
+  const mgDrop = 2496;
+  const mgAccelerators = 2487;
+
+  final marketGroups = [
+    _marketGroup(mgRoot, nameId: 24, groups: [mgBoosters, mgAccelerators]),
+    _marketGroup(mgBoosters, nameId: 977, parentGroupId: mgRoot, groups: [mgSlot1, mgSlot2]),
+    _marketGroup(mgSlot1, nameId: 2488, parentGroupId: mgBoosters, groups: [mgBluePill]),
+    _marketGroup(mgBluePill, nameId: 2491, parentGroupId: mgSlot1, types: [100, 101]),
+    _marketGroup(mgSlot2, nameId: 2489, parentGroupId: mgBoosters, groups: [mgDrop]),
+    _marketGroup(mgDrop, nameId: 2496, parentGroupId: mgSlot2, types: [200]),
+    _marketGroup(mgAccelerators, nameId: 2487, parentGroupId: mgRoot, types: [400]),
+  ];
+
+  const names = {
+    24: "Implants & Boosters",
+    977: "Booster",
+    2488: "Booster Slot 01",
+    2491: "Blue Pill",
+    2489: "Booster Slot 02",
+    2496: "Drop",
+    2487: "Cerebral Accelerators",
+  };
+
+  final baseTypes = {
+    100: _type(100, marketGroupId: mgBluePill),
+    101: _type(101, marketGroupId: mgBluePill),
+    200: _type(200, marketGroupId: mgDrop),
+    400: _type(400, marketGroupId: mgAccelerators),
+  };
+
+  final baseSlots = {
+    100: Slots_BoosterSlot(typeId: 100, slotIndex: 1),
+    101: Slots_BoosterSlot(typeId: 101, slotIndex: 1),
+    200: Slots_BoosterSlot(typeId: 200, slotIndex: 2),
+    400: Slots_BoosterSlot(typeId: 400, slotIndex: 10),
+  };
+
+  List<BoosterSlotSection> build({
+    Map<int, Slots_BoosterSlot>? boosterSlots,
+    Map<int, pb_types.Type>? types,
+    List<pb_market.MarketGroup>? groups,
+    int? slotFilter,
+  }) => buildBoosterSlotSections(
+    boosterSlots: boosterSlots ?? baseSlots,
+    typeOf: (typeId) => (types ?? baseTypes)[typeId],
+    marketGroups: groups ?? marketGroups,
+    names: names,
+    slotFallbackLabel: (slotIndex) => "Booster $slotIndex",
+    otherLabel: "Other",
+    slotFilter: slotFilter,
+  );
+
+  test("groups published booster types by slot with market labels", () {
+    final sections = build();
+    expect(sections.map((section) => section.slotIndex), [1, 2, 10]);
+
+    final slot1 = sections[0];
+    // The slot-level branch group wins over the leaf family group.
+    expect(slot1.label, "Booster Slot 01");
+    expect(slot1.families.single.label, "Blue Pill");
+    expect(slot1.families.single.typeIds, [100, 101]);
+
+    // The sibling "Cerebral Accelerators" group labels its own slot.
+    final slot10 = sections[2];
+    expect(slot10.label, "Cerebral Accelerators");
+    expect(slot10.families.single.label, "Other");
+    expect(slot10.families.single.typeIds, [400]);
+  });
+
+  test("excludes unpublished and unknown types", () {
+    final sections = build(
+      boosterSlots: {
+        100: Slots_BoosterSlot(typeId: 100, slotIndex: 1),
+        200: Slots_BoosterSlot(typeId: 200, slotIndex: 2),
+        300: Slots_BoosterSlot(typeId: 300, slotIndex: 3),
+      },
+      types: {200: _type(200, published: false)},
+    );
+
+    expect(sections, isEmpty);
+  });
+
+  test("includes no-market-group published types in a trailing Other bucket", () {
+    final sections = build(
+      boosterSlots: {
+        100: Slots_BoosterSlot(typeId: 100, slotIndex: 1),
+        111: Slots_BoosterSlot(typeId: 111, slotIndex: 1),
+      },
+      types: {...baseTypes, 111: _type(111)},
+    );
+
+    final families = sections.single.families;
+    expect(families.map((family) => family.label), ["Blue Pill", "Other"]);
+    expect(families.last.typeIds, [111]);
+  });
+
+  test("falls back to a numeric slot label when no market group claims the slot", () {
+    final sections = build(
+      boosterSlots: {111: Slots_BoosterSlot(typeId: 111, slotIndex: 111)},
+      types: {111: _type(111)},
+    );
+
+    final section = sections.single;
+    expect(section.slotIndex, 111);
+    expect(section.label, "Booster 111");
+    expect(section.families.single.label, "Other");
+  });
+
+  test("orders sections by slot index", () {
+    final sections = build(
+      boosterSlots: {
+        1: Slots_BoosterSlot(typeId: 1, slotIndex: 10),
+        2: Slots_BoosterSlot(typeId: 2, slotIndex: 2),
+        3: Slots_BoosterSlot(typeId: 3, slotIndex: 1),
+      },
+      types: {1: _type(1), 2: _type(2), 3: _type(3)},
+    );
+
+    expect(sections.map((section) => section.slotIndex), [1, 2, 10]);
+  });
+
+  test("slotFilter keeps only the requested slot", () {
+    final sections = build(slotFilter: 2);
+
+    expect(sections.map((section) => section.slotIndex), [2]);
+    expect(sections.single.families.single.typeIds, [200]);
+  });
+
+  test("treats types attached to the section group itself as Other", () {
+    // Serenity flattens some slot groups into leaf market groups with direct
+    // types; those must not become a family duplicating the section label.
+    final flatGroups = [
+      _marketGroup(mgRoot, nameId: 24, groups: [mgBoosters]),
+      _marketGroup(mgBoosters, nameId: 977, parentGroupId: mgRoot, groups: [mgSlot1, 2834]),
+      _marketGroup(mgSlot1, nameId: 2488, parentGroupId: mgBoosters, types: [100]),
+      _marketGroup(2834, nameId: 2834, parentGroupId: mgBoosters, types: [500]),
+    ];
+    final sections = build(
+      boosterSlots: {
+        100: Slots_BoosterSlot(typeId: 100, slotIndex: 1),
+        500: Slots_BoosterSlot(typeId: 500, slotIndex: 89),
+      },
+      types: {100: _type(100, marketGroupId: mgSlot1), 500: _type(500, marketGroupId: 2834)},
+      groups: flatGroups,
+    );
+
+    final section = sections.firstWhere((section) => section.slotIndex == 89);
+    // Name id 2834 is unresolved in [names]: the numeric fallback kicks in.
+    expect(section.label, "Booster 89");
+    expect(section.families.single.label, "Other");
+  });
+}

--- a/apps/eve-fit-assistant/test/pages/fit/booster_select_list_test.dart
+++ b/apps/eve-fit-assistant/test/pages/fit/booster_select_list_test.dart
@@ -181,7 +181,10 @@ void main() {
         100: Slots_BoosterSlot(typeId: 100, slotIndex: 1),
         500: Slots_BoosterSlot(typeId: 500, slotIndex: 89),
       },
-      types: {100: _type(100, marketGroupId: mgSlot1), 500: _type(500, marketGroupId: 2834)},
+      types: {
+        100: _type(100, marketGroupId: mgSlot1),
+        500: _type(500, marketGroupId: 2834),
+      },
       groups: flatGroups,
     );
 
@@ -189,5 +192,35 @@ void main() {
     // Name id 2834 is unresolved in [names]: the numeric fallback kicks in.
     expect(section.label, "Booster 89");
     expect(section.families.single.label, "Other");
+  });
+
+  test("slotFilter still derives section hierarchy from all published slots", () {
+    // Same flattened fixture, but filtered to slot 89: without the unfiltered
+    // hierarchy map, "Booster" would become the section and unresolved group
+    // 2834 a blank family row instead of Other.
+    final flatGroups = [
+      _marketGroup(mgRoot, nameId: 24, groups: [mgBoosters]),
+      _marketGroup(mgBoosters, nameId: 977, parentGroupId: mgRoot, groups: [mgSlot1, 2834]),
+      _marketGroup(mgSlot1, nameId: 2488, parentGroupId: mgBoosters, types: [100]),
+      _marketGroup(2834, nameId: 2834, parentGroupId: mgBoosters, types: [500]),
+    ];
+    final sections = build(
+      boosterSlots: {
+        100: Slots_BoosterSlot(typeId: 100, slotIndex: 1),
+        500: Slots_BoosterSlot(typeId: 500, slotIndex: 89),
+      },
+      types: {
+        100: _type(100, marketGroupId: mgSlot1),
+        500: _type(500, marketGroupId: 2834),
+      },
+      groups: flatGroups,
+      slotFilter: 89,
+    );
+
+    final section = sections.single;
+    expect(section.slotIndex, 89);
+    expect(section.label, "Booster 89");
+    expect(section.families.single.label, "Other");
+    expect(section.families.single.typeIds, [500]);
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated booster selection dialog in the Fit Assistant.
  - Boosters are organized by slot and market-group family, with an “Other” category for uncategorized items.
  - Added support for filtering booster choices by slot when replacing an existing booster.
  - Added English and Chinese translations for the “Other” category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->