### PR TITLE
feat(fit): display warp disruption field generator range on slot rows

### DIFF
--- a/apps/eve-fit-assistant/lib/pages/fit/components/equipment/slot_row/related_values_logic.dart
+++ b/apps/eve-fit-assistant/lib/pages/fit/components/equipment/slot_row/related_values_logic.dart
@@ -38,6 +38,14 @@ List<SlotRelatedValueSegment> collectSlotRelatedValues(native.Item item) {
       final fieldRange = item.getAttribute(EveConstAttrID.empFieldRange);
       if (fieldRange > 0) {
         segments.add((iconAttributeId: EveConstAttrID.maxRange, text: _formatRangeKm(fieldRange)));
+      } else {
+        final scrambleRange = item.getAttribute(EveConstAttrID.warpScrambleRange);
+        if (scrambleRange > 0) {
+          segments.add((
+            iconAttributeId: EveConstAttrID.maxRange,
+            text: _formatRangeKm(scrambleRange),
+          ));
+        }
       }
     }
   }

--- a/apps/eve-fit-assistant/test/pages/fit/slot_related_values_test.dart
+++ b/apps/eve-fit-assistant/test/pages/fit/slot_related_values_test.dart
@@ -127,6 +127,36 @@ void main() {
       });
     });
 
+    group("warp scramble range fallback", () {
+      test("used when no optimal range, no charge, and no EMP field range", () {
+        final segments = collectSlotRelatedValues(
+          buildItem(attributes: {EveConstAttrID.warpScrambleRange: 20100}),
+        );
+        expect(segments, hasLength(1));
+        expect(segments.single.iconAttributeId, EveConstAttrID.maxRange);
+        expect(segments.single.text, "20.1 km");
+      });
+
+      test("EMP field range takes priority over warp scramble range", () {
+        final segments = collectSlotRelatedValues(
+          buildItem(
+            attributes: {
+              EveConstAttrID.empFieldRange: 20000,
+              EveConstAttrID.warpScrambleRange: 20100,
+            },
+          ),
+        );
+        expect(segments.single.text, "20.0 km");
+      });
+
+      test("zero scramble range yields no segment", () {
+        final segments = collectSlotRelatedValues(
+          buildItem(attributes: {EveConstAttrID.warpScrambleRange: 0}),
+        );
+        expect(segments, isEmpty);
+      });
+    });
+
     group("capacitor usage", () {
       test("capacitor need per cycle time", () {
         final segments = collectSlotRelatedValues(

--- a/packages/efa_constant/lib/eve.dart
+++ b/packages/efa_constant/lib/eve.dart
@@ -245,6 +245,10 @@ class EveConstAttrID {
   /// - High is good: True
   static const int empFieldRange = 99;
 
+  /// - Name: warpScrambleRange
+  /// - High is good: True
+  static const int warpScrambleRange = 103;
+
   /// - Name: fighterTubes
   /// - High is good: True
   static const int fighterTubes = 2216;


### PR DESCRIPTION
Closes #460 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Item details now display warp scramble range when no other applicable range is available.
  - EMP field range continues to take priority when present.
  - Zero or unavailable warp scramble ranges no longer produce an empty range entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->