### PR TITLE
feat(fit): end-to-end mutated drone support

### DIFF
--- a/apps/eve-fit-assistant/lib/features/chat/fit_context.dart
+++ b/apps/eve-fit-assistant/lib/features/chat/fit_context.dart
@@ -472,7 +472,11 @@ Map<String, Object?> _encodeNativeFit(native_storage.Fit fit) => {
   "modules": [for (final m in fit.modules) _encodeNativeModule(m)],
   "drones": [
     for (final d in fit.drones)
-      {"type_id": d.typeId, "group_id": d.groupId, "state": _stateName(d.state)},
+      {
+        "item_id": d.itemId.when(item: (id) => {"item": id}, dynamic_: (id) => {"dynamic": id}),
+        "group_id": d.groupId,
+        "state": _stateName(d.state),
+      },
   ],
   "fighters": [
     for (final f in fit.fighters)

--- a/apps/eve-fit-assistant/lib/pages/fit/components/equipment/slot_row/drone_slot.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/components/equipment/slot_row/drone_slot.dart
@@ -13,22 +13,75 @@ class _DroneSlotRow extends ConsumerWidget {
   final FitContext fitContext;
   final FitInteractionOptions interactionOptions;
 
-  List<TileAction> _buildStartActions(BuildContext context, WidgetRef ref) => <TileAction>[
-    if (fitContext.fit.body.drones.getOrNull(slotIdent.index)?.quantity != 1)
-      TileAction(
-        onPressed: (_) => _handleSetAmount(context, ref, 1),
-        backgroundColor: Colors.green.shade200,
-        foregroundColor: Colors.black,
-        label: "x1",
-      ),
-    if (fitContext.fit.body.drones.getOrNull(slotIdent.index)?.quantity != 5)
-      TileAction(
-        onPressed: (_) => _handleSetAmount(context, ref, 5),
-        backgroundColor: Colors.green.shade400,
-        foregroundColor: Colors.white,
-        label: "x5",
-      ),
-  ];
+  List<TileAction> _buildStartActions(BuildContext context, WidgetRef ref) {
+    final actions = <TileAction>[
+      if (fitContext.fit.body.drones.getOrNull(slotIdent.index)?.quantity != 1)
+        TileAction(
+          onPressed: (_) => _handleSetAmount(context, ref, 1),
+          backgroundColor: Colors.green.shade200,
+          foregroundColor: Colors.black,
+          label: "x1",
+        ),
+      if (fitContext.fit.body.drones.getOrNull(slotIdent.index)?.quantity != 5)
+        TileAction(
+          onPressed: (_) => _handleSetAmount(context, ref, 5),
+          backgroundColor: Colors.green.shade400,
+          foregroundColor: Colors.white,
+          label: "x5",
+        ),
+    ];
+
+    final dynamicItem = fitContext.dynamicItemFor(slotInfo.slot.itemId);
+    if (dynamicItem != null) {
+      actions
+        ..add(
+          TileAction(
+            onPressed: (_) => fitContext.fitWrapper.revertDroneFromDynamic(slotIdent.index),
+            backgroundColor: Colors.grey,
+            foregroundColor: Colors.white,
+            icon: Icons.cyclone_outlined,
+            label: context.l10n.dynamicRevert,
+            group: _SlotActionGroup.abyss,
+          ),
+        )
+        ..add(
+          TileAction(
+            onPressed: (_) => _handleMutateRandom(context, ref),
+            backgroundColor: Colors.deepPurple,
+            foregroundColor: Colors.white,
+            icon: Icons.casino_outlined,
+            label: context.l10n.fitActionMutateRandom,
+            group: _SlotActionGroup.abyss,
+          ),
+        );
+    } else if (_availableDynamicModifierTypeIds(ref).isNotEmpty) {
+      actions.add(
+        TileAction(
+          onPressed: (_) => _handleConvertToDynamic(context, ref),
+          backgroundColor: Colors.red,
+          foregroundColor: Colors.white,
+          icon: Icons.cyclone_outlined,
+          label: context.l10n.dynamicConvert,
+          group: _SlotActionGroup.abyss,
+        ),
+      );
+    }
+
+    if (dynamicItem != null || _availableDynamicModifierTypeIds(ref).isNotEmpty) {
+      actions.add(
+        TileAction(
+          onPressed: (_) => _handleMutateAll(context, ref),
+          backgroundColor: Colors.deepPurple,
+          foregroundColor: Colors.white,
+          icon: Icons.casino_outlined,
+          label: context.l10n.fitActionMutateRandomAll,
+          group: _SlotActionGroup.abyss,
+        ),
+      );
+    }
+
+    return actions;
+  }
 
   List<TileAction> _buildEndActions(BuildContext context, WidgetRef ref) => <TileAction>[
     if ((fitContext.fit.body.drones.getOrNull(slotIdent.index)?.quantity ?? 0) > 1)
@@ -46,6 +99,15 @@ class _DroneSlotRow extends ConsumerWidget {
       foregroundColor: Colors.black,
       label: "+1",
     ),
+    if (fitContext.dynamicItemFor(slotInfo.slot.itemId) != null)
+      TileAction(
+        onPressed: (_) => fitContext.fitWrapper.revertAllSameDynamicDrones(slotIdent.index),
+        backgroundColor: Colors.grey,
+        foregroundColor: Colors.white,
+        icon: Icons.cyclone_outlined,
+        label: context.l10n.fitActionRevertAllDynamic,
+        group: _SlotActionGroup.abyss,
+      ),
     TileAction(
       onPressed: (_) => _handleRemoveDrone(context, ref),
       backgroundColor: colorActionDelete,
@@ -75,6 +137,55 @@ class _DroneSlotRow extends ConsumerWidget {
 
   Future<void> _handleRemoveDrone(BuildContext context, WidgetRef ref) async {
     await fitContext.fitWrapper.removeDrone(slotIdent.index);
+  }
+
+  List<int> _availableDynamicModifierTypeIds(WidgetRef ref) {
+    final originTypeId = fitContext.resolveOriginTypeId(slotInfo.slot.itemId);
+    if (originTypeId == null) return const [];
+
+    final collection = ref.read(repoCollectionProvider);
+    return collection?.getDynamicTypeOptions(originTypeId)?.modifierTypeIds.toList() ?? const [];
+  }
+
+  Future<void> _handleConvertToDynamic(BuildContext context, WidgetRef ref) async {
+    final modifierTypeIds = _availableDynamicModifierTypeIds(ref);
+    if (modifierTypeIds.isEmpty) return;
+
+    final modifierTypeId = await showDialog<int>(
+      context: context,
+      builder: (context) => AppDialog(
+        title: context.l10n.dynamicSelectTitle,
+        content: _DynamicModifierDialog(modifierTypeIds: modifierTypeIds),
+      ),
+    );
+    if (modifierTypeId == null) return;
+
+    await fitContext.fitWrapper.convertDroneToDynamic(slotIdent.index, modifierTypeId);
+  }
+
+  Future<void> _handleMutateRandom(BuildContext context, WidgetRef ref) async {
+    final dynamicItem = fitContext.dynamicItemFor(slotInfo.slot.itemId);
+    if (dynamicItem == null) return;
+    await fitContext.fitWrapper.randomizeDynamicAttributes(dynamicItem.dynamicItemId);
+  }
+
+  Future<void> _handleMutateAll(BuildContext context, WidgetRef ref) async {
+    var modifierTypeId = fitContext.dynamicItemFor(slotInfo.slot.itemId)?.modifierTypeId;
+    if (modifierTypeId == null) {
+      final modifierTypeIds = _availableDynamicModifierTypeIds(ref);
+      if (modifierTypeIds.isEmpty) return;
+
+      modifierTypeId = await showDialog<int>(
+        context: context,
+        builder: (context) => AppDialog(
+          title: context.l10n.dynamicSelectTitle,
+          content: _DynamicModifierDialog(modifierTypeIds: modifierTypeIds),
+        ),
+      );
+      if (modifierTypeId == null) return;
+    }
+
+    await fitContext.fitWrapper.mutateAllSameOriginDrones(slotIdent.index, modifierTypeId);
   }
 
   Widget _buildRecoveryRow(BuildContext context, WidgetRef ref, String title) {
@@ -162,7 +273,13 @@ class _DroneSlotRow extends ConsumerWidget {
       startActionPane: buildTileActionPane(startActions),
       endActionPane: buildTileActionPane(endActions, overflowFirst: true),
       child: SlidableEdgeZone(
-        child: TileSecondaryActionRegion(actions: [...startActions, ...endActions], child: content),
+        child: TileSecondaryActionRegion(
+          actions: flattenTileActionGroups([
+            ...startActions,
+            ...endActions,
+          ], _SlotActionGroup.values),
+          child: content,
+        ),
       ),
     );
   }

--- a/apps/eve-fit-assistant/lib/pages/fit/wrapper.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/wrapper.dart
@@ -1687,6 +1687,122 @@ class FitWrapper {
     return fit.copyWith(body: fit.body.copyWith(drones: drones.toIList()));
   });
 
+  // Drone mutation operates on whole stacks: one dynamic item per drone group,
+  // shared by every unit of the stack (quantity changes keep the roll).
+  Future<void> convertDroneToDynamic(int index, int modifierTypeId) => wrapped.update((fit) {
+    if (index < 0 || index >= fit.body.drones.length) return fit;
+    final drone = fit.body.drones[index];
+    if (drone.itemId is FitStorageItemIdDynamic) return fit;
+
+    final originTypeId = _resolveOriginTypeId(fit, drone.itemId);
+    if (originTypeId == null) return fit;
+
+    final dynamicMutator = ref.read(repoCollectionProvider)?.getDynamicMutator(modifierTypeId);
+    if (dynamicMutator == null) return fit;
+    if (!dynamicMutator.applicableTypes.contains(originTypeId)) return fit;
+
+    final dynamicItemId = _allocateDynamicItemId(fit);
+    final dynamicItem = FitDynamicItem(
+      dynamicItemId: dynamicItemId,
+      originTypeId: originTypeId,
+      typeId: dynamicMutator.resultingTypeId,
+      modifierTypeId: modifierTypeId,
+      dynamicAttributes: IMap.fromEntries(
+        dynamicMutator.attributes.keys.map((attributeId) => MapEntry<int, double>(attributeId, 1)),
+      ),
+    );
+    final updatedFit = _storeDynamicItem(fit, dynamicItem);
+    final drones = updatedFit.body.drones.toList();
+    drones[index] = drone.copyWith(itemId: FitStorageItemId.dynamic(dynamicId: dynamicItemId));
+    return updatedFit.copyWith(body: updatedFit.body.copyWith(drones: drones.toIList()));
+  });
+
+  Future<void> revertDroneFromDynamic(int index) => wrapped.update((fit) {
+    if (index < 0 || index >= fit.body.drones.length) return fit;
+    final drone = fit.body.drones[index];
+    return drone.itemId.when(
+      item: (_) => fit,
+      dynamic: (dynamicId) {
+        final dynamicItem = fit.dynamicRegistry.dynamicItems[dynamicId];
+        if (dynamicItem == null) return fit;
+        final drones = fit.body.drones.toList();
+        drones[index] = drone.copyWith(itemId: FitStorageItemId.item(id: dynamicItem.originTypeId));
+        return fit.copyWith(body: fit.body.copyWith(drones: drones.toIList()));
+      },
+    );
+  });
+
+  Future<void> mutateAllSameOriginDrones(int index, int modifierTypeId) => wrapped.update((fit) {
+    if (index < 0 || index >= fit.body.drones.length) return fit;
+    final originTypeId = _resolveOriginTypeId(fit, fit.body.drones[index].itemId);
+    if (originTypeId == null) return fit;
+
+    final dynamicMutator = ref.read(repoCollectionProvider)?.getDynamicMutator(modifierTypeId);
+    if (dynamicMutator == null) return fit;
+    if (!dynamicMutator.applicableTypes.contains(originTypeId)) return fit;
+
+    var updatedFit = fit;
+    for (var i = 0; i < updatedFit.body.drones.length; i++) {
+      final drone = updatedFit.body.drones[i];
+      if (_resolveOriginTypeId(updatedFit, drone.itemId) != originTypeId) continue;
+
+      updatedFit = drone.itemId.when(
+        item: (_) {
+          final dynamicItemId = _allocateDynamicItemId(updatedFit);
+          final dynamicItem = FitDynamicItem(
+            dynamicItemId: dynamicItemId,
+            originTypeId: originTypeId,
+            typeId: dynamicMutator.resultingTypeId,
+            modifierTypeId: modifierTypeId,
+            dynamicAttributes: _randomizedDynamicAttributes(dynamicMutator),
+          );
+          final fitWithItem = _storeDynamicItem(updatedFit, dynamicItem);
+          final drones = fitWithItem.body.drones.toList();
+          drones[i] = drone.copyWith(itemId: FitStorageItemId.dynamic(dynamicId: dynamicItemId));
+          return fitWithItem.copyWith(body: fitWithItem.body.copyWith(drones: drones.toIList()));
+        },
+        dynamic: (dynamicId) {
+          final existing = updatedFit.dynamicRegistry.dynamicItems[dynamicId];
+          if (existing == null || existing.modifierTypeId != modifierTypeId) return updatedFit;
+          return _storeDynamicItem(
+            updatedFit,
+            existing.copyWith(dynamicAttributes: _randomizedDynamicAttributes(dynamicMutator)),
+          );
+        },
+      );
+    }
+    return updatedFit;
+  });
+
+  Future<void> revertAllSameDynamicDrones(int index) => wrapped.update((fit) {
+    if (index < 0 || index >= fit.body.drones.length) return fit;
+    final sourceDynamic = fit.body.drones[index].itemId.when(
+      item: (_) => null,
+      dynamic: (dynamicId) => fit.dynamicRegistry.dynamicItems[dynamicId],
+    );
+    if (sourceDynamic == null) return fit;
+
+    final drones = fit.body.drones.toList();
+    var changed = false;
+    for (var i = 0; i < drones.length; i++) {
+      final reverted = drones[i].itemId.when(
+        item: (_) => null,
+        dynamic: (dynamicId) {
+          final dynamicItem = fit.dynamicRegistry.dynamicItems[dynamicId];
+          if (dynamicItem == null) return null;
+          if (dynamicItem.originTypeId != sourceDynamic.originTypeId) return null;
+          if (dynamicItem.modifierTypeId != sourceDynamic.modifierTypeId) return null;
+          return drones[i].copyWith(itemId: FitStorageItemId.item(id: dynamicItem.originTypeId));
+        },
+      );
+      if (reverted == null) continue;
+      drones[i] = reverted;
+      changed = true;
+    }
+    if (!changed) return fit;
+    return fit.copyWith(body: fit.body.copyWith(drones: drones.toIList()));
+  });
+
   FitStorage applySubsystemResize(
     FitStorage fit,
     Ship ship,

--- a/apps/eve-fit-assistant/lib/pages/item-detail/page.dart
+++ b/apps/eve-fit-assistant/lib/pages/item-detail/page.dart
@@ -28,6 +28,7 @@ import "package:eve_fit_assistant/utils/skill.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:fpdart/fpdart.dart" hide State;
 
 const List<int> _requiredSkillAttributeIds = [182, 183, 184, 1285, 1289, 1290];
 const List<int> _requiredSkillLevelAttributeIds = [277, 278, 279, 1286, 1287, 1288];
@@ -1964,6 +1965,14 @@ FitModuleItem? _resolveStoredModule(FitStorage fit, native.OutSlotType slotType,
       native.OutSlotType_Rig() => fit.body.slots.rig.getOrNull(index)?.toNullable(),
       native.OutSlotType_SubSystem() => fit.body.slots.subsystem.getOrNull(index)?.toNullable(),
       native.OutSlotType_Service() => fit.body.slots.service.getOrNull(index)?.toNullable(),
+      native.OutSlotType_DroneBay() => switch (fit.body.drones.getOrNull(index)) {
+        final drone? => FitModuleItem(
+          itemId: drone.itemId,
+          state: drone.state,
+          charge: const Option.none(),
+        ),
+        _ => null,
+      },
       _ => null,
     };
 

--- a/apps/eve-fit-assistant/lib/storage/fit/schema.dart
+++ b/apps/eve-fit-assistant/lib/storage/fit/schema.dart
@@ -414,17 +414,18 @@ native.Fit convertFitBodyToNative(FitStorage fitStorage) {
   for (final (index, drone) in fitStorage.body.drones.mapWithIndex(
     (drone, index) => (index, drone),
   )) {
-    final typeId = _resolveNativeTypeId(
+    if (!_hasValidDynamicReference(
       fitStorage,
       drone.itemId,
       context: "drone $index in fit ${fitStorage.metadata.fitId}",
-    );
-    if (typeId == null) continue;
+    )) {
+      continue;
+    }
     drones.addAll(
       List.generate(
         drone.quantity,
         (_) => native.Drone(
-          typeId: typeId,
+          itemId: drone.itemId.when(item: native.ItemID.item, dynamic: native.ItemID.dynamic_),
           groupId: index,
           state: switch (drone.state) {
             FitItemState.passive => native.State.passive,

--- a/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/edit.rs
+++ b/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/edit.rs
@@ -404,16 +404,15 @@ pub fn apply_edit_ops(
                 };
                 match result {
                     Ok(state) => {
-                        let group_id = next_group_id(
-                            edited
-                                .fit
-                                .drones
-                                .iter()
-                                .map(|drone| (drone.type_id, drone.group_id)),
-                            *type_id,
-                        );
+                        let group_id =
+                            next_group_id(
+                                edited.fit.drones.iter().map(|drone| {
+                                    (drone.item_id.as_type_id(&edited), drone.group_id)
+                                }),
+                                *type_id,
+                            );
                         edited.fit.drones.push(ItemDrone {
-                            type_id: *type_id,
+                            item_id: eve_fit_os::calculate::item::ItemID::Item(*type_id),
                             group_id,
                             state,
                         });
@@ -431,7 +430,11 @@ pub fn apply_edit_ops(
 
             FitEditOp::RemoveDrone { type_id } => {
                 let before = edited.fit.drones.len();
-                edited.fit.drones.retain(|drone| drone.type_id != *type_id);
+                let drones = std::mem::take(&mut edited.fit.drones);
+                edited.fit.drones = drones
+                    .into_iter()
+                    .filter(|drone| drone.item_id.as_type_id(&edited) != *type_id)
+                    .collect();
                 let removed = before - edited.fit.drones.len();
                 if removed > 0 {
                     applied.push(format!("remove {removed} drone(s) of type {type_id}"));
@@ -443,13 +446,17 @@ pub fn apply_edit_ops(
 
             FitEditOp::SetDroneState { type_id, state } => match parse_drone_state(state) {
                 Ok(state) => {
-                    let mut matched = 0;
-                    for drone in edited
+                    let matches: Vec<bool> = edited
                         .fit
                         .drones
-                        .iter_mut()
-                        .filter(|drone| drone.type_id == *type_id)
-                    {
+                        .iter()
+                        .map(|drone| drone.item_id.as_type_id(&edited) == *type_id)
+                        .collect();
+                    let mut matched = 0;
+                    for (drone, is_match) in edited.fit.drones.iter_mut().zip(matches) {
+                        if !is_match {
+                            continue;
+                        }
                         drone.state = state;
                         matched += 1;
                     }

--- a/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/mod.rs
+++ b/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/mod.rs
@@ -1076,12 +1076,13 @@ impl FitToolContext {
 
         let mut drones: Vec<DroneGroupEntry> = Vec::new();
         for drone in &input.drones {
+            let drone_type_id = drone.item_id.as_type_id(&fit.container);
             match drones.iter_mut().find(|group| {
-                group.item.type_id == drone.type_id && group.state == state_name(drone.state)
+                group.item.type_id == drone_type_id && group.state == state_name(drone.state)
             }) {
                 Some(group) => group.count += 1,
                 None => drones.push(DroneGroupEntry {
-                    item: fit.type_ref(drone.type_id),
+                    item: fit.type_ref(drone_type_id),
                     count: 1,
                     state: state_name(drone.state),
                 }),

--- a/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/mod.rs
+++ b/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/mod.rs
@@ -880,7 +880,7 @@ impl FitToolContext {
                 started.elapsed().as_millis()
             );
             let payload = parse_callback_fit_payload(&raw)?;
-            let active = payload.into_active();
+            let active = payload.into_active()?;
             let (after, validation) = self.calculate_report(&active.container);
             if !self.commit_active(ticket, active) {
                 log::debug!(
@@ -958,7 +958,7 @@ impl FitToolContext {
         );
         let payload = parse_callback_fit_payload(&raw)?;
         let created_id = payload.fit_id.clone();
-        let active = payload.into_active();
+        let active = payload.into_active()?;
         let summary = self.summarize(&active);
         if self.commit_active(ticket, active) {
             return Ok(summary);
@@ -1040,7 +1040,7 @@ impl FitToolContext {
             started.elapsed().as_millis()
         );
         let payload = parse_callback_fit_payload(&raw)?;
-        let active = payload.into_active();
+        let active = payload.into_active()?;
         // Summarize straight from the input snapshot (no engine pass needed).
         let summary = self.summarize(&active);
         if self.commit_active(ticket, active) {

--- a/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/schema.rs
+++ b/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/schema.rs
@@ -7,7 +7,7 @@ use eve_fit_os::fit::{
 };
 use serde::Deserialize;
 
-use super::ActiveFit;
+use super::{ActiveFit, FitToolError};
 
 /// A fit payload as pushed from the app (mirrors the bridge `Fit` DTOs in
 /// JSON form), used by the `load_fit` tool to switch the attached fit
@@ -134,8 +134,21 @@ pub struct DynamicItemDto {
 }
 
 impl FitPayload {
-    pub fn into_active(self) -> ActiveFit {
-        ActiveFit {
+    pub fn into_active(self) -> Result<ActiveFit, FitToolError> {
+        // A drone referencing a dynamic item missing from `dynamic_items`
+        // would panic later in `ItemID::as_type_id`, whose
+        // `FitContainer::get_dynamic_item_base_type_id` lookup unwraps;
+        // reject the dangling reference here instead.
+        for drone in &self.fit.drones {
+            if let ItemIdDto::Dynamic(id) = &drone.item_id {
+                if !self.dynamic_items.contains_key(id) {
+                    return Err(FitToolError::BadPayload(format!(
+                        "drone references unknown dynamic item {id}"
+                    )));
+                }
+            }
+        }
+        Ok(ActiveFit {
             name: self.name,
             container: FitContainer::new(
                 self.fit.into_native(),
@@ -154,7 +167,7 @@ impl FitPayload {
                     .collect(),
             ),
             names: self.names,
-        }
+        })
     }
 }
 
@@ -252,5 +265,70 @@ impl BoosterDto {
             type_id: self.type_id,
             index: self.index,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload_with_drone(item_id: ItemIdDto) -> FitPayload {
+        FitPayload {
+            name: None,
+            fit_id: None,
+            names: HashMap::new(),
+            fit: FitDto {
+                ship_type_id: 587,
+                damage_profile: DamageProfileDto {
+                    em: 0.0,
+                    explosive: 0.0,
+                    kinetic: 0.0,
+                    thermal: 0.0,
+                },
+                modules: vec![],
+                drones: vec![DroneDto {
+                    item_id,
+                    group_id: 0,
+                    state: StateDto::Active,
+                }],
+                fighters: vec![],
+                implants: vec![],
+                boosters: vec![],
+            },
+            skills: HashMap::new(),
+            dynamic_items: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn into_active_rejects_drone_with_missing_dynamic_item() {
+        // Regression: a drone referencing a dynamic item absent from
+        // `dynamic_items` must not reach `ItemID::as_type_id`, whose
+        // `get_dynamic_item_base_type_id` lookup unwraps and panics.
+        let err = payload_with_drone(ItemIdDto::Dynamic(7))
+            .into_active()
+            .unwrap_err();
+        assert!(matches!(err, FitToolError::BadPayload(_)));
+        assert_eq!(
+            err.to_string(),
+            "invalid payload from the app: drone references unknown dynamic item 7"
+        );
+    }
+
+    #[test]
+    fn into_active_accepts_drone_with_known_dynamic_item() {
+        let mut payload = payload_with_drone(ItemIdDto::Dynamic(7));
+        payload.dynamic_items.insert(
+            7,
+            DynamicItemDto {
+                base_type: 2456,
+                dynamic_attributes: HashMap::new(),
+            },
+        );
+        let active = payload.into_active().unwrap();
+        assert_eq!(
+            active.container.dynamic.get(&7).map(|item| item.base_type),
+            Some(2456)
+        );
     }
 }

--- a/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/schema.rs
+++ b/apps/eve-fit-assistant/rust/lib/efa-chat/src/tools/fit/schema.rs
@@ -102,7 +102,7 @@ pub struct ChargeDto {
 
 #[derive(Debug, Deserialize)]
 pub struct DroneDto {
-    pub type_id: i32,
+    pub item_id: ItemIdDto,
     pub group_id: u8,
     pub state: StateDto,
 }
@@ -212,7 +212,10 @@ impl ModuleDto {
 impl DroneDto {
     fn into_native(self) -> ItemDrone {
         ItemDrone {
-            type_id: self.type_id,
+            item_id: match self.item_id {
+                ItemIdDto::Item(id) => eve_fit_os::calculate::item::ItemID::Item(id),
+                ItemIdDto::Dynamic(id) => eve_fit_os::calculate::item::ItemID::Dynamic(id),
+            },
             group_id: self.group_id,
             state: match self.state {
                 StateDto::Passive => ItemState::Passive,

--- a/apps/eve-fit-assistant/rust/lib/efa-chat/tests/test_fit_tools.rs
+++ b/apps/eve-fit-assistant/rust/lib/efa-chat/tests/test_fit_tools.rs
@@ -48,12 +48,12 @@ fn test_fit() -> FitContainer {
             .collect(),
         drones: vec![
             ItemDrone {
-                type_id: 2488,
+                item_id: eve_fit_os::calculate::item::ItemID::Item(2488),
                 group_id: 0,
                 state: ItemState::Active,
             },
             ItemDrone {
-                type_id: 2488,
+                item_id: eve_fit_os::calculate::item::ItemID::Item(2488),
                 group_id: 1,
                 state: ItemState::Active,
             },

--- a/apps/eve-fit-assistant/rust/src/api/storage.rs
+++ b/apps/eve-fit-assistant/rust/src/api/storage.rs
@@ -55,7 +55,7 @@ pub enum ItemID {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Drone {
-    pub type_id: i32,
+    pub item_id: ItemID,
     pub group_id: u8,
     pub state: State,
 }
@@ -203,7 +203,7 @@ impl ItemID {
 impl Drone {
     pub(crate) fn into_native(self) -> ItemDrone {
         ItemDrone {
-            type_id: self.type_id,
+            item_id: self.item_id.into_native(),
             group_id: self.group_id,
             state: self.state.into_native(),
         }

--- a/apps/eve-fit-assistant/test/storage/fit/fit_dynamic_drone_compat_test.dart
+++ b/apps/eve-fit-assistant/test/storage/fit/fit_dynamic_drone_compat_test.dart
@@ -1,0 +1,128 @@
+import "dart:convert";
+
+import "package:eve_fit_assistant/native/api/storage.dart" as native;
+import "package:eve_fit_assistant/storage/fit/persistence.dart";
+import "package:eve_fit_assistant/storage/fit/schema.dart";
+import "package:flutter_test/flutter_test.dart";
+
+/// Hand-written v2 fit payload with one drone stack whose `itemId` is a
+/// dynamic reference (origin 2203 Hobgoblin I, mutated 60478 "Light Mutated
+/// Drone", mutator 60460 "Exigent Light Drone Navigation Mutaplasmid").
+///
+/// All factors lie inside the mutator's `[min, max]` ranges as shipped in the
+/// current data bundle. This fixture represents a payload produced by a future
+/// app version and must be handled gracefully by the current code.
+Map<String, dynamic> _dynamicDroneV2FitJson() => <String, dynamic>{
+  "version": 2,
+  "fit": <String, dynamic>{
+    "metadata": <String, dynamic>{
+      "fitId": "test-fit-dynamic-drone",
+      "shipTypeId": 1234,
+      "name": "Dynamic Drone Fit",
+      "lastModified": 0,
+      "description": "",
+      "checkoutRef": <String, dynamic>{"checkoutId": "checkout-abc", "serverId": "Serenity"},
+    },
+    "body": <String, dynamic>{
+      "shipTypeId": 1234,
+      "characterId": "predefined_all_5",
+      "damageProfile": <String, dynamic>{
+        "em": 0.25,
+        "explosive": 0.25,
+        "kinetic": 0.25,
+        "thermal": 0.25,
+      },
+      "slots": <String, dynamic>{
+        "high": <dynamic>[],
+        "medium": <dynamic>[],
+        "low": <dynamic>[],
+        "rig": <dynamic>[],
+        "subsystem": <dynamic>[],
+        "service": <dynamic>[],
+        "tacticalMode": null,
+      },
+      "drones": <dynamic>[
+        <String, dynamic>{
+          "itemId": <String, dynamic>{"dynamicId": 0, "runtimeType": "dynamic"},
+          "state": "active",
+          "quantity": 5,
+        },
+      ],
+      "fighters": <dynamic>[],
+      "implants": <dynamic>[],
+      "boosters": <dynamic>[],
+    },
+    "dynamicRegistry": <String, dynamic>{
+      "dynamicItems": <String, dynamic>{
+        "0": <String, dynamic>{
+          "dynamicItemId": 0,
+          "originTypeId": 2203,
+          "typeId": 60478,
+          "modifierTypeId": 60460,
+          "dynamicAttributes": <String, dynamic>{
+            "9": 1.05,
+            "37": 1.15,
+            "54": 0.95,
+            "64": 1.05,
+            "158": 0.9,
+            "160": 1.2,
+            "263": 1.1,
+            "265": 0.8,
+          },
+        },
+      },
+    },
+  },
+};
+
+Map<String, dynamic> _roundTripJson(Map<String, dynamic> json) =>
+    jsonDecode(jsonEncode(json)) as Map<String, dynamic>;
+
+void main() {
+  group("dynamic drone forward compatibility (v2 fixture)", () {
+    test("decodes a dynamic drone stack without migration", () {
+      final decoded = decodeFitStorage(_roundTripJson(_dynamicDroneV2FitJson()));
+
+      expect(decoded.didMigrate, isFalse);
+      final drone = decoded.fit.body.drones.single;
+      expect(drone.itemId.dynamicIdOrNull, 0);
+      expect(drone.quantity, 5);
+      final dynamicItem = decoded.fit.dynamicRegistry.dynamicItems[0];
+      expect(dynamicItem, isNotNull);
+      expect(dynamicItem!.originTypeId, 2203);
+      expect(dynamicItem.typeId, 60478);
+      expect(dynamicItem.modifierTypeId, 60460);
+    });
+
+    test("convertFitBodyToNative passes dynamic drone item ids through", () {
+      final fit = decodeFitStorage(_roundTripJson(_dynamicDroneV2FitJson())).fit;
+
+      final nativeFit = convertFitBodyToNative(fit);
+
+      expect(nativeFit.drones, hasLength(5));
+      for (final drone in nativeFit.drones) {
+        expect(drone.itemId, isA<native.ItemID_Dynamic>());
+        expect((drone.itemId as native.ItemID_Dynamic).field0, 0);
+        expect(drone.groupId, 0);
+        expect(drone.state, native.State.active);
+      }
+    });
+
+    test("load-prune-save preserves the dynamic registry entry", () {
+      final fit = decodeFitStorage(_roundTripJson(_dynamicDroneV2FitJson())).fit;
+
+      final pruned = pruneDynamicRegistry(fit);
+
+      expect(pruned.dynamicRegistry.dynamicItems.keys, contains(0));
+      expect(
+        pruned.dynamicRegistry.dynamicItems[0]!.dynamicAttributes[64],
+        fit.dynamicRegistry.dynamicItems[0]!.dynamicAttributes[64],
+      );
+
+      final reDecoded = decodeFitStorage(_roundTripJson(encodeFitStorage(pruned)));
+      expect(reDecoded.didMigrate, isFalse);
+      expect(reDecoded.fit.dynamicRegistry.dynamicItems.keys, contains(0));
+      expect(reDecoded.fit.body.drones.single.itemId.dynamicIdOrNull, 0);
+    });
+  });
+}

--- a/apps/eve-fit-assistant/test/storage/fit/fit_schema_v3_test.dart
+++ b/apps/eve-fit-assistant/test/storage/fit/fit_schema_v3_test.dart
@@ -70,6 +70,65 @@ void main() {
       expect(decoded.fit.metadata.checkoutRef.checkoutId, "checkout-abc");
       expect(decoded.fit.metadata.checkoutRef.serverId, "Serenity");
     });
+
+    test("decodes a plain-drone v2 fixture with decode-encode equality", () {
+      final fixture = <String, dynamic>{
+        "version": 2,
+        "fit": <String, dynamic>{
+          "metadata": <String, dynamic>{
+            "fitId": "test-fit-plain-drone",
+            "shipTypeId": 1234,
+            "name": "Plain Drone Fit",
+            "lastModified": 0,
+            "description": "",
+            "checkoutRef": <String, dynamic>{
+              "checkoutId": "checkout-abc",
+              "serverId": "Serenity",
+            },
+          },
+          "body": <String, dynamic>{
+            "shipTypeId": 1234,
+            "characterId": "predefined_all_5",
+            "damageProfile": <String, dynamic>{
+              "em": 0.25,
+              "explosive": 0.25,
+              "kinetic": 0.25,
+              "thermal": 0.25,
+            },
+            "slots": <String, dynamic>{
+              "high": <dynamic>[],
+              "medium": <dynamic>[],
+              "low": <dynamic>[],
+              "rig": <dynamic>[],
+              "subsystem": <dynamic>[],
+              "service": <dynamic>[],
+              "tacticalMode": null,
+            },
+            "drones": <dynamic>[
+              <String, dynamic>{
+                "itemId": <String, dynamic>{"id": 2203, "runtimeType": "item"},
+                "state": "active",
+                "quantity": 5,
+              },
+            ],
+            "fighters": <dynamic>[],
+            "implants": <dynamic>[],
+            "boosters": <dynamic>[],
+          },
+          "dynamicRegistry": <String, dynamic>{"dynamicItems": <String, dynamic>{}},
+        },
+      };
+
+      final decoded = decodeFitStorage(_roundTripJson(fixture));
+      expect(decoded.didMigrate, isFalse);
+      expect(decoded.fit.body.drones.single.quantity, 5);
+      expect(decoded.fit.body.drones.single.itemId.asId, 2203);
+
+      final reEncoded = _roundTripJson(encodeFitStorage(decoded.fit));
+      final reDecoded = decodeFitStorage(reEncoded);
+      expect(reDecoded.didMigrate, isFalse);
+      expect(reEncoded, _roundTripJson(fixture));
+    });
   });
 
   group("FitStorage legacy version compatibility", () {

--- a/apps/eve-fit-assistant/test/storage/fit/native_conversion_test.dart
+++ b/apps/eve-fit-assistant/test/storage/fit/native_conversion_test.dart
@@ -1,3 +1,9 @@
+@TestOn("vm")
+library;
+
+import "dart:io";
+
+import "package:eve_fit_assistant/config/logger.dart";
 import "package:eve_fit_assistant/native/api/storage.dart" as native;
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/storage/repo/models/checkout_ref.dart";
@@ -45,6 +51,11 @@ FitStorage _makeFit() => FitStorage(
 );
 
 void main() {
+  setUpAll(() {
+    final logDir = Directory.systemTemp.createTempSync("efa_native_conversion_log_");
+    GlobalLogger.init(logDir.path, enableDebugLog: false);
+  });
+
   group("convertModulesToNative", () {
     test("excludes passive rigs but keeps all subsequent modules", () {
       final modules = convertModulesToNative(_makeFit());
@@ -72,6 +83,61 @@ void main() {
         modules.singleWhere((m) => m.slot.slotType == native.SlotType.high).state,
         native.State.passive,
       );
+    });
+  });
+
+  group("convertFitBodyToNative drones", () {
+    test("expands quantity and passes dynamic item ids through", () {
+      final base = _makeFit();
+      final fit = base.copyWith(
+        body: base.body.copyWith(
+          drones: IList([
+            const FitDroneItem(
+              itemId: FitStorageItemId.dynamic(dynamicId: 7),
+              state: FitItemState.active,
+              quantity: 3,
+            ),
+          ]),
+        ),
+        dynamicRegistry: FitDynamicRegistry(
+          dynamicItems: IMap({
+            7: FitDynamicItem(
+              dynamicItemId: 7,
+              originTypeId: 2203,
+              typeId: 60478,
+              modifierTypeId: 60460,
+              dynamicAttributes: IMap({64: 1.05}),
+            ),
+          }),
+        ),
+      );
+
+      final nativeFit = convertFitBodyToNative(fit);
+
+      expect(nativeFit.drones, hasLength(3));
+      for (final drone in nativeFit.drones) {
+        expect(drone.itemId, isA<native.ItemID_Dynamic>());
+        expect((drone.itemId as native.ItemID_Dynamic).field0, 7);
+        expect(drone.groupId, 0);
+        expect(drone.state, native.State.active);
+      }
+    });
+
+    test("skips drones with dangling dynamic references", () {
+      final base = _makeFit();
+      final fit = base.copyWith(
+        body: base.body.copyWith(
+          drones: IList([
+            const FitDroneItem(
+              itemId: FitStorageItemId.dynamic(dynamicId: 7),
+              state: FitItemState.active,
+              quantity: 3,
+            ),
+          ]),
+        ),
+      );
+
+      expect(convertFitBodyToNative(fit).drones, isEmpty);
     });
   });
 }

--- a/apps/eve-fit-assistant/test/storage/fit/native_payload_test.dart
+++ b/apps/eve-fit-assistant/test/storage/fit/native_payload_test.dart
@@ -1,5 +1,6 @@
 import "dart:convert";
 
+import "package:efa_fit/efa_fit.dart";
 import "package:eve_fit_assistant/storage/fit/persistence.dart";
 import "package:eve_fit_assistant/storage/fit/schema.dart";
 import "package:eve_fit_assistant/storage/repo/models/checkout_ref.dart";
@@ -88,6 +89,68 @@ Map<String, dynamic> _legacyV1FitJson() => <String, dynamic>{
 
 Map<String, dynamic> _roundTripJson(Map<String, dynamic> json) =>
     jsonDecode(jsonEncode(json)) as Map<String, dynamic>;
+
+/// V2 fit payload with a drone stack referencing a dynamic (mutated) item.
+/// Mirrors the fixture in `fit_dynamic_drone_compat_test.dart`.
+Map<String, dynamic> _dynamicDroneV2FitJson() => <String, dynamic>{
+  "metadata": <String, dynamic>{
+    "fitId": "test-fit-dynamic-drone",
+    "shipTypeId": 1234,
+    "name": "Dynamic Drone Fit",
+    "lastModified": 0,
+    "description": "",
+    "checkoutRef": <String, dynamic>{"checkoutId": "checkout-abc", "serverId": "Serenity"},
+  },
+  "body": <String, dynamic>{
+    "shipTypeId": 1234,
+    "characterId": "predefined_all_5",
+    "damageProfile": <String, dynamic>{
+      "em": 0.25,
+      "explosive": 0.25,
+      "kinetic": 0.25,
+      "thermal": 0.25,
+    },
+    "slots": <String, dynamic>{
+      "high": <dynamic>[],
+      "medium": <dynamic>[],
+      "low": <dynamic>[],
+      "rig": <dynamic>[],
+      "subsystem": <dynamic>[],
+      "service": <dynamic>[],
+      "tacticalMode": null,
+    },
+    "drones": <dynamic>[
+      <String, dynamic>{
+        "itemId": <String, dynamic>{"dynamicId": 0, "runtimeType": "dynamic"},
+        "state": "active",
+        "quantity": 5,
+      },
+    ],
+    "fighters": <dynamic>[],
+    "implants": <dynamic>[],
+    "boosters": <dynamic>[],
+  },
+  "dynamicRegistry": <String, dynamic>{
+    "dynamicItems": <String, dynamic>{
+      "0": <String, dynamic>{
+        "dynamicItemId": 0,
+        "originTypeId": 2203,
+        "typeId": 60478,
+        "modifierTypeId": 60460,
+        "dynamicAttributes": <String, dynamic>{
+          "9": 1.05,
+          "37": 1.15,
+          "54": 0.95,
+          "64": 1.05,
+          "158": 0.9,
+          "160": 1.2,
+          "263": 1.1,
+          "265": 0.8,
+        },
+      },
+    },
+  },
+};
 
 void main() {
   group("encodeNativeFitPayload", () {
@@ -213,6 +276,29 @@ void main() {
           ),
         ),
       );
+    });
+
+    test("round-trips a dynamic drone payload through the EFA binary codec", () {
+      final payload = encodeNativeFitPayload(
+        decodeFitStorage(
+          <String, dynamic>{"version": 2, "fit": _dynamicDroneV2FitJson()},
+        ).fit,
+      );
+
+      final decoded = decodeNativeFitPayload(
+        _roundTripJson(decodeEfaFitBinary(encodeEfaFitBinary(payload))),
+      );
+
+      expect(decoded.didMigrate, isFalse);
+      final drone = decoded.fit.body.drones.single;
+      expect(drone.itemId.dynamicIdOrNull, 0);
+      expect(drone.quantity, 5);
+      final dynamicItem = decoded.fit.dynamicRegistry.dynamicItems[0];
+      expect(dynamicItem, isNotNull);
+      expect(dynamicItem!.originTypeId, 2203);
+      expect(dynamicItem.typeId, 60478);
+      expect(dynamicItem.modifierTypeId, 60460);
+      expect(dynamicItem.dynamicAttributes[64], 1.05);
     });
   });
 }

--- a/apps/eve-fit-assistant/test/storage/repo/collection_dynamic_gate_test.dart
+++ b/apps/eve-fit-assistant/test/storage/repo/collection_dynamic_gate_test.dart
@@ -1,0 +1,46 @@
+import "dart:typed_data";
+
+import "package:efa_proto/collections.pb.dart";
+import "package:efa_proto/dynamic.pb.dart" as pb_dynamic;
+import "package:efa_proto/types.pb.dart" as pb_types;
+import "package:eve_fit_assistant/storage/repo/collection.dart";
+import "package:flutter_test/flutter_test.dart";
+
+void main() {
+  group("dynamic drone data gating", () {
+    test("mutator-less collection hides drone mutation", () {
+      // Simulates an old data bundle: no dynamic mutators at all. The UI keys
+      // Convert/Mutate actions off these lookups, so the feature stays hidden.
+      final collection = RepoCollectionService.decodeFromBytes(
+        collectionBytes: Uint8List.fromList(Collection().writeToBuffer()),
+      );
+
+      expect(collection.getDynamicTypeOptions(2203), isNull);
+      expect(collection.getDynamicMutator(60460), isNull);
+    });
+
+    test("collection with drone mutators exposes options for applicable drones", () {
+      final raw = Collection()
+        ..types.addAll({
+          2203: pb_types.Type(typeId: 2203, groupId: 100, published: true),
+        })
+        ..dynamicMutators.addAll({
+          60460: pb_dynamic.DynamicMutator(
+            modifierTypeId: 60460,
+            resultingTypeId: 60478,
+            applicableTypes: [2203],
+          ),
+        })
+        ..dynamicTypeOptions.addAll({
+          2203: pb_dynamic.DynamicTypeOptions(modifierTypeIds: [60460]),
+        });
+      final collection = RepoCollectionService.decodeFromBytes(
+        collectionBytes: Uint8List.fromList(raw.writeToBuffer()),
+      );
+
+      expect(collection.getDynamicTypeOptions(2203)?.modifierTypeIds, [60460]);
+      expect(collection.getDynamicMutator(60460)?.resultingTypeId, 60478);
+      expect(collection.getDynamicMutator(60460)?.applicableTypes, contains(2203));
+    });
+  });
+}

--- a/worker/efa-platform-fit-storage/src/engine.rs
+++ b/worker/efa-platform-fit-storage/src/engine.rs
@@ -280,7 +280,7 @@ pub fn build_container(state: &pb::FitState) -> ef::FitContainer {
     for (index, drone) in state.drones.iter().enumerate() {
         for _ in 0..drone.quantity {
             drones.push(ef::ItemDrone {
-                type_id: drone.type_id as i32,
+                item_id: ItemID::Item(drone.type_id as i32),
                 group_id: index as u8,
                 state: item_state(drone.state),
             });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic drone stacks in fit editing and storage.
  * Added actions to convert, mutate, and revert individual or related drones.
  * Added support for viewing drone details, including dynamic attributes.

* **Improvements**
  * Dynamic drone data is preserved when fits are loaded, saved, and exchanged.
  * Existing fits with standard or dynamic drones remain compatible.
  * Invalid dynamic drone references are handled safely without blocking fit loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->